### PR TITLE
Fixed bug with os.path.join usage

### DIFF
--- a/scripts/gufi_find
+++ b/scripts/gufi_find
@@ -492,7 +492,7 @@ if __name__=='__main__':
         paths = ['']
 
     # prepend the provided paths with the GUFI root path
-    paths = [os.path.sep.join([config['IndexRoot'], path]) for path in paths]
+    paths = [os.path.normpath(os.path.sep.join([config['IndexRoot'], path])) for path in paths]
 
     # parse expressions without the 'real' and path arguments
     args, unknown = expression_parser.parse_known_args(sys.argv[i:])

--- a/scripts/gufi_find
+++ b/scripts/gufi_find
@@ -492,7 +492,7 @@ if __name__=='__main__':
         paths = ['']
 
     # prepend the provided paths with the GUFI root path
-    paths = [os.path.join(config['IndexRoot'], path) for path in paths]
+    paths = [os.path.sep.join([config['IndexRoot'], path]) for path in paths]
 
     # parse expressions without the 'real' and path arguments
     args, unknown = expression_parser.parse_known_args(sys.argv[i:])

--- a/scripts/gufi_ls
+++ b/scripts/gufi_ls
@@ -210,7 +210,7 @@ if __name__=='__main__':
         args.FILE = ['']
 
     # prepend the provided paths with the GUFI root path
-    args.FILE = [os.path.sep.join([config['IndexRoot'], path]) for path in args.FILE]
+    args.FILE = [os.path.normpath(os.path.sep.join([config['IndexRoot'], path])) for path in args.FILE]
 
     where = build_where(args)
     order_by = build_order_by(args)

--- a/scripts/gufi_ls
+++ b/scripts/gufi_ls
@@ -210,7 +210,7 @@ if __name__=='__main__':
         args.FILE = ['']
 
     # prepend the provided paths with the GUFI root path
-    args.FILE = [os.path.join(config['IndexRoot'], path) for path in args.FILE]
+    args.FILE = [os.path.sep.join([config['IndexRoot'], path]) for path in args.FILE]
 
     where = build_where(args)
     order_by = build_order_by(args)

--- a/scripts/gufi_stats
+++ b/scripts/gufi_stats
@@ -232,7 +232,7 @@ if __name__=='__main__':
         args.paths = ['']
 
     # prepend the provided paths with the GUFI root path
-    args.paths = [os.path.sep.join([config['IndexRoot'], path]) for path in args.paths]
+    args.paths = [os.path.normpath(os.path.sep.join([config['IndexRoot'], path])) for path in args.paths]
 
     if args.order:
         args.order = ORDER[args.order]

--- a/scripts/gufi_stats
+++ b/scripts/gufi_stats
@@ -232,7 +232,7 @@ if __name__=='__main__':
         args.paths = ['']
 
     # prepend the provided paths with the GUFI root path
-    args.paths = [os.path.join(config['IndexRoot'], path) for path in args.paths]
+    args.paths = [os.path.sep.join([config['IndexRoot'], path]) for path in args.paths]
 
     if args.order:
         args.order = ORDER[args.order]


### PR DESCRIPTION
os.path.join arguments that are not the first should not begin with path separators
    - everything left of the rightmost slash is dropped

This affects`gufi_find`, `gufi_ls`, and `gufi_stats`
Fixes an issue mentioned in #8.