### PR TITLE
Fix build for OSX

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -70,24 +70,24 @@ matrix:
         - stage: build_and_test
           os: osx
           osx_image: xcode10.1
-           sudo: false
-           addons:
-               homebrew:
-                   packages:
-                       - cmake
-                       - llvm@7
-                       - mysql
-                       - ossp-uuid
-                       - pcre
-                       - sqlite3
-                       - truncate
-                   update: true
-           env:
-               - C_COMPILER=clang
-               - CXX_COMPILER=clang++
-               - BUILD=cmake
-               - FORMULAE=llvm@7
-           script: contrib/travis/osx.sh
+          sudo: false
+          addons:
+              homebrew:
+                  packages:
+                      - cmake
+                      - llvm@7
+                      - mysql
+                      - ossp-uuid
+                      - pcre
+                      - sqlite3
+                      - truncate
+                  update: true
+          env:
+              - C_COMPILER=clang
+              - CXX_COMPILER=clang++
+              - BUILD=cmake
+              - FORMULAE=llvm@7
+          script: contrib/travis/osx.sh
 
         # macOS 10.13 make
         - stage: build_and_test

--- a/.travis.yml
+++ b/.travis.yml
@@ -66,28 +66,28 @@ matrix:
             - DOCKER_IMAGE=centos
           script: contrib/travis/centos7.sh
 
-        # # macOS 10.13 CMake
-        # - stage: build_and_test
-        #   os: osx
-        #   osx_image: xcode10.1
-        #   sudo: false
-        #   addons:
-        #       homebrew:
-        #           packages:
-        #               - cmake
-        #               - llvm@7
-        #               - mysql
-        #               - ossp-uuid
-        #               - pcre
-        #               - sqlite3
-        #               - truncate
-        #           update: true
-        #   env:
-        #       - C_COMPILER=clang
-        #       - CXX_COMPILER=clang++
-        #       - BUILD=cmake
-        #       - FORMULAE=llvm@7
-        #   script: contrib/travis/osx.sh
+        # macOS 10.13 CMake
+        - stage: build_and_test
+          os: osx
+          osx_image: xcode10.1
+           sudo: false
+           addons:
+               homebrew:
+                   packages:
+                       - cmake
+                       - llvm@7
+                       - mysql
+                       - ossp-uuid
+                       - pcre
+                       - sqlite3
+                       - truncate
+                   update: true
+           env:
+               - C_COMPILER=clang
+               - CXX_COMPILER=clang++
+               - BUILD=cmake
+               - FORMULAE=llvm@7
+           script: contrib/travis/osx.sh
 
         # macOS 10.13 make
         - stage: build_and_test

--- a/bffuse.c
+++ b/bffuse.c
@@ -101,6 +101,7 @@ OF SUCH DAMAGE.
 #include <bf.h>
 #include <dbutils.h>
 
+extern int errno;
 char globalmnt[MAXPATH];
 int  globalmntlen;
 char globaldbname[MAXPTHREAD][MAXPATH];

--- a/bfmi.c
+++ b/bfmi.c
@@ -102,6 +102,9 @@ OF SUCH DAMAGE.
 #include <pwd.h>
 #include <grp.h>
 #include "mysql.h"
+
+extern int errno;
+
 struct mysqlinput {
    char  dbuser[50];
    char  dbpasswd[50];

--- a/bfq.c
+++ b/bfq.c
@@ -106,6 +106,7 @@ OF SUCH DAMAGE.
 #include "dbutils.h"
 // #include "putils.h"
 
+extern int errno;
 #define AGGREGATE_NAME         "file:aggregate%d?mode=memory&cache=shared"
 #define AGGREGATE_ATTACH_NAME  "aggregate"
 

--- a/bfresultfuse.c
+++ b/bfresultfuse.c
@@ -100,6 +100,7 @@ OF SUCH DAMAGE.
 #include <bf.h>
 #include <dbutils.h>
 
+extern int errno;
 char globalmnt[MAXPATH];
 size_t  globalmntlen;
 char globaldbname[MAXPTHREAD][MAXPATH];

--- a/bfti.c
+++ b/bfti.c
@@ -99,6 +99,8 @@ OF SUCH DAMAGE.
 #include "utils.h"
 #include "dbutils.h"
 
+extern int errno;
+
 // This becomes an argument to thpool_add_work(), so it must return void,
 // instead of void*.
 static void processdir(void * passv)

--- a/bfwi.c
+++ b/bfwi.c
@@ -99,6 +99,8 @@ OF SUCH DAMAGE.
 #include "utils.h"
 #include "dbutils.h"
 
+extern int errno;
+
 /* used to allow all threads to open up the input file if there is one */
 FILE *gin[MAXPTHREAD];
 

--- a/bfwreaddirplus2db.c
+++ b/bfwreaddirplus2db.c
@@ -99,6 +99,7 @@ OF SUCH DAMAGE.
 #include "utils.h"
 #include "dbutils.h"
 
+extern int errno;
 pthread_mutex_t outdb_mutex[MAXPTHREAD];
 pthread_mutex_t outfile_mutex[MAXPTHREAD];
 sqlite3_stmt *global_res[MAXPTHREAD];

--- a/contrib/cmake/Findxattr.cmake
+++ b/contrib/cmake/Findxattr.cmake
@@ -9,6 +9,13 @@
 
 find_package(PkgConfig)
 
+# OSX Frameworks have a non-compatible version of xattr.h
+# exclude OSX Frameworks from the search path for this package
+if(APPLE)
+  set(XATTR_CMAKE_FIND_FRAMEWORK "${CMAKE_FIND_FRAMEWORK}")
+  set(CMAKE_FIND_FRAMEWORK "NEVER")
+endif()
+
 # normal location
 find_path(ATTR_XATTR
   NAMES attr/xattr.h
@@ -37,8 +44,10 @@ find_path(XATTR_LIB_DIR
 include(FindPackageHandleStandardArgs)
 # handle the QUIETLY and REQUIRED arguments and set XATTR_FOUND to TRUE
 # if all listed variables are TRUE
-find_package_handle_standard_args(XATTR DEFAULT_MSG
-                                  XATTR_HEADER XATTR_INCLUDE_DIR)
+#find_package_handle_standard_args(XATTR DEFAULT_MSG
+#                                  XATTR_HEADER XATTR_INCLUDE_DIR)
+find_package_handle_standard_args(XATTR
+                                  REQUIRED_VARS XATTR_HEADER XATTR_INCLUDE_DIR)
 
 mark_as_advanced(XATTR_INCLUDE_DIR)
 
@@ -47,3 +56,8 @@ set(XATTR_INCLUDEDIR "${XATTR_INCLUDE_DIR}")
 
 unset(XATTR_LIB_DIR)
 unset(XATTR_INCLUDE_DIR)
+
+# Restore previous OSX frameworks search setting
+if(APPLE)
+  set(CMAKE_FIND_FRAMEWORK "${XATTR_CMAKE_FIND_FRAMEWORK}")
+endif()

--- a/dbutils.c
+++ b/dbutils.c
@@ -86,6 +86,8 @@ OF SUCH DAMAGE.
 #include "dbutils.h"
 #include "bf.h"
 
+extern int errno;
+
 char *rsql = // "DROP TABLE IF EXISTS readdirplus;"
             "CREATE TABLE readdirplus(path TEXT, type TEXT, inode INT64 PRIMARY KEY, pinode INT64, suspect INT64);";
 

--- a/dfw.c
+++ b/dfw.c
@@ -91,6 +91,8 @@ OF SUCH DAMAGE.
 #include "bf.h"
 #include "utils.c"
 
+extern int errno;
+
 void listdir(const char *name, long long int level, struct dirent *entry, long long int pin, int statit, int xattrit,int loader )
 {
     DIR *dir;

--- a/gpfs-scan-listnew-out.c
+++ b/gpfs-scan-listnew-out.c
@@ -13,6 +13,7 @@
 //for testing where gpfs doesnt exisst
 //#include <mygpfs.h>
 
+extern int errno;
 pthread_mutex_t lock;
 int gotit;
 

--- a/gpfs-scan-listnew.c
+++ b/gpfs-scan-listnew.c
@@ -5,6 +5,8 @@
 
 #include <gpfs.h>
 
+extern int errno;
+
 /* Scan inodes in the gpfs mount point */
 int proc_inodes(char *pathp,char *intime)
 {

--- a/make_testdirs.c
+++ b/make_testdirs.c
@@ -84,6 +84,8 @@ OF SUCH DAMAGE.
 #include <string.h>
 #include <errno.h>
 
+extern int errno;
+
 // Usage:
 //
 //    make_testdirs -d <n_dirs> -f <n_files> dirname

--- a/querydb.c
+++ b/querydb.c
@@ -95,6 +95,8 @@ OF SUCH DAMAGE.
 #include "utils.h"
 #include "dbutils.h"
 
+extern int errno;
+
 void sub_help() {
    printf("DB_path           path to dir containinng %s.*\n",DBNAME);
    printf("SQL               arbitrary SQL on DB\n");

--- a/querydbn.c
+++ b/querydbn.c
@@ -99,6 +99,8 @@ OF SUCH DAMAGE.
 #include "utils.h"
 #include "dbutils.h"
 
+extern int errno;
+
 void sub_help() {
    printf("  -s              dir-summary (currently-unused internal functionality)\n");
    // printf("  -N <DB_count>   query DBs written by multiple threads (\n");}

--- a/utils.c.in
+++ b/utils.c.in
@@ -87,6 +87,7 @@ OF SUCH DAMAGE.
 #include "utils.h"
 #include "structq.h"
 
+extern int errno;
 
 // --- threading
 threadpool mythpool;


### PR DESCRIPTION
Update all file using errno.h to correctly extern errno. Update
the CMake build process so that we no longer detect the
erroneous version of xattr.h in the system frameworks.