### PR TITLE
gufi_jail updates

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -264,6 +264,9 @@ set(COMMON_LIBRARIES
   dl
 )
 
+# enable "make test"
+enable_testing()
+
 # build the core executables
 add_subdirectory(src)
 
@@ -275,9 +278,6 @@ add_subdirectory(config)
 
 # build documentation
 add_subdirectory(docs)
-
-# enable "make test"
-enable_testing()
 
 # recurse down into the test subdirectory
 add_subdirectory(test)

--- a/contrib/travis/build_and_test.sh
+++ b/contrib/travis/build_and_test.sh
@@ -84,16 +84,6 @@ fi
 
 make
 
-SUDO=
-if [[ -x "$(command -v sudo)" ]]
-then
-    SUDO=sudo
-fi
-
-${SUDO} make install
-${SUDO} cp /etc/GUFI/config.example /etc/GUFI/config
-${SUDO} chmod 644 /etc/GUFI/config
-
 if [[ "${BUILD}" = "cmake" ]]; then
     ctest --verbose
 elif [[ "${BUILD}" = "make" ]]; then

--- a/contrib/travis/build_and_test.sh
+++ b/contrib/travis/build_and_test.sh
@@ -63,14 +63,15 @@
 
 set -e
 
+mkdir -p build
+cd build
+
 export CC="${C_COMPILER}"
 export CXX="${CXX_COMPILER}"
 export GTEST_COLOR=1
 export DEP_PATH="/tmp"
 export PATH="${DEP_PATH}/sqlite3/bin:${PATH}"
 
-mkdir -p build
-cd build
 cmake ${CMAKE_FLAGS} -DDEP_INSTALL_PREFIX="${DEP_PATH}" ..
 
 # use files from the generated tar
@@ -82,6 +83,16 @@ if  [[ "${BUILD}" = "make" ]]; then
 fi
 
 make
+
+SUDO=
+if [[ -x "$(command -v sudo)" ]]
+then
+    SUDO=sudo
+fi
+
+${SUDO} make install
+${SUDO} cp /etc/GUFI/config.example /etc/GUFI/config
+${SUDO} chmod 644 /etc/GUFI/config
 
 if [[ "${BUILD}" = "cmake" ]]; then
     ctest --verbose

--- a/contrib/travis/centos7.sh
+++ b/contrib/travis/centos7.sh
@@ -76,14 +76,14 @@ de yum -y install epel-release centos-release-scl
 de yum -y install fuse-devel libattr1 pcre-devel
 
 # install extra packages
-de yum -y install autoconf cmake3 make patch pkgconfig sudo
+de yum -y install autoconf cmake3 make patch pkgconfig
 
 # create symlinks
 de ln -sf /usr/bin/cmake3 /usr/bin/cmake
 de ln -sf /usr/bin/ctest3 /usr/bin/ctest
 
 if [[ "${C_COMPILER}" = gcc-* ]]; then
-    VERSIONN="${C_COMPILER##*-}"
+    VERSION="${C_COMPILER##*-}"
     C_PACKAGE="devtoolset-${VERSION}"
     CENTOS_C_COMPILER="gcc-${VERSION}"
     de update-alternatives --install /usr/bin/gcc-${VERSION} gcc-${VERSION} /opt/rh/devtoolset-${VERSION}/root/usr/bin/gcc 10

--- a/contrib/travis/centos7.sh
+++ b/contrib/travis/centos7.sh
@@ -76,7 +76,7 @@ de yum -y install epel-release centos-release-scl
 de yum -y install fuse-devel libattr1 pcre-devel
 
 # install extra packages
-de yum -y install autoconf cmake3 make patch pkgconfig
+de yum -y install autoconf cmake3 make patch pkgconfig sudo
 
 # create symlinks
 de ln -sf /usr/bin/cmake3 /usr/bin/cmake

--- a/contrib/travis/centos7.sh
+++ b/contrib/travis/centos7.sh
@@ -115,9 +115,5 @@ fi
 # install the compilers
 de yum -y install ${C_PACKAGE} ${CXX_PACKAGE}
 
-# add the travis user
-de useradd travis -m -s /sbin/nologin || true
-de chown -R travis /GUFI
-
 # build and test GUFI
-docker exec --env C_COMPILER="${CENTOS_C_COMPILER}" --env CXX_COMPILER="${CENTOS_CXX_COMPILER}" --env BUILD="${BUILD}" --env CMAKE_FLAGS="${CMAKE_FLAGS}" --user travis "${TRAVIS_JOB_NUMBER}" bash -c "cd /GUFI && LD_LIBRARY_PATH=\"/opt/rh/httpd24/root/usr/lib64/:\$(printenv LD_LIBRARY_PATH)\" PKG_CONFIG_PATH=\"/tmp/sqlite3/lib/pkgconfig:\$(printenv PKG_CONFIG_PATH)\" ${SCRIPT_PATH}/build_and_test.sh"
+docker exec --env C_COMPILER="${CENTOS_C_COMPILER}" --env CXX_COMPILER="${CENTOS_CXX_COMPILER}" --env BUILD="${BUILD}" --env CMAKE_FLAGS="${CMAKE_FLAGS}" "${TRAVIS_JOB_NUMBER}" bash -c "cd /GUFI && LD_LIBRARY_PATH=\"/opt/rh/httpd24/root/usr/lib64/:\$(printenv LD_LIBRARY_PATH)\" PKG_CONFIG_PATH=\"/tmp/sqlite3/lib/pkgconfig:\$(printenv PKG_CONFIG_PATH)\" ${SCRIPT_PATH}/build_and_test.sh"

--- a/contrib/travis/suse12.3.sh
+++ b/contrib/travis/suse12.3.sh
@@ -81,7 +81,7 @@ de zypper --non-interactive --no-gpg-checks update
 de zypper --non-interactive install fuse-devel libattr-devel libmysqlclient-devel libuuid-devel pcre-devel
 
 # install extra packages
-de zypper --non-interactive install autoconf binutils cmake libgcc_s1 patch pkg-config
+de zypper --non-interactive install autoconf binutils cmake libgcc_s1 patch pkg-config sudo
 
 if [[ "${C_COMPILER}" = gcc-* ]]; then
     C_PACKAGE="gcc${C_COMPILER##*-}"

--- a/contrib/travis/suse12.3.sh
+++ b/contrib/travis/suse12.3.sh
@@ -81,7 +81,7 @@ de zypper --non-interactive --no-gpg-checks update
 de zypper --non-interactive install fuse-devel libattr-devel libmysqlclient-devel libuuid-devel pcre-devel
 
 # install extra packages
-de zypper --non-interactive install autoconf binutils cmake libgcc_s1 patch pkg-config sudo
+de zypper --non-interactive install autoconf binutils cmake libgcc_s1 patch pkg-config
 
 if [[ "${C_COMPILER}" = gcc-* ]]; then
     C_PACKAGE="gcc${C_COMPILER##*-}"

--- a/scripts/CMakeLists.txt
+++ b/scripts/CMakeLists.txt
@@ -117,32 +117,3 @@ install(FILES gufi_common.py DESTINATION bin COMPONENT Server)
 # gufi_jail is used by sshd_config to prevent commands other than gufi_* from running
 configure_file(gufi_jail gufi_jail COPYONLY)
 install(PROGRAMS gufi_jail DESTINATION bin COMPONENT Server)
-
-# gufi_jail tests
-add_test(NAME jail:gufi_find COMMAND ${CMAKE_COMMAND} -E env SSH_ORIGINAL_COMMAND=gufi_find
-  gufi_jail WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}")
-
-add_test(NAME jail:gufi_ls COMMAND ${CMAKE_COMMAND} -E env SSH_ORIGINAL_COMMAND=gufi_ls
-  gufi_jail WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}")
-
-add_test(NAME jail:gufi_stats COMMAND ${CMAKE_COMMAND} -E env SSH_ORIGINAL_COMMAND=gufi_stats\ depth
-  gufi_jail WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}")
-
-add_test(NAME jail:gufi COMMAND ${CMAKE_COMMAND} -E env SSH_ORIGINAL_COMMAND=gufi
-  gufi_jail WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}")
-
-add_test(NAME jail:find COMMAND ${CMAKE_COMMAND} -E env SSH_ORIGINAL_COMMAND=find
-  gufi_jail WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}")
-
-add_test(NAME jail:ls COMMAND ${CMAKE_COMMAND} -E env SSH_ORIGINAL_COMMAND=ls
-  gufi_jail WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}")
-
-add_test(NAME jail:bash COMMAND ${CMAKE_COMMAND} -E env SSH_ORIGINAL_COMMAND=bash
-  gufi_jail WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}")
-
-# group these tests under gufi_jail
-set_tests_properties(jail:gufi_find jail:gufi_ls jail:gufi_stats
-                     jail:gufi jail:find jail:ls jail:bash PROPERTIES LABELS "gufi_jail")
-
-# tests that are expected to fail
-set_tests_properties(jail:gufi jail:find jail:ls jail:bash PROPERTIES WILL_FAIL TRUE)

--- a/scripts/CMakeLists.txt
+++ b/scripts/CMakeLists.txt
@@ -114,5 +114,5 @@ endforeach()
 configure_file(gufi_common.py gufi_common.py @ONLY)
 install(FILES gufi_common.py DESTINATION bin COMPONENT Server)
 
-# gufi_jail.sh is used by sshd_config to prevent commands other than gufi_* from running
-install(PROGRAMS gufi_jail.sh DESTINATION bin COMPONENT Server)
+# gufi_jail is used by sshd_config to prevent commands other than gufi_* from running
+install(PROGRAMS gufi_jail DESTINATION bin COMPONENT Server)

--- a/scripts/CMakeLists.txt
+++ b/scripts/CMakeLists.txt
@@ -115,4 +115,34 @@ configure_file(gufi_common.py gufi_common.py @ONLY)
 install(FILES gufi_common.py DESTINATION bin COMPONENT Server)
 
 # gufi_jail is used by sshd_config to prevent commands other than gufi_* from running
+configure_file(gufi_jail gufi_jail COPYONLY)
 install(PROGRAMS gufi_jail DESTINATION bin COMPONENT Server)
+
+# gufi_jail tests
+add_test(NAME jail:gufi_find COMMAND ${CMAKE_COMMAND} -E env SSH_ORIGINAL_COMMAND=gufi_find
+  gufi_jail WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}")
+
+add_test(NAME jail:gufi_ls COMMAND ${CMAKE_COMMAND} -E env SSH_ORIGINAL_COMMAND=gufi_ls
+  gufi_jail WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}")
+
+add_test(NAME jail:gufi_stats COMMAND ${CMAKE_COMMAND} -E env SSH_ORIGINAL_COMMAND=gufi_stats\ depth
+  gufi_jail WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}")
+
+add_test(NAME jail:gufi COMMAND ${CMAKE_COMMAND} -E env SSH_ORIGINAL_COMMAND=gufi
+  gufi_jail WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}")
+
+add_test(NAME jail:find COMMAND ${CMAKE_COMMAND} -E env SSH_ORIGINAL_COMMAND=find
+  gufi_jail WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}")
+
+add_test(NAME jail:ls COMMAND ${CMAKE_COMMAND} -E env SSH_ORIGINAL_COMMAND=ls
+  gufi_jail WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}")
+
+add_test(NAME jail:bash COMMAND ${CMAKE_COMMAND} -E env SSH_ORIGINAL_COMMAND=bash
+  gufi_jail WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}")
+
+# group these tests under gufi_jail
+set_tests_properties(jail:gufi_find jail:gufi_ls jail:gufi_stats
+                     jail:gufi jail:find jail:ls jail:bash PROPERTIES LABELS "gufi_jail")
+
+# tests that are expected to fail
+set_tests_properties(jail:gufi jail:find jail:ls jail:bash PROPERTIES WILL_FAIL TRUE)

--- a/scripts/gufi_jail
+++ b/scripts/gufi_jail
@@ -6,20 +6,18 @@
 # Add a section like this to /etc/ssh/sshd_config:
 #
 # Match Group gufi
-#       ForceCommand gufi_jail.sh
+#       ForceCommand /path/to/gufi_jail
 #
 
 set -f
 
 set -- ${SSH_ORIGINAL_COMMAND}
 case "$1" in
-    gufi_find|gufi_ls|gufi_stat|gufi_stats)
+    gufi_find|gufi_ls|gufi_stats)
         ;;
     *)
+        echo "Error: Command \"$1\" is not allowed" >&2
         exit 1
 esac
 
-command="$1"
-shift
-
-exec "${command}" "$@"
+exec "$@"


### PR DESCRIPTION
Fixed error with `exec` call
~~Added tests to make sure commands that should pass do pass.~~
~~Added tests to check obvious attempts to circumvent `gufi_jail`.~~
Tests are preserved in the commits, but have been removed for now. They require the config file to be installed before testing, and some of the test machines do not like `sudo`.