### PR TITLE
gufi_ls updates

### DIFF
--- a/contrib/make/test
+++ b/contrib/make/test
@@ -3,7 +3,7 @@ export
 TESTTAR  = testdir.tar
 TESTDIR  = testdir
 TESTDST  = $(TESTDIR).gufi
-TESTGUFI = $(TESTDST)/$(TESTDIR)
+TESTGUFI = $(TESTDST)
 
 ifneq ("$(CXX)", "false")
 SUBDIRECTORIES=googletest

--- a/contrib/make/test
+++ b/contrib/make/test
@@ -3,7 +3,6 @@ export
 TESTTAR  = testdir.tar
 TESTDIR  = testdir
 TESTDST  = $(TESTDIR).gufi
-TESTGUFI = $(TESTDST)
 
 ifneq ("$(CXX)", "false")
 SUBDIRECTORIES=googletest
@@ -27,7 +26,7 @@ $(TESTDIR): $(TESTTAR)
 	tar -xf $(TESTTAR)
 
 # generate the GUFI index
-bfwi $(TESTDST) $(TESTGUFI): runbfti $(TESTDIR)
+bfwi $(TESTDST) $(TESTDST): runbfti $(TESTDIR)
 	./runbfwi $(TESTDIR) $(TESTDST)
 
 bfti:                        runbfti bfwi
@@ -39,7 +38,7 @@ listschemadb:                runlistschemadb
 listtablesdb:                runlisttablesdb
 
 bfti bfq bfwreaddirplus2db querydb dfw:
-	./$< $(TESTGUFI)
+	./$< $(TESTDST)
 
 querydbn:                    runquerydbn bfti
 groupfilespacehogusesummary: rungroupfilespacehogusesummary
@@ -49,7 +48,7 @@ userfilespacehog:            runuserfilespacehog
 oldbigfiles:                 runoldbigfiles
 
 querydbn groupfilespacehogusesummary userfilespacehogusesummary groupfilespacehog userfilespacehog oldbigfiles:
-	./$< $(TESTGUFI) 2
+	./$< $(TESTDST) 2
 
 verifyknowntree:
 	./$@

--- a/include/bf.h
+++ b/include/bf.h
@@ -144,6 +144,7 @@ typedef enum OpenMode {
 
 struct input {
    char name[MAXPATH];
+   size_t name_len;
    char nameto[MAXPATH];
    char sqltsum[MAXSQL];
    size_t sqltsum_len;

--- a/scripts/gufi_config.py
+++ b/scripts/gufi_config.py
@@ -103,6 +103,8 @@ def read_config(filename):
                 value = gufi_common.get_port(value)
             elif name == 'Threads':
                 value = gufi_common.get_positive(value)
+            elif name in ['Paramiko', 'IndexRoot']:
+                value = os.path.normpath(value)
             out[name] = value
         return out
 

--- a/scripts/gufi_ls
+++ b/scripts/gufi_ls
@@ -93,7 +93,7 @@ def build_select(args):
         select += ['blocks']
 
     if args.long_listing:
-        select += ['modetotxt(mode)', 'printf("%' + str(args.nlink_width) + 'd", "nlink)', 'uidtouser(uid, ' + str(args.user_width) + ')']
+        select += ['modetotxt(mode)', 'printf("%' + str(args.nlink_width) + 'd", nlink)', 'uidtouser(uid, ' + str(args.user_width) + ')']
         if not args.no_group:
             select += ['gidtogroup(gid, ' + str(args.group_width) + ')']
 
@@ -104,7 +104,7 @@ def build_select(args):
         elif args.blocksize:
             select += ['blocksize(size, "' + args.blocksize + '", ' + str(args.size_width) + ')']
         else:
-            select += ['printf("% ' + str(args.size_width) + 'z", size)']
+            select += ['printf("%' + str(args.size_width) + 'd", size)']
         select += ['strftime("%b  %e %H:%M", mtime)', 'case when (type == "l") then (name || " -> " || linkname) else name end']
 
     else:
@@ -137,7 +137,7 @@ def build_recursive_select(args):
         elif args.blocksize:
             select += ['blocksize(usize, "' + args.blocksize + '", ' + str(args.size_width) + ')']
         else:
-            select += ['printf("% ' + str(args.size_width) + 'z", usize)']
+            select += ['printf("%' + str(args.size_width) + 'd", usize)']
         select += ['strftime("%b  %e %H:%M", umtime)', 'case when (utype == "l") then (ufullpath || "/" || uname || " -> " || ulinkname) else ufullpath || "/" || uname end']
 
     else:
@@ -175,17 +175,32 @@ def build_order_by(args):
     '''Build the ORDER BY portion of the query.'''
     order_by = []
 
-    if args.reverse:
-        order_by += ['name COLLATE NOCASE DESC']
-
     if args.sort_largest:
-        order_by += ['size DESC']
+        order_by += ['size ' + ('ASC' if args.reverse else 'DESC')]
 
     if args.mtime:
-        order_by += ['mtime DESC']
+        order_by += ['mtime ' + ('ASC' if args.reverse else 'DESC')]
 
     if len(order_by) == 0:
-        return ['name COLLATE NOCASE ASC']
+        order_by += ['name COLLATE NOCASE ASC']
+
+    if args.no_sort:
+        order_by = []
+
+    return order_by
+
+def build_order_by_recursive(args):
+    '''Build the ORDER BY portion of the query.'''
+    order_by = []
+
+    if args.sort_largest:
+        order_by += ['usize ' + ('ASC' if args.reverse else 'DESC')]
+
+    if args.mtime:
+        order_by += ['umtime ' + ('ASC' if args.reverse else 'DESC')]
+
+    if len(order_by) == 0:
+        order_by += ['ufullpath || "/" || uname COLLATE NOCASE ASC']
 
     if args.no_sort:
         order_by = []
@@ -251,7 +266,7 @@ if __name__=='__main__':
             path, match_name = os.path.split(path)
             recursive = False
 
-        # WHERE clause is common
+        # common clauses
         where = build_where(args, match_name)
 
         # create the base command
@@ -263,20 +278,29 @@ if __name__=='__main__':
         if recursive:
             I = 'CREATE TABLE {0} (fullpath TEXT, name TEXT, type TEXT, inode INT(64), nlink INT(64), size INT(64), mode INT(64), uid INT(64), gid INT(64), blksize INT(64), blocks INT(64), mtime INT(64), atime INT(64), ctime INT(64), linkname TEXT, xattrs TEXT, pinode INT(64));'.format(args.inmemory_name)
 
-            SE = 'INSERT INTO {0} '.format(args.inmemory_name) + gufi_common.build_query(['fpath()', 'name', 'type',
-                                                                                          'inode', 'nlink', 'size',
-                                                                                          'mode', 'uid', 'gid',
-                                                                                          'blksize', 'blocks', 'mtime',
-                                                                                          'atime', 'ctime', 'linkname',
-                                                                                          'xattrs', 'pinode'],
-                                                                                         ['{}'],
-                                                                                         where,
-                                                                                         None,
-                                                                                         None,
-                                                                                         args.num_results)
+            S = 'INSERT INTO {0} '.format(args.inmemory_name) + gufi_common.build_query(['fpath()', '"" as name', 'type',
+                                                                                         'inode', 'nlink', 'size',
+                                                                                         'mode', 'uid', 'gid',
+                                                                                         'blksize', 'blocks', 'mtime',
+                                                                                         'atime', 'ctime', 'linkname',
+                                                                                         'xattrs', 'pinode'],
+                                                                                        ['summary'],
+                                                                                        where,
+                                                                                        None,
+                                                                                        None,
+                                                                                        None)
 
-            S = SE.format('summary')
-            E = SE.format('pentries')
+            E = 'INSERT INTO {0} '.format(args.inmemory_name) + gufi_common.build_query(['fpath()', 'name', 'type',
+                                                                                         'inode', 'nlink', 'size',
+                                                                                         'mode', 'uid', 'gid',
+                                                                                         'blksize', 'blocks', 'mtime',
+                                                                                         'atime', 'ctime', 'linkname',
+                                                                                         'xattrs', 'pinode'],
+                                                                                        ['pentries'],
+                                                                                        where,
+                                                                                        None,
+                                                                                        None,
+                                                                                        None)
 
             J = 'INSERT INTO aggregate.{0} SELECT * FROM {0}'.format(args.inmemory_name)
 
@@ -291,12 +315,16 @@ if __name__=='__main__':
                                  underm.pinode=under.uinode
                     )
 
-                    SELECT {4} FROM under;'''.format(args.inmemory_name,
+                    {4};'''.format(args.inmemory_name,
                                                      'u' + ', u'.join(column_names),
                                                      ', '.join(column_names),
                                                      path,
-                                                     ', '.join(build_recursive_select(args))
-                                                 )
+                                                     gufi_common.build_query(build_recursive_select(args),
+                                                                             ['under'],
+                                                                             ['u' + w for w in where],
+                                                                             None,
+                                                                             build_order_by_recursive(args),
+                                                                             args.num_results))
 
             query_cmd += ['-n', str(config['Threads']),
                           '-I', I,
@@ -305,6 +333,7 @@ if __name__=='__main__':
                           '-J', J,
                           '-G', G,
                           '-a']
+
         else:
             query_cmd += ['-n', '1',
                           '-E', gufi_common.build_query(build_select(args),

--- a/scripts/gufi_ls
+++ b/scripts/gufi_ls
@@ -248,12 +248,12 @@ if __name__=='__main__':
 
     args = parser.parse_args();
 
+    # return code
+    rc = 0
+
     # at least 1 argument
     if len(args.paths[0]) == 0:
         args.paths= [['']]
-
-    # return code
-    rc = 0
 
     for path in args.paths[0]:
         # prepend the provided paths with the GUFI index root
@@ -261,89 +261,102 @@ if __name__=='__main__':
 
         recursive = args.recursive
 
-        # if the path is not a directory, remove the last part of the path
-        match_name = None
-        if not os.path.isdir(fullpath):
-            fullpath, match_name = os.path.split(fullpath)
-            recursive = False
-
         # create the base command
-        query_cmd = [config['Exec'],
-                     '-e', '0'] # always use aggregation
+        query_cmd = [config['Exec']]
 
-        # add more arguments
+        if (fullpath == config['IndexRoot']) and not recursive:
+            S = gufi_common.build_query(build_select(args),
+                                        ['summary'],
+                                        None,
+                                        None,
+                                        build_order_by(args),
+                                        args.num_results)
 
-        # common clauses
-        where = build_where(args, match_name)
+            query_cmd += ['-S', S,
+                          '-z', '1']
+        else:
+            # if the path is not a directory, remove the last part of the path
+            match_name = None
+            if not os.path.isdir(fullpath):
+                fullpath, match_name = os.path.split(fullpath)
+                recursive = False
 
-        I = 'CREATE TABLE {0} (fullpath TEXT, name TEXT, type TEXT, inode INT(64), nlink INT(64), size INT(64), mode INT(64), uid INT(64), gid INT(64), blksize INT(64), blocks INT(64), mtime INT(64), atime INT(64), ctime INT(64), linkname TEXT, xattrs TEXT, pinode INT(64));'.format(args.inmemory_name)
+            # always use aggregation
+            query_cmd += ['-e', '0']
 
-        S = 'INSERT INTO {0} {1}'.format(args.inmemory_name, gufi_common.build_query(['fpath()', '"" as name' if args.recursive else 'name', 'type', 'inode', 'nlink', 'size',
-                                                                                      'mode', 'uid', 'gid', 'blksize', 'blocks', 'mtime',
-                                                                                      'atime', 'ctime', 'linkname', 'xattrs', 'pinode'],
-                                                                                     ['summary'],
-                                                                                     where,
-                                                                                     None,
-                                                                                     None,
-                                                                                     None))
+            # add more arguments
 
-        E = 'INSERT INTO {0} {1}'.format(args.inmemory_name, gufi_common.build_query(['fpath()', 'name', 'type', 'inode', 'nlink', 'size',
-                                                                                      'mode', 'uid', 'gid', 'blksize', 'blocks', 'mtime',
-                                                                                      'atime', 'ctime', 'linkname', 'xattrs', 'pinode'],
-                                                                                     ['pentries'],
-                                                                                     where,
-                                                                                     None,
-                                                                                     None,
-                                                                                     None))
+            # common clauses
+            where = build_where(args, match_name)
 
-        J = 'INSERT INTO aggregate.{0} SELECT * FROM {0}'.format(args.inmemory_name)
+            I = 'CREATE TABLE {0} (fullpath TEXT, name TEXT, type TEXT, inode INT(64), nlink INT(64), size INT(64), mode INT(64), uid INT(64), gid INT(64), blksize INT(64), blocks INT(64), mtime INT(64), atime INT(64), ctime INT(64), linkname TEXT, xattrs TEXT, pinode INT(64));'.format(args.inmemory_name)
 
-        if recursive:
-            column_names = ['fullpath', 'name', 'type', 'inode', 'nlink', 'size', 'mode', 'uid', 'gid', 'blksize', 'blocks', 'mtime', 'atime', 'ctime', 'linkname', 'xattrs', 'pinode']
+            S = 'INSERT INTO {0} {1}'.format(args.inmemory_name, gufi_common.build_query(['fpath()', '"" as name' if args.recursive else 'name', 'type', 'inode', 'nlink', 'size',
+                                                                                          'mode', 'uid', 'gid', 'blksize', 'blocks', 'mtime',
+                                                                                          'atime', 'ctime', 'linkname', 'xattrs', 'pinode'],
+                                                                                         ['summary'],
+                                                                                         where,
+                                                                                         None,
+                                                                                         None,
+                                                                                         None))
 
-            # recursive select on pinode
-            G = '''WITH RECURSIVE under ({1}) AS
-                    (
+            E = 'INSERT INTO {0} {1}'.format(args.inmemory_name, gufi_common.build_query(['fpath()', 'name', 'type', 'inode', 'nlink', 'size',
+                                                                                          'mode', 'uid', 'gid', 'blksize', 'blocks', 'mtime',
+                                                                                          'atime', 'ctime', 'linkname', 'xattrs', 'pinode'],
+                                                                                         ['pentries'],
+                                                                                         where,
+                                                                                         None,
+                                                                                         None,
+                                                                                         None))
+
+            J = 'INSERT INTO aggregate.{0} SELECT * FROM {0}'.format(args.inmemory_name)
+
+            if recursive:
+                column_names = ['fullpath', 'name', 'type', 'inode', 'nlink', 'size', 'mode', 'uid', 'gid', 'blksize', 'blocks', 'mtime', 'atime', 'ctime', 'linkname', 'xattrs', 'pinode']
+
+                # recursive select on pinode
+                G = '''WITH RECURSIVE under ({1}) AS
+                (
                          SELECT {2} FROM {0} WHERE inode=(SELECT inode FROM {0} WHERE fullpath=\"{3}\")
                              UNION ALL
                          SELECT {2} FROM {0} underm
                                      JOIN under ON
                                  underm.pinode=under.uinode
-                    )
+                )
 
-                    {4};'''.format(args.inmemory_name,
-                                                     'u' + ', u'.join(column_names),
-                                                     ', '.join(column_names),
-                                                     fullpath,
-                                                     gufi_common.build_query(build_recursive_select(args),
-                                                                             ['under'],
-                                                                             ['u' + w for w in where],
-                                                                             None,
-                                                                             build_order_by_recursive(args),
-                                                                             args.num_results))
-        else:
-            # select on pinode
-            G = gufi_common.build_query(build_select(args),
-                                        [args.inmemory_name],
-                                        ['pinode == ({})'.format(gufi_common.build_query(['inode'],
-                                                                                         [args.inmemory_name],
-                                                                                         ['fullpath == "{}"'.format(fullpath)],
-                                                                                         None,
-                                                                                         None,
-                                                                                         None))],
-                                        None,
-                                        build_order_by(args),
-                                        args.num_results)
+                {4};'''.format(args.inmemory_name,
+                               'u' + ', u'.join(column_names),
+                               ', '.join(column_names),
+                               fullpath,
+                               gufi_common.build_query(build_recursive_select(args),
+                                                       ['under'],
+                                                       ['u' + w for w in where],
+                                                       None,
+                                                       build_order_by_recursive(args),
+                                                       args.num_results))
+            else:
+                # select on pinode
+                G = gufi_common.build_query(build_select(args),
+                                            [args.inmemory_name],
+                                            ['pinode == ({})'.format(gufi_common.build_query(['inode'],
+                                                                                             [args.inmemory_name],
+                                                                                             ['fullpath == "{}"'.format(fullpath)],
+                                                                                             None,
+                                                                                             None,
+                                                                                             None))],
+                                            None,
+                                            build_order_by(args),
+                                            args.num_results)
 
-            query_cmd += ['-z', '1']
+                query_cmd += ['-z', '1']
 
-        query_cmd += ['-n', str(config['Threads']),
-                      '-I', I,
-                      '-S', S,
-                      '-E', E,
-                      '-J', J,
-                      '-G', G,
-                      '-a']
+            query_cmd += ['-n', str(config['Threads']),
+                          '-I', I,
+                          '-S', S,
+                          '-E', E,
+                          '-J', J,
+                          '-G', G,
+                          '-a']
 
         if args.delim:
             query_cmd += ['-d', args.delim]

--- a/scripts/gufi_ls
+++ b/scripts/gufi_ls
@@ -263,21 +263,20 @@ if __name__=='__main__':
         if recursive:
             I = 'CREATE TABLE {0} (fullpath TEXT, name TEXT, type TEXT, inode INT(64), nlink INT(64), size INT(64), mode INT(64), uid INT(64), gid INT(64), blksize INT(64), blocks INT(64), mtime INT(64), atime INT(64), ctime INT(64), linkname TEXT, xattrs TEXT, pinode INT(64));'.format(args.inmemory_name)
 
-            # there is a duplicate pinode column in pentries
-            common_columns = ['fpath()', 'name', 'type', 'inode', 'nlink', 'size', 'mode', 'uid', 'gid', 'blksize', 'blocks', 'mtime', 'atime', 'ctime', 'linkname', 'xattrs']
-            S = 'INSERT INTO {0} '.format(args.inmemory_name) + gufi_common.build_query(common_columns + ['pinode'],
-                                                                                        ['summary'],
-                                                                                        where,
-                                                                                        None,
-                                                                                        None,
-                                                                                        args.num_results)
+            SE = 'INSERT INTO {0} '.format(args.inmemory_name) + gufi_common.build_query(['fpath()', 'name', 'type',
+                                                                                          'inode', 'nlink', 'size',
+                                                                                          'mode', 'uid', 'gid',
+                                                                                          'blksize', 'blocks', 'mtime',
+                                                                                          'atime', 'ctime', 'linkname',
+                                                                                          'xattrs', 'pinode'],
+                                                                                         ['{}'],
+                                                                                         where,
+                                                                                         None,
+                                                                                         None,
+                                                                                         args.num_results)
 
-            E = 'INSERT INTO {0} '.format(args.inmemory_name) + gufi_common.build_query(common_columns + ['`pinode:1`'],
-                                                                                        ['pentries'],
-                                                                                        where,
-                                                                                        None,
-                                                                                        None,
-                                                                                        args.num_results)
+            S = SE.format('summary')
+            E = SE.format('pentries')
 
             J = 'INSERT INTO aggregate.{0} SELECT * FROM {0}'.format(args.inmemory_name)
 

--- a/scripts/gufi_ls
+++ b/scripts/gufi_ls
@@ -70,69 +70,104 @@ import sys
 import gufi_common
 import gufi_config
 
-def build_select(config, args):
+#        1024  1000  1024
+SIZES = ['K',  'KB', 'KiB',
+         'M',  'MB', 'MiB',
+         'G',  'GB', 'GiB',
+         'T',  'TB', 'TiB',
+         'P',  'PB', 'PiB',
+         'E',  'EB', 'EiB',
+         'Z',  'ZB', 'ZiB',
+         'Y',  'YB', 'YiB']
+
+def build_select(args):
     '''Build the SELECT portion of the query on the initial scan of entries'''
     select = []
 
     # ordering of concatenation matters
 
     if args.inode:
-        select = ['inode'] + select
+        select += ['inode']
 
     if args.size:
         select += ['blocks']
 
     if args.long_listing:
-        select += ['type', 'mode', 'nlink', 'uid']
+        select += ['modetotxt(mode)', 'nlink', 'uidtouser(uid, ' + str(args.user_width) + ')']
         if not args.no_group:
-            select += ['gid']
-        select += ['size', 'mtime', ('(path() || "/" || name)' if args.recursive or (len(config['IndexRoot']) > 1) else 'name') + ' as fullpath', 'linkname']
+            select += ['gidtogroup(gid, ' + str(args.group_width) + ')']
+
+        # in GNU ls, order of arguments determines which one has precedence
+        # here, --human-readable has precedence
+        if args.human_readable:
+            select += ['human_readable_size(size, ' + str(args.size_width) + ')']
+        elif args.blocksize:
+            select += ['blocksize(size, "' + args.blocksize + '", ' + str(args.size_width) + ')']
+        else:
+            select += ['printf("% ' + str(args.size_width) + 'z", size)']
+        select += ['strftime("%b  %e %H:%M", mtime)', 'case when (type == "l") then (name' + ' || " -> " || linkname) else name end']
+
     else:
         # at minimum, print the file name
-        select += [('(path() || "/" ||  name)' if args.recursive or (len(config['IndexRoot']) > 1) else 'name') + ' as fullpath']
+        select += ['name']
 
     return select
 
-
-def build_aggregate_select(args):
-    '''Build the SELECT portion of the query on the aggregate data'''
+def build_recursive_select(args):
+    '''Build the SELECT portion of the query on the initial scan of entries'''
     select = []
 
     # ordering of concatenation matters
 
     if args.inode:
-        select = ['inode'] + select
+        select += ['uinode']
 
     if args.size:
-        select += ['blocks']
+        select += ['ublocks']
 
     if args.long_listing:
-        select += ['printf("%03o", mode)', 'nlink', 'uid']
+        select += ['modetotxt(umode)', 'unlink', 'uidtouser(uuid, ' + str(args.user_width) + ')']
         if not args.no_group:
-            select += ['gid']
-        select += ['size', 'strftime("%m %d %H:%M", mtime, "unixepoch")', 'case when (type == "l") then (fullpath' + ' || " -> " || linkname) else fullpath end']
+            select += ['gidtogroup(ugid, ' + str(args.group_width) + ')']
+
+        # in GNU ls, order of arguments determines which one has precedence
+        # here, --human-readable has precedence
+        if args.human_readable:
+            select += ['human_readable_size(usize, ' + str(args.size_width) + ')']
+        elif args.blocksize:
+            select += ['blocksize(usize, "' + args.blocksize + '", ' + str(args.size_width) + ')']
+        else:
+            select += ['printf("% ' + str(args.size_width) + 'z", usize)']
+        select += ['strftime("%b  %e %H:%M", umtime)', 'case when (utype == "l") then (uname' + ' || " -> " || ulinkname) else uname end']
+
     else:
         # at minimum, print the file name
-        select += ['fullpath']
+        select += ['uname']
 
     return select
 
-
-def build_where(args):
+def build_where(args, name = None):
     '''Build the WHERE portion of the query'''
     where = []
 
-    # everything
-    if not args.all:
-        where += ['fullpath REGEXP "^(?![\.]).*$"']
+    if name:
+        where = ['name REGEXP "^{}$"'.format(name)]
+    else:
+        # -a: if show all, override -A
+        if args.all:
+            pass
+        else:
+            # -A: ignore . and ..
+            if args.almost_all:
+                where += ['name <> "." AND name <> ".."']
 
-    # ignore . and ..
-    elif args.almost_all:
-        where += ['fullpath REGEXP "(?!(\.|\.\.))"']
+            # everything that's not hidden
+            else:
+                where += ['name REGEXP "^(?![\.]).*$"']
 
-    # ignore files that end with ~
-    elif args.ignore_backups == True:
-        where += ['fullpath REGEXP "^.*(?<![\~])$"']
+        # -B: ignore files that end with ~
+        if args.ignore_backups == True:
+            where += ['name REGEXP "^.*(?<![\~])$"']
 
     return where
 
@@ -141,7 +176,7 @@ def build_order_by(args):
     order_by = []
 
     if args.reverse:
-        order_by += ['fullpath DESC']
+        order_by += ['name COLLATE NOCASE DESC']
 
     if args.sort_largest:
         order_by += ['size DESC']
@@ -150,7 +185,7 @@ def build_order_by(args):
         order_by += ['mtime DESC']
 
     if len(order_by) == 0:
-        return ['fullpath ASC']
+        return ['name COLLATE NOCASE ASC']
 
     if args.no_sort:
         order_by = []
@@ -164,74 +199,123 @@ if __name__=='__main__':
     # parse the arguments
     parser = argparse.ArgumentParser(description='GUFI version of ls', add_help=False)
     # override help to not use -h
-    parser.add_argument('--help',                                                  action='help',                                    help='show this help message and exit')
-    parser.add_argument('--version', '-v',                                         action='version',          version=os.path.basename(os.path.realpath(__file__)) + ' @GUFI_VERSION@')
-    parser.add_argument('-a', '--all',                      dest='all',            action='store_true',                              help='do not ignore entries starting with .')
-    parser.add_argument('-A', '--almost-all',               dest='almost_all',     action='store_true',                              help='do not list implied . and ..')
-    parser.add_argument('-B', '--ignore-backups',           dest='ignore_backups', action='store_true',                              help='do not list implied entries ending with ~')
-    parser.add_argument('-G', '--no-group',                 dest='no_group',       action='store_true',                              help='in a long listing, don\'t print group names')
-    parser.add_argument('-i', '--inode',                    dest='inode',          action='store_true',                              help='print the index number of each file')
-    parser.add_argument('-l',                               dest='long_listing',   action='store_true',                              help='use a long listing format')
-    parser.add_argument('-r', '--reverse',                  dest='reverse',        action='store_true',                              help='reverse order while sorting')
-    parser.add_argument('-R', '--recursive',                dest='recursive',      action='store_true',                              help='list subdirectories recursively')
-    parser.add_argument('-s', '--size',                     dest='size',           action='store_true',                              help='print the allocated size of each file, in blocks')
-    parser.add_argument('-S',                               dest='sort_largest',   action='store_true',                              help='sort by file size, largest first')
-    parser.add_argument('-t',                               dest='mtime',          action='store_true',                              help='sort by modification time, newest first')
-    parser.add_argument('-U',                               dest='no_sort',        action='store_true',                              help='do not sort; list entries in directory order')
+    parser.add_argument('--help',                                                   action='help',                                    help='show this help message and exit')
+    parser.add_argument('--version', '-v',                                          action='version',          version=os.path.basename(os.path.realpath(__file__)) + ' @GUFI_VERSION@')
+    parser.add_argument('-a', '--all',                       dest='all',            action='store_true',                              help='do not ignore entries starting with .')
+    parser.add_argument('-A', '--almost-all',                dest='almost_all',     action='store_true',                              help='do not list implied . and ..')
+    parser.add_argument('--block-size',                      dest='blocksize',      choices=SIZES,                                    help='with -l, scale sizes by SIZE when printing them')
+    parser.add_argument('-B', '--ignore-backups',            dest='ignore_backups', action='store_true',                              help='do not list implied entries ending with ~')
+    parser.add_argument('-G', '--no-group',                  dest='no_group',       action='store_true',                              help='in a long listing, don\'t print group names')
+    parser.add_argument('-h', '--human-readable',            dest='human_readable', action='store_true',                              help='with -l and -s, print sizes like 1K 234M 2G etc.')
+    parser.add_argument('-i', '--inode',                     dest='inode',          action='store_true',                              help='print the index number of each file')
+    parser.add_argument('-l',                                dest='long_listing',   action='store_true',                              help='use a long listing format')
+    parser.add_argument('-r', '--reverse',                   dest='reverse',        action='store_true',                              help='reverse order while sorting')
+    parser.add_argument('-R', '--recursive',                 dest='recursive',      action='store_true',                              help='list subdirectories recursively')
+    parser.add_argument('-s', '--size',                      dest='size',           action='store_true',                              help='print the allocated size of each file, in blocks')
+    parser.add_argument('-S',                                dest='sort_largest',   action='store_true',                              help='sort by file size, largest first')
+    parser.add_argument('-t',                                dest='mtime',          action='store_true',                              help='sort by modification time, newest first')
+    parser.add_argument('-U',                                dest='no_sort',        action='store_true',                              help='do not sort; list entries in directory order')
 
-    parser.add_argument('FILE',                                                    type=str, action='append', nargs='*')
+    # for now, only 1 path is allowed
+    parser.add_argument('paths',                                                    type=str, action='append' , nargs='*')
 
     # GUFI specific arguments
-    parser.add_argument('--delim',         metavar='c',     dest='delim',          type=gufi_common.get_char, default=' ',           help='delimiter separating output columns')
-    parser.add_argument('--num_results',   metavar='n',     dest='num_results',    type=gufi_common.get_non_negative,                help='first n results')
-    parser.add_argument('--output',                         dest='output',         type=str,                                         help='Output file prefix (Creates file <output>.tid)')
-    parser.add_argument('--output-buffer', metavar='bytes', dest='output_buffer',  type=gufi_common.get_positive,      default=4096, help='Size of each thread\'s output buffer')
+    parser.add_argument('--delim',          metavar='c',     dest='delim',          type=gufi_common.get_char, default=' ',           help='delimiter separating output columns')
+    parser.add_argument('--num_results',    metavar='n',     dest='num_results',    type=gufi_common.get_non_negative,                help='first n results')
+    parser.add_argument('--output-file',                     dest='output_file',    type=str,                                         help='Output file prefix (Creates file <output>.tid)')
+    parser.add_argument('--output-db',                       dest='output_db',      type=str,                                         help='Output database prefix (Creates file <output>.tid)')
+    parser.add_argument('--output-buffer',  metavar='bytes', dest='output_buffer',  type=gufi_common.get_non_negative, default=4096,  help='Size of each thread\'s output buffer')
+    parser.add_argument('--in-memory-name', metavar='name',  dest='inmemory_name',  type=str,                          default='out', help='Name of in-memory database when -R is used')
+    parser.add_argument('--size-width',     metavar='chars', dest='size_width',     type=gufi_common.get_non_negative, default=10,    help='Width of size column')
+    parser.add_argument('--user-width',     metavar='chars', dest='user_width',     type=gufi_common.get_non_negative, default=5,     help='Width of user column')
+    parser.add_argument('--group-width',    metavar='chars', dest='group_width',    type=gufi_common.get_non_negative, default=5,     help='Width of group column')
 
     args = parser.parse_args();
 
-    # default to IndexRoot
-    args.FILE = args.FILE[0]
-    if len(args.FILE) == 0:
-        args.FILE = ['']
+    if len(args.paths[0]) == 0:
+        args.paths= [['']]
 
-    # prepend the provided paths with the GUFI root path
-    args.FILE = [os.path.normpath(os.path.sep.join([config['IndexRoot'], path])) for path in args.FILE]
+    # return code
+    rc = 0
 
-    where = build_where(args)
-    order_by = build_order_by(args)
+    for path in args.paths[0]:
+        # prepend the provided paths with the GUFI root path
+        path = os.path.normpath(os.path.sep.join([config['IndexRoot'], path]))
 
-    first_query = gufi_common.build_query(build_select(config, args),
-                                          ['entries'],
-                                          where,
-                                          None,
-                                          order_by,
-                                          args.num_results)
-    second_query = gufi_common.build_query(build_aggregate_select(args),
-                                           ['entries'],
-                                           where,
-                                           None,
-                                           order_by,
-                                           args.num_results)
+        recursive = args.recursive
 
-    # create the query command
-    query_cmd = [config['Exec'],
-                 '-e', str(int(args.recursive)),
-                 '-n', str(config['Threads']),
-                 '-E', first_query,
-                 '-J', 'SELECT * FROM entries;',
-                 '-G', second_query,
-                 '-z', '-1' if args.recursive else '1']
+        # if the path is not a directory, remove the last part of the path
+        match_name = None
+        if not os.path.isdir(path):
+            path, match_name = os.path.split(path)
+            recursive = False
 
-    if args.delim:
-        query_cmd += ['-d', args.delim]
+        # create the base command
+        query_cmd = [config['Exec'],
+                     '-e', str(int(not recursive))]
 
-    if args.output:
-        query_cmd += ['-o', args.output]
+        # add more arguments
 
-    if args.output_buffer:
-        query_cmd += ['-B', str(args.output_buffer)]
+        if recursive:
+            I = 'CREATE TABLE {0} (fullpath TEXT, name TEXT, type TEXT, inode INT(64), nlink INT(64), size INT(64), mode INT(64), uid INT(64), gid INT(64), blksize INT(64), blocks INT(64), mtime INT(64), atime INT(64), ctime INT(64), linkname TEXT, xattrs TEXT, pinode INT(64));'.format(args.inmemory_name)
 
-    query = subprocess.Popen(query_cmd + args.FILE)
-    query.communicate() # block until query finishes
+            common = 'INSERT INTO {0} SELECT fpath(), name, type, inode, nlink, size, mode, uid, gid, blksize, blocks, mtime, atime, ctime, linkname, xattrs, pinode FROM '.format(args.inmemory_name)
+            S = common + 'summary'
+            E = common + 'pentries'
+            J = 'INSERT INTO aggregate.{0} SELECT * FROM {0}'.format(args.inmemory_name)
 
-    sys.exit(query.returncode)
+            column_names = ['fullpath', 'name', 'type', 'inode', 'nlink', 'size', 'mode', 'uid', 'gid', 'blksize', 'blocks', 'mtime', 'atime', 'ctime', 'linkname', 'xattrs', 'pinode']
+
+            G = '''WITH RECURSIVE under ({1}) AS
+                    (
+                         SELECT {2} FROM {0} WHERE inode=(SELECT inode FROM {0} WHERE fullpath=\"{3}\")
+                             UNION ALL
+                         SELECT {2} FROM {0} underm
+                                     JOIN under ON
+                                 underm.pinode=under.uinode
+                    )
+
+                    SELECT {4} FROM under;'''.format(args.inmemory_name,
+                                                     'u' + ', u'.join(column_names),
+                                                     ', '.join(column_names),
+                                                     path,
+                                                     ', '.join(build_recursive_select(args))
+                                                 )
+
+            query_cmd += ['-n', str(config['Threads']),
+                          '-I', I,
+                          '-S', S,
+                          '-E', E,
+                          '-J', J,
+                          '-G', G,
+                          '-a']
+        else:
+            query_cmd += ['-n', '1',
+                          '-E', gufi_common.build_query(build_select(args),
+                                                        ['entries'],
+                                                        build_where(args, match_name),
+                                                        None,
+                                                        build_order_by(args),
+                                                        args.num_results),
+                          '-y', '0',
+                          '-z', '0']
+
+        if args.delim:
+            query_cmd += ['-d', args.delim]
+
+        if args.output_file:
+            query_cmd += ['-o', args.output_file]
+
+        if args.output_db:
+            query_cmd += ['-O', args.output_db]
+
+        if args.output_buffer:
+            query_cmd += ['-B', str(args.output_buffer)]
+
+        query = subprocess.Popen(query_cmd + [path])
+        query.communicate() # block until query finishes
+
+        if query.returncode != 0:
+            rc = 2
+
+    sys.exit(rc)

--- a/scripts/gufi_ls
+++ b/scripts/gufi_ls
@@ -264,16 +264,42 @@ if __name__=='__main__':
         # create the base command
         query_cmd = [config['Exec']]
 
+        # always use aggregation
+        query_cmd += ['-e', '0']
+
+        I = 'CREATE TABLE {0} (fullpath TEXT, name TEXT, type TEXT, inode INT(64), nlink INT(64), size INT(64), mode INT(64), uid INT(64), gid INT(64), blksize INT(64), blocks INT(64), mtime INT(64), atime INT(64), ctime INT(64), linkname TEXT, xattrs TEXT, pinode INT(64));'.format(args.inmemory_name)
+
+        S = ''
+
+        J = 'INSERT INTO aggregate.{0} {1}'.format(args.inmemory_name, gufi_common.build_query(['*'],
+                                                                                               [args.inmemory_name],
+                                                                                               None,
+                                                                                               None,
+                                                                                               None,
+                                                                                               args.num_results))
+
+        G = ''
+
         if (fullpath == config['IndexRoot']) and not recursive:
-            S = gufi_common.build_query(build_select(args),
-                                        ['summary'],
+            S = 'INSERT INTO {0} {1}'.format(args.inmemory_name, gufi_common.build_query(['fpath()', 'name', 'type', 'inode', 'nlink', 'size',
+                                                                                          'mode', 'uid', 'gid', 'blksize', 'blocks', 'mtime',
+                                                                                          'atime', 'ctime', 'linkname', 'xattrs', 'pinode'],
+                                                                                         ['summary'],
+                                                                                         None,
+                                                                                         None,
+                                                                                         build_order_by(args),
+                                                                                         args.num_results))
+
+            G = gufi_common.build_query(build_select(args),
+                                        [args.inmemory_name],
                                         None,
                                         None,
                                         build_order_by(args),
                                         args.num_results)
 
-            query_cmd += ['-S', S,
+            query_cmd += ['-y', '1',
                           '-z', '1']
+
         else:
             # if the path is not a directory, remove the last part of the path
             match_name = None
@@ -281,15 +307,8 @@ if __name__=='__main__':
                 fullpath, match_name = os.path.split(fullpath)
                 recursive = False
 
-            # always use aggregation
-            query_cmd += ['-e', '0']
-
-            # add more arguments
-
             # common clauses
             where = build_where(args, match_name)
-
-            I = 'CREATE TABLE {0} (fullpath TEXT, name TEXT, type TEXT, inode INT(64), nlink INT(64), size INT(64), mode INT(64), uid INT(64), gid INT(64), blksize INT(64), blocks INT(64), mtime INT(64), atime INT(64), ctime INT(64), linkname TEXT, xattrs TEXT, pinode INT(64));'.format(args.inmemory_name)
 
             S = 'INSERT INTO {0} {1}'.format(args.inmemory_name, gufi_common.build_query(['fpath()', '"" as name' if args.recursive else 'name', 'type', 'inode', 'nlink', 'size',
                                                                                           'mode', 'uid', 'gid', 'blksize', 'blocks', 'mtime',
@@ -308,8 +327,6 @@ if __name__=='__main__':
                                                                                          None,
                                                                                          None,
                                                                                          None))
-
-            J = 'INSERT INTO aggregate.{0} SELECT * FROM {0}'.format(args.inmemory_name)
 
             if recursive:
                 column_names = ['fullpath', 'name', 'type', 'inode', 'nlink', 'size', 'mode', 'uid', 'gid', 'blksize', 'blocks', 'mtime', 'atime', 'ctime', 'linkname', 'xattrs', 'pinode']
@@ -350,13 +367,14 @@ if __name__=='__main__':
 
                 query_cmd += ['-z', '1']
 
-            query_cmd += ['-n', str(config['Threads']),
-                          '-I', I,
-                          '-S', S,
-                          '-E', E,
-                          '-J', J,
-                          '-G', G,
+            query_cmd += ['-E', E,
                           '-a']
+
+        query_cmd += ['-n', str(config['Threads']),
+                      '-I', I,
+                      '-S', S,
+                      '-J', J,
+                      '-G', G]
 
         if args.delim:
             query_cmd += ['-d', args.delim]

--- a/scripts/gufi_ls
+++ b/scripts/gufi_ls
@@ -255,57 +255,52 @@ if __name__=='__main__':
     rc = 0
 
     for path in args.paths[0]:
-        # prepend the provided paths with the GUFI root path
-        path = os.path.normpath(os.path.sep.join([config['IndexRoot'], path]))
+        # prepend the provided paths with the GUFI index root
+        fullpath = os.path.normpath(os.path.sep.join([config['IndexRoot'], path]))
 
         recursive = args.recursive
 
         # if the path is not a directory, remove the last part of the path
         match_name = None
-        if not os.path.isdir(path):
-            path, match_name = os.path.split(path)
+        if not os.path.isdir(fullpath):
+            fullpath, match_name = os.path.split(fullpath)
             recursive = False
+
+        # create the base command
+        query_cmd = [config['Exec'],
+                     '-e', '0'] # always use aggregation
+
+        # add more arguments
 
         # common clauses
         where = build_where(args, match_name)
 
-        # create the base command
-        query_cmd = [config['Exec'],
-                     '-e', str(int(not recursive))]
+        I = 'CREATE TABLE {0} (fullpath TEXT, name TEXT, type TEXT, inode INT(64), nlink INT(64), size INT(64), mode INT(64), uid INT(64), gid INT(64), blksize INT(64), blocks INT(64), mtime INT(64), atime INT(64), ctime INT(64), linkname TEXT, xattrs TEXT, pinode INT(64));'.format(args.inmemory_name)
 
-        # add more arguments
+        S = 'INSERT INTO {0} {1}'.format(args.inmemory_name, gufi_common.build_query(['fpath()', '"" as name' if args.recursive else 'name', 'type', 'inode', 'nlink', 'size',
+                                                                                      'mode', 'uid', 'gid', 'blksize', 'blocks', 'mtime',
+                                                                                      'atime', 'ctime', 'linkname', 'xattrs', 'pinode'],
+                                                                                     ['summary'],
+                                                                                     where,
+                                                                                     None,
+                                                                                     None,
+                                                                                     None))
+
+        E = 'INSERT INTO {0} {1}'.format(args.inmemory_name, gufi_common.build_query(['fpath()', 'name', 'type', 'inode', 'nlink', 'size',
+                                                                                      'mode', 'uid', 'gid', 'blksize', 'blocks', 'mtime',
+                                                                                      'atime', 'ctime', 'linkname', 'xattrs', 'pinode'],
+                                                                                     ['pentries'],
+                                                                                     where,
+                                                                                     None,
+                                                                                     None,
+                                                                                     None))
+
+        J = 'INSERT INTO aggregate.{0} SELECT * FROM {0}'.format(args.inmemory_name)
 
         if recursive:
-            I = 'CREATE TABLE {0} (fullpath TEXT, name TEXT, type TEXT, inode INT(64), nlink INT(64), size INT(64), mode INT(64), uid INT(64), gid INT(64), blksize INT(64), blocks INT(64), mtime INT(64), atime INT(64), ctime INT(64), linkname TEXT, xattrs TEXT, pinode INT(64));'.format(args.inmemory_name)
-
-            S = 'INSERT INTO {0} '.format(args.inmemory_name) + gufi_common.build_query(['fpath()', '"" as name', 'type',
-                                                                                         'inode', 'nlink', 'size',
-                                                                                         'mode', 'uid', 'gid',
-                                                                                         'blksize', 'blocks', 'mtime',
-                                                                                         'atime', 'ctime', 'linkname',
-                                                                                         'xattrs', 'pinode'],
-                                                                                        ['summary'],
-                                                                                        where,
-                                                                                        None,
-                                                                                        None,
-                                                                                        None)
-
-            E = 'INSERT INTO {0} '.format(args.inmemory_name) + gufi_common.build_query(['fpath()', 'name', 'type',
-                                                                                         'inode', 'nlink', 'size',
-                                                                                         'mode', 'uid', 'gid',
-                                                                                         'blksize', 'blocks', 'mtime',
-                                                                                         'atime', 'ctime', 'linkname',
-                                                                                         'xattrs', 'pinode'],
-                                                                                        ['pentries'],
-                                                                                        where,
-                                                                                        None,
-                                                                                        None,
-                                                                                        None)
-
-            J = 'INSERT INTO aggregate.{0} SELECT * FROM {0}'.format(args.inmemory_name)
-
             column_names = ['fullpath', 'name', 'type', 'inode', 'nlink', 'size', 'mode', 'uid', 'gid', 'blksize', 'blocks', 'mtime', 'atime', 'ctime', 'linkname', 'xattrs', 'pinode']
 
+            # recursive select on pinode
             G = '''WITH RECURSIVE under ({1}) AS
                     (
                          SELECT {2} FROM {0} WHERE inode=(SELECT inode FROM {0} WHERE fullpath=\"{3}\")
@@ -318,32 +313,36 @@ if __name__=='__main__':
                     {4};'''.format(args.inmemory_name,
                                                      'u' + ', u'.join(column_names),
                                                      ', '.join(column_names),
-                                                     path,
+                                                     fullpath,
                                                      gufi_common.build_query(build_recursive_select(args),
                                                                              ['under'],
                                                                              ['u' + w for w in where],
                                                                              None,
                                                                              build_order_by_recursive(args),
                                                                              args.num_results))
-
-            query_cmd += ['-n', str(config['Threads']),
-                          '-I', I,
-                          '-S', S,
-                          '-E', E,
-                          '-J', J,
-                          '-G', G,
-                          '-a']
-
         else:
-            query_cmd += ['-n', '1',
-                          '-E', gufi_common.build_query(build_select(args),
-                                                        ['entries'],
-                                                        where,
-                                                        None,
-                                                        build_order_by(args),
-                                                        args.num_results),
-                          '-y', '0',
-                          '-z', '0']
+            # select on pinode
+            G = gufi_common.build_query(build_select(args),
+                                        [args.inmemory_name],
+                                        ['pinode == ({})'.format(gufi_common.build_query(['inode'],
+                                                                                         [args.inmemory_name],
+                                                                                         ['fullpath == "{}"'.format(fullpath)],
+                                                                                         None,
+                                                                                         None,
+                                                                                         None))],
+                                        None,
+                                        build_order_by(args),
+                                        args.num_results)
+
+            query_cmd += ['-z', '1']
+
+        query_cmd += ['-n', str(config['Threads']),
+                      '-I', I,
+                      '-S', S,
+                      '-E', E,
+                      '-J', J,
+                      '-G', G,
+                      '-a']
 
         if args.delim:
             query_cmd += ['-d', args.delim]
@@ -357,7 +356,7 @@ if __name__=='__main__':
         if args.output_buffer:
             query_cmd += ['-B', str(args.output_buffer)]
 
-        query = subprocess.Popen(query_cmd + [path])
+        query = subprocess.Popen(query_cmd + [fullpath])
         query.communicate() # block until query finishes
 
         if query.returncode != 0:

--- a/scripts/gufi_ls
+++ b/scripts/gufi_ls
@@ -93,7 +93,7 @@ def build_select(args):
         select += ['blocks']
 
     if args.long_listing:
-        select += ['modetotxt(mode)', 'nlink', 'uidtouser(uid, ' + str(args.user_width) + ')']
+        select += ['modetotxt(mode)', 'printf("%' + str(args.nlink_width) + 'd", "nlink)', 'uidtouser(uid, ' + str(args.user_width) + ')']
         if not args.no_group:
             select += ['gidtogroup(gid, ' + str(args.group_width) + ')']
 
@@ -105,7 +105,7 @@ def build_select(args):
             select += ['blocksize(size, "' + args.blocksize + '", ' + str(args.size_width) + ')']
         else:
             select += ['printf("% ' + str(args.size_width) + 'z", size)']
-        select += ['strftime("%b  %e %H:%M", mtime)', 'case when (type == "l") then (name' + ' || " -> " || linkname) else name end']
+        select += ['strftime("%b  %e %H:%M", mtime)', 'case when (type == "l") then (name || " -> " || linkname) else name end']
 
     else:
         # at minimum, print the file name
@@ -126,7 +126,7 @@ def build_recursive_select(args):
         select += ['ublocks']
 
     if args.long_listing:
-        select += ['modetotxt(umode)', 'unlink', 'uidtouser(uuid, ' + str(args.user_width) + ')']
+        select += ['modetotxt(umode)', 'printf("%' + str(args.nlink_width) + 'd", unlink)', 'uidtouser(uuid, ' + str(args.user_width) + ')']
         if not args.no_group:
             select += ['gidtogroup(ugid, ' + str(args.group_width) + ')']
 
@@ -138,11 +138,11 @@ def build_recursive_select(args):
             select += ['blocksize(usize, "' + args.blocksize + '", ' + str(args.size_width) + ')']
         else:
             select += ['printf("% ' + str(args.size_width) + 'z", usize)']
-        select += ['strftime("%b  %e %H:%M", umtime)', 'case when (utype == "l") then (uname' + ' || " -> " || ulinkname) else uname end']
+        select += ['strftime("%b  %e %H:%M", umtime)', 'case when (utype == "l") then (ufullpath || "/" || uname || " -> " || ulinkname) else ufullpath || "/" || uname end']
 
     else:
         # at minimum, print the file name
-        select += ['uname']
+        select += ['ufullpath || "/" || uname']
 
     return select
 
@@ -226,6 +226,7 @@ if __name__=='__main__':
     parser.add_argument('--output-db',                       dest='output_db',      type=str,                                         help='Output database prefix (Creates file <output>.tid)')
     parser.add_argument('--output-buffer',  metavar='bytes', dest='output_buffer',  type=gufi_common.get_non_negative, default=4096,  help='Size of each thread\'s output buffer')
     parser.add_argument('--in-memory-name', metavar='name',  dest='inmemory_name',  type=str,                          default='out', help='Name of in-memory database when -R is used')
+    parser.add_argument('--nlink-width',    metavar='chars', dest='nlink_width',    type=gufi_common.get_non_negative, default=2,     help='Width of nlink column')
     parser.add_argument('--size-width',     metavar='chars', dest='size_width',     type=gufi_common.get_non_negative, default=10,    help='Width of size column')
     parser.add_argument('--user-width',     metavar='chars', dest='user_width',     type=gufi_common.get_non_negative, default=5,     help='Width of user column')
     parser.add_argument('--group-width',    metavar='chars', dest='group_width',    type=gufi_common.get_non_negative, default=5,     help='Width of group column')
@@ -250,6 +251,9 @@ if __name__=='__main__':
             path, match_name = os.path.split(path)
             recursive = False
 
+        # WHERE clause is common
+        where = build_where(args, match_name)
+
         # create the base command
         query_cmd = [config['Exec'],
                      '-e', str(int(not recursive))]
@@ -259,9 +263,22 @@ if __name__=='__main__':
         if recursive:
             I = 'CREATE TABLE {0} (fullpath TEXT, name TEXT, type TEXT, inode INT(64), nlink INT(64), size INT(64), mode INT(64), uid INT(64), gid INT(64), blksize INT(64), blocks INT(64), mtime INT(64), atime INT(64), ctime INT(64), linkname TEXT, xattrs TEXT, pinode INT(64));'.format(args.inmemory_name)
 
-            common = 'INSERT INTO {0} SELECT fpath(), name, type, inode, nlink, size, mode, uid, gid, blksize, blocks, mtime, atime, ctime, linkname, xattrs, pinode FROM '.format(args.inmemory_name)
-            S = common + 'summary'
-            E = common + 'pentries'
+            # there is a duplicate pinode column in pentries
+            common_columns = ['fpath()', 'name', 'type', 'inode', 'nlink', 'size', 'mode', 'uid', 'gid', 'blksize', 'blocks', 'mtime', 'atime', 'ctime', 'linkname', 'xattrs']
+            S = 'INSERT INTO {0} '.format(args.inmemory_name) + gufi_common.build_query(common_columns + ['pinode'],
+                                                                                        ['summary'],
+                                                                                        where,
+                                                                                        None,
+                                                                                        None,
+                                                                                        args.num_results)
+
+            E = 'INSERT INTO {0} '.format(args.inmemory_name) + gufi_common.build_query(common_columns + ['`pinode:1`'],
+                                                                                        ['pentries'],
+                                                                                        where,
+                                                                                        None,
+                                                                                        None,
+                                                                                        args.num_results)
+
             J = 'INSERT INTO aggregate.{0} SELECT * FROM {0}'.format(args.inmemory_name)
 
             column_names = ['fullpath', 'name', 'type', 'inode', 'nlink', 'size', 'mode', 'uid', 'gid', 'blksize', 'blocks', 'mtime', 'atime', 'ctime', 'linkname', 'xattrs', 'pinode']
@@ -293,7 +310,7 @@ if __name__=='__main__':
             query_cmd += ['-n', '1',
                           '-E', gufi_common.build_query(build_select(args),
                                                         ['entries'],
-                                                        build_where(args, match_name),
+                                                        where,
                                                         None,
                                                         build_order_by(args),
                                                         args.num_results),

--- a/scripts/gufi_ls
+++ b/scripts/gufi_ls
@@ -182,7 +182,7 @@ def build_order_by(args):
         order_by += ['mtime ' + ('ASC' if args.reverse else 'DESC')]
 
     if len(order_by) == 0:
-        order_by += ['name COLLATE NOCASE ASC']
+        order_by += ['name COLLATE NOCASE ' + ('DESC' if args.reverse else 'ASC')]
 
     if args.no_sort:
         order_by = []
@@ -200,7 +200,7 @@ def build_order_by_recursive(args):
         order_by += ['umtime ' + ('ASC' if args.reverse else 'DESC')]
 
     if len(order_by) == 0:
-        order_by += ['ufullpath || "/" || uname COLLATE NOCASE ASC']
+        order_by += ['ufullpath || "/" || uname COLLATE NOCASE ' + ('DESC' if args.reverse else 'ASC')]
 
     if args.no_sort:
         order_by = []
@@ -248,6 +248,7 @@ if __name__=='__main__':
 
     args = parser.parse_args();
 
+    # at least 1 argument
     if len(args.paths[0]) == 0:
         args.paths= [['']]
 

--- a/src/bf.c
+++ b/src/bf.c
@@ -460,8 +460,8 @@ int parse_cmd_line(int         argc,
 
    // aggregating requires -E and 2 more SQL queries (-J and -G)
    if (in->show_results == AGGREGATE) {
-       if (!in->sqlent_len || !strlen(in->aggregate) || !strlen(in->intermediate)) {
-           fprintf(stderr, "Missing SQL statements. Need: -E (entries), -J (intermediate), and -G (aggregate)\n");
+       if ((!in->sqlsum_len && !in->sqlent_len) || !strlen(in->aggregate) || !strlen(in->intermediate)) {
+           fprintf(stderr, "Missing SQL statements. Need: -S (summary) or -E (entries), and -J (intermediate) and -G (aggregate)\n");
            return retval = -1;
        }
    }

--- a/src/bf.c
+++ b/src/bf.c
@@ -161,6 +161,7 @@ void show_input(struct input* in, int retval) {
    printf("in.dodelim            = %d\n",    in->dodelim);
    printf("in.delim              = '%s'\n",  in->delim);
    printf("in.name               = '%s'\n",  in->name);
+   printf("in.name_len           = '%zu'\n", in->name_len);
    printf("in.outfile            = %d\n",    in->outfile);
    printf("in.outfilen           = '%s'\n",  in->outfilen);
    printf("in.outdb              = %d\n",    in->outdb);
@@ -215,6 +216,7 @@ int parse_cmd_line(int         argc,
                    struct input *in) {
    in->maxthreads         = 1;         // don't default to zero threads
    SNPRINTF(in->delim, sizeof(in->delim), "|");
+   in->name_len           = 0;
    in->sqlinit_len        = 0;
    in->sqltsum_len        = 0;
    in->sqlsum_len         = 0;

--- a/src/dbutils.c
+++ b/src/dbutils.c
@@ -82,9 +82,9 @@ char *rsql = // "DROP TABLE IF EXISTS readdirplus;"
 char *rsqli = "INSERT INTO readdirplus VALUES (@path,@type,@inode,@pinode,@suspect);";
 
 char *esql = // "DROP TABLE IF EXISTS entries;"
-            "CREATE TABLE entries(id INTEGER PRIMARY KEY, name TEXT, type TEXT, inode INT64, mode INT64, nlink INT64, uid INT64, gid INT64, size INT64, blksize INT64, blocks INT64, atime INT64, mtime INT64, ctime INT64, linkname TEXT, xattrs TEXT, crtime INT64, ossint1 INT64, ossint2 INT64, ossint3 INT64, ossint4 INT64, osstext1 TEXT, osstext2 TEXT, pinode INT64);";
+            "CREATE TABLE entries(id INTEGER PRIMARY KEY, name TEXT, type TEXT, inode INT64, mode INT64, nlink INT64, uid INT64, gid INT64, size INT64, blksize INT64, blocks INT64, atime INT64, mtime INT64, ctime INT64, linkname TEXT, xattrs TEXT, crtime INT64, ossint1 INT64, ossint2 INT64, ossint3 INT64, ossint4 INT64, osstext1 TEXT, osstext2 TEXT);";
 
-char *esqli = "INSERT INTO entries VALUES (NULL,@name,@type,@inode,@mode,@nlink,@uid,@gid,@size,@blksize,@blocks,@atime,@mtime, @ctime,@linkname,@xattrs,@crtime,@ossint1,@ossint2,@ossint3,@ossint4,@osstext1,@osstext2,@pinode);";
+char *esqli = "INSERT INTO entries VALUES (NULL,@name,@type,@inode,@mode,@nlink,@uid,@gid,@size,@blksize,@blocks,@atime,@mtime, @ctime,@linkname,@xattrs,@crtime,@ossint1,@ossint2,@ossint3,@ossint4,@osstext1,@osstext2);";
 
 char *ssql = "DROP TABLE IF EXISTS summary;"
              "CREATE TABLE summary(id INTEGER PRIMARY KEY, name TEXT, type TEXT, inode INT64, mode INT64, nlink INT64, uid INT64, gid INT64, size INT64, blksize INT64, blocks INT64, atime INT64, mtime INT64, ctime INT64, linkname TEXT, xattrs TEXT, totfiles INT64, totlinks INT64, minuid INT64, maxuid INT64, mingid INT64, maxgid INT64, minsize INT64, maxsize INT64, totltk INT64, totmtk INT64, totltm INT64, totmtm INT64, totmtg INT64, totmtt INT64, totsize INT64, minctime INT64, maxctime INT64, minmtime INT64, maxmtime INT64, minatime INT64, maxatime INT64, minblocks INT64, maxblocks INT64, totxattr INT64,depth INT64, mincrtime INT64, maxcrtime INT64, minossint1 INT64, maxossint1 INT64, totossint1 INT64, minossint2 INT64, maxossint2 INT64, totossint2 INT64, minossint3 INT64, maxossint3 INT64, totossint3 INT64,minossint4 INT64, maxossint4 INT64, totossint4 INT64, rectype INT64, pinode INT64);";

--- a/src/dbutils.c
+++ b/src/dbutils.c
@@ -659,45 +659,21 @@ int insertdbgor(struct work *pwork, sqlite3 *db, sqlite3_stmt *res)
 
 int insertsumdb(sqlite3 *sdb, struct work *pwork,struct sum *su)
 {
-    int cnt;
-    int found;
     char *err_msg = 0;
     char sqlstmt[MAXSQL];
     int rc;
-    int len=0;
-    const char *shortname;
-    int depth;
-    size_t i;
-    int rectype;
+    int depth = 0;
+    int rectype = 0;
 
-    rectype=0; // directory summary record type
-    depth=0;
-    i=0;
-    while (i < strlen(pwork->name)) {
-      if (!strncmp(pwork->name+i,"/",1)) depth++;
-      i++;
+    /* remove trailing path separators (pwork->name is a directory, not a file) */
+    for(size_t i = strlen(pwork->name) - 1; i && (pwork->name[i] == '/'); i--) {
+        pwork->name[i] = '\0';
     }
-    //printf("dbutil insertsum name %s depth %d\n",pwork->name,depth);
-    shortname=pwork->name;
-    len=strlen(pwork->name);
-    cnt=0;
-    found=0;
-    while (len > 0) {
-       if (!memcmp(shortname,"/",1)) {
-          found=cnt;
-       }
-       cnt++;
-       len--;
-       shortname++;
-    }
-    if (found > 0) {
-      shortname=pwork->name+found+1;
-    } else {
-      shortname=pwork->name;
-    }
-    if (strlen(shortname) < 1) printf("***** shortname is < 1 %s\n",pwork->name);
 
-
+    /* get the basename */
+    char nameout[MAXPATH];
+    char shortname[MAXPATH];
+    shortpath(pwork->name, nameout, shortname);
 
 /*
 CREATE TABLE summary(name TEXT PRIMARY KEY, type TEXT, inode INT, mode INT, nlink INT, uid INT, gid INT, size INT, blksize INT, blocks INT, atime INT, mtime INT, ctime INT, linkname TEXT, xattrs TEXT, totfiles INT, totlinks INT, minuid INT, maxuid INT, mingid INT, maxgid INT, minsize INT, maxsize INT, totltk INT, totmtk INT, totltm INT, totmtm INT, totmtg INT, totmtt INT, totsize INT, minctime INT, maxctime INT, minmtime INT, maxmtime INT, minatime INT, maxatime INT, minblocks INT, maxblocks INT, totxattr INT,depth INT, mincrtime INT, maxcrtime INT, minossint1 INT, maxossint1 INT, totossint1 INT, minossint2 INT, maxossint2, totossint2 INT, minossint3 INT, maxossint3, totossint3 INT,minossint4 INT, maxossint4 INT, totossint4 INT, rectype INT, pinode INT);

--- a/src/gufi_query.c
+++ b/src/gufi_query.c
@@ -730,11 +730,19 @@ int processdir(struct QPTPool * ctx, const size_t id, void * data, void * args) 
                     ca.count = 0;
 
                     /* this probably needs a timer */
+                    #ifdef DEBUG
                     char *err = NULL;
-                    if (sqlite3_exec(db, in.sqlsum, ta->print_callback_func, &ca, &err) != SQLITE_OK) {
+                    if (
+                    #endif
+                        sqlite3_exec(db, in.sqlsum, ta->print_callback_func, &ca,
+                    #ifdef DEBUG
+                        &err) != SQLITE_OK) {
                         fprintf(stderr, "Error: %s: %s: \"%s\"\n", err, dbname, in.sqlent);
                         sqlite3_free(err);
                     }
+                    #else
+                    NULL);
+                    #endif
                     #endif
 
                     recs = ca.count;
@@ -761,14 +769,18 @@ int processdir(struct QPTPool * ctx, const size_t id, void * data, void * args) 
 
                         #ifdef DEBUG
                         clock_gettime(CLOCK_MONOTONIC, &exec_start);
-                        #endif
                         char *err = NULL;
-                        if (sqlite3_exec(db, in.sqlent, ta->print_callback_func, &ca, &err) != SQLITE_OK) {
+                        if (
+                        #endif
+                        sqlite3_exec(db, in.sqlent, ta->print_callback_func, &ca,
+                        #ifdef DEBUG
+                        &err) != SQLITE_OK) {
                             fprintf(stderr, "Error: %s: %s: \"%s\"\n", err, dbname, in.sqlent);
                             sqlite3_free(err);
                         }
-                        #ifdef DEBUG
                         clock_gettime(CLOCK_MONOTONIC, &exec_end);
+                        #else
+                        NULL) ;
                         #endif
                         #endif
                     }

--- a/src/gufi_query.c
+++ b/src/gufi_query.c
@@ -1147,7 +1147,7 @@ int main(int argc, char *argv[])
         for(int i = 0; i < in.maxthreads; i++) {
             if (!attachdb(aggregate_name, gts.outdbd[i], AGGREGATE_ATTACH_NAME)               ||
                 (sqlite3_exec(gts.outdbd[i], in.intermediate, NULL, NULL, NULL) != SQLITE_OK)) {
-                printf("Aggregation of intermediate databases error: %s\n", sqlite3_errmsg(gts.outdbd[i]));
+                fprintf(stderr, "Aggregation of intermediate databases error: %s\n", sqlite3_errmsg(gts.outdbd[i]));
             }
         }
 

--- a/src/template_db.c
+++ b/src/template_db.c
@@ -95,7 +95,7 @@ static ssize_t gufi_copyfd(int src_fd, int dst_fd, size_t size) {
 
 extern int errno;
 
-static int create_tables(const char * name, sqlite3 *db, void * args) {
+static int create_tables(const char *name, sqlite3 *db, void *args) {
     if ((create_table_wrapper(name, db, "esql",        esql,        NULL, NULL) != SQLITE_OK) ||
         (create_table_wrapper(name, db, "ssql",        ssql,        NULL, NULL) != SQLITE_OK) ||
         (create_table_wrapper(name, db, "vssqldir",    vssqldir,    NULL, NULL) != SQLITE_OK) ||
@@ -121,6 +121,7 @@ off_t create_template(int * fd) {
                           , NULL, NULL
                           #endif
                           );
+
     sqlite3_close(db);
 
     if ((*fd = open(name, O_RDONLY)) == -1) {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -70,7 +70,7 @@ add_test(NAME verifyknowntree COMMAND verifyknowntree)
 
 # copy test scripts into the test directory within the build directory
 # list these explicitly to prevent random garbage from getting in
-foreach(SCRIPT
+foreach(TEST
     bfwiflat2gufitest
     dfw2gufitest
     generatetree
@@ -101,7 +101,7 @@ foreach(SCRIPT
     testdir.tar
     verifyknowntree)
   # copy the script into the build directory for easy access
-  configure_file(${SCRIPT} ${SCRIPT} COPYONLY)
+  configure_file(${TEST} ${TEST} COPYONLY)
 endforeach()
 
 # create an empty directory and extract testdir.tar into it for runtests

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -108,7 +108,7 @@ endforeach()
 set(TESTTAR  "${CMAKE_CURRENT_BINARY_DIR}/testdir.tar")
 set(TESTDIR  "${CMAKE_CURRENT_BINARY_DIR}/testdir")
 set(TESTDST  "${TESTDIR}.gufi")
-set(TESTGUFI "${TESTDST}/${TESTDIR}")
+set(TESTGUFI "${TESTDST}")
 
 add_custom_target(cleanup_tree ALL COMMAND rm -rf "${TESTDIR}" "${TESTGUFI}")
 add_custom_target(mkdir ALL COMMAND mkdir -p "${TESTDIR}"

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -105,12 +105,11 @@ foreach(SCRIPT
 endforeach()
 
 # create an empty directory and extract testdir.tar into it for runtests
-set(TESTTAR  "${CMAKE_CURRENT_BINARY_DIR}/testdir.tar")
-set(TESTDIR  "${CMAKE_CURRENT_BINARY_DIR}/testdir")
-set(TESTDST  "${TESTDIR}.gufi")
-set(TESTGUFI "${TESTDST}")
+set(TESTTAR "${CMAKE_CURRENT_BINARY_DIR}/testdir.tar")
+set(TESTDIR "${CMAKE_CURRENT_BINARY_DIR}/testdir")
+set(TESTDST "${TESTDIR}.gufi")
 
-add_custom_target(cleanup_tree ALL COMMAND rm -rf "${TESTDIR}" "${TESTGUFI}")
+add_custom_target(cleanup_tree ALL COMMAND rm -rf "${TESTDIR}" "${TESTDST}")
 add_custom_target(mkdir ALL COMMAND mkdir -p "${TESTDIR}"
                   DEPENDS cleanup_tree)
 add_custom_target(untar_tree ALL COMMAND tar -xf "${TESTTAR}" -C "${TESTDIR}"
@@ -119,20 +118,20 @@ add_custom_target(untar_tree ALL COMMAND tar -xf "${TESTTAR}" -C "${TESTDIR}"
 # run individual tests
 # bfwi must run first
 add_test(NAME bfwi                            COMMAND runbfwi                        ${TESTDIR} ${TESTDST} WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
-add_test(NAME bfti                            COMMAND runbfti                        ${TESTGUFI}           WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
-add_test(NAME bfq                             COMMAND runbfq                         ${TESTGUFI}           WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
-add_test(NAME bfwreaddirplus2db               COMMAND runbfwreaddirplus2db           ${TESTGUFI}           WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
-add_test(NAME querydb                         COMMAND runquerydb                     ${TESTGUFI}           WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
-add_test(NAME querydbn                        COMMAND runquerydbn                    ${TESTGUFI} 2         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
-add_test(NAME dfw                             COMMAND rundfw                         ${TESTGUFI}           WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+add_test(NAME bfti                            COMMAND runbfti                        ${TESTDST}           WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+add_test(NAME bfq                             COMMAND runbfq                         ${TESTDST}           WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+add_test(NAME bfwreaddirplus2db               COMMAND runbfwreaddirplus2db           ${TESTDST}           WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+add_test(NAME querydb                         COMMAND runquerydb                     ${TESTDST}           WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+add_test(NAME querydbn                        COMMAND runquerydbn                    ${TESTDST} 2         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+add_test(NAME dfw                             COMMAND rundfw                         ${TESTDST}           WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 
 # other tests
-add_test(NAME listschemadb                    COMMAND runlistschemadb                ${TESTGUFI}           WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
-add_test(NAME listtablesdb                    COMMAND runlisttablesdb                ${TESTGUFI}           WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
-add_test(NAME groupfilespacehogusesummary     COMMAND rungroupfilespacehogusesummary ${TESTGUFI} 2         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
-add_test(NAME userfilespacehogusesummary      COMMAND runuserfilespacehogusesummary  ${TESTGUFI} 2         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
-add_test(NAME groupfilespacehog               COMMAND rungroupfilespacehog           ${TESTGUFI} 2         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
-add_test(NAME userfilespacehog                COMMAND runuserfilespacehog            ${TESTGUFI} 2         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
-add_test(NAME oldbigfiles                     COMMAND runoldbigfiles                 ${TESTGUFI} 2         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+add_test(NAME listschemadb                    COMMAND runlistschemadb                ${TESTDST}           WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+add_test(NAME listtablesdb                    COMMAND runlisttablesdb                ${TESTDST}           WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+add_test(NAME groupfilespacehogusesummary     COMMAND rungroupfilespacehogusesummary ${TESTDST} 2         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+add_test(NAME userfilespacehogusesummary      COMMAND runuserfilespacehogusesummary  ${TESTDST} 2         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+add_test(NAME groupfilespacehog               COMMAND rungroupfilespacehog           ${TESTDST} 2         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+add_test(NAME userfilespacehog                COMMAND runuserfilespacehog            ${TESTDST} 2         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+add_test(NAME oldbigfiles                     COMMAND runoldbigfiles                 ${TESTDST} 2         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 
 # add_test(NAME gufitest COMMAND gufitest.py all)

--- a/test/runbfwi
+++ b/test/runbfwi
@@ -136,7 +136,7 @@ CLEAN_GUFI=":"
 
 if [ -n "$GUFI_BASE" ]; then
     DEST="$GUFI_BASE"
-    GUFI="$GUFI_BASE/$SOURCE"
+    GUFI="$GUFI_BASE"
     CLEAN_GUFI="rm -rf $GUFI"
 fi
 

--- a/test/verifyknowntree
+++ b/test/verifyknowntree
@@ -35,12 +35,6 @@ ${ORIGIN}/../${SRC}/gufi_dir2index "${src}" "${dst}"
 dst="$(echo ${dst} | tr -s /)" # clean up slashes
 dst="${dst%/}"                 # remove last slash
 
-if [[ "${src}" =~ ^/ ]]; then
-    dst="${dst}${src}"
-else
-    dst="${dst}/${src}"
-fi
-
 # do not exit after first error
 set +e
 


### PR DESCRIPTION
Fixes #8 

updated non-recursive queries to use formatting functions
fixed depth of non-recursive queries
recursive ls
indexing `/a/b/c` to `/q/r/s` now goes to `/q/r/s`, where `s` contains `c`'s immediate contents.