### PR TITLE
Make sure we don't free work while inside processdirs loop or we will…

### DIFF
--- a/src/bfmi.c
+++ b/src/bfmi.c
@@ -271,11 +271,11 @@ static void processdir(void * passv)
       free(records);
     }
 
-    // free the queue entry - this has to be here or there will be a leak
-    free(passmywork->freeme);
-
     // one less thread running
     decrthread();
+
+    // free the queue entry - this has to be here or there will be a leak
+    free(passmywork->freeme);
 
     // return NULL;
 }

--- a/src/bfq.c
+++ b/src/bfq.c
@@ -305,11 +305,11 @@ static void processdir(void * passv)
     }
 
  out_free:
-    // free the queue entry - this has to be here or there will be a leak
-    free(passmywork->freeme);
-
     // one less thread running
     decrthread();
+
+    // free the queue entry - this has to be here or there will be a leak
+    free(passmywork->freeme);
 
     // return NULL;
 }

--- a/src/bfti.c
+++ b/src/bfti.c
@@ -157,11 +157,11 @@ static void processdir(void * passv)
     closedir(dir);
 
  out_free:
-    // free the queue entry - this has to be here or there will be a leak
-    free(passmywork->freeme);
-
     // one less thread running
     decrthread();
+
+    // free the queue entry - this has to be here or there will be a leak
+    free(passmywork->freeme);
 
     // return NULL;
 }

--- a/src/bfwi.c
+++ b/src/bfwi.c
@@ -358,11 +358,11 @@ static void processdir(void * passv)
     }
 
  out_free:
-    // free the queue entry - this has to be here or there will be a leak
-    free(passmywork->freeme);
-
     // one less thread running
     decrthread();
+
+    // free the queue entry - this has to be here or there will be a leak
+    free(passmywork->freeme);
 
     /// return NULL;
 }

--- a/src/bfwreaddirplus2db.c
+++ b/src/bfwreaddirplus2db.c
@@ -523,11 +523,11 @@ static void processdir(void * passv)
     closedir(dir);
 
  out_free:
-    // free the queue entry - this has to be here or there will be a leak
-    free(passmywork->freeme);
-
     // one less thread running
     decrthread();
+
+    // free the queue entry - this has to be here or there will be a leak
+    free(passmywork->freeme);
 
     /// return NULL;
 }


### PR DESCRIPTION
… mess up the linked list

This resolves a segfault where a thread can finish and free itself before the queue_mutex is unlocked in processdirs. Calling decthread before free insures that processdirs has released the mutex and is no longer manipulating the linked list.