### PR TITLE
Change pullxattrs to be able to read as many xattrs as can fit the buffer

### DIFF
--- a/contrib/make_testindex.cpp
+++ b/contrib/make_testindex.cpp
@@ -480,7 +480,8 @@ void generatecurr(ThreadArgs *arg, const std::size_t files, std::list <off_t> &s
         SNPRINTF(work.name, MAXPATH, "%s", s.str().c_str());
         SNPRINTF(work.type, 2, "f");
         work.linkname[0] = '\0';
-        SNPRINTF(work.xattr, MAXPATH, "xattr %zu", i);
+        SNPRINTF(work.xattrs,   MAXXATTR, "xattr %zu\x1fvalue %zu\x00", i);
+        work.xattrs_len = strlen(work.xattrs);
         SNPRINTF(work.osstext1, MAXXATTR, "osstext1 %zu", i);
         SNPRINTF(work.osstext2, MAXXATTR, "osstext2 %zu", i);
 
@@ -496,13 +497,13 @@ void generatecurr(ThreadArgs *arg, const std::size_t files, std::list <off_t> &s
         work.statuso.st_atime = std::max(work.statuso.st_ctime, (time_t) time_rng(gen));
         work.statuso.st_mtime = std::max(work.statuso.st_ctime, (time_t) time_rng(gen));
 
-        work.pinode  = rng(gen);
-        work.xattrs  = rng(gen);
-        work.crtime  = rng(gen);
-        work.ossint1 = rng(gen);
-        work.ossint2 = rng(gen);
-        work.ossint3 = rng(gen);
-        work.ossint4 = rng(gen);
+        work.pinode     = rng(gen);
+        work.xattrs_len = 0;
+        work.crtime     = rng(gen);
+        work.ossint1    = rng(gen);
+        work.ossint2    = rng(gen);
+        work.ossint3    = rng(gen);
+        work.ossint4    = rng(gen);
 
         // add this data to the summary
         sumit(&summary, &work);
@@ -548,7 +549,8 @@ void generatecurr(ThreadArgs *arg, const std::size_t files, std::list <off_t> &s
     SNPRINTF(work.name, MAXPATH, "%s", arg->path.c_str());
     SNPRINTF(work.type, 2, "d");
     work.linkname[0] = '\0';
-    SNPRINTF(work.xattr, MAXPATH, "xattr");
+    SNPRINTF(work.xattrs, MAXXATTR, "xattr.key\x1fxattr.value\x00");
+    work.xattrs_len = strlen(work.xattrs);
     SNPRINTF(work.osstext1, MAXXATTR, "osstext1");
     SNPRINTF(work.osstext2, MAXXATTR, "osstext2");
 

--- a/contrib/verifytraceintree.cpp
+++ b/contrib/verifytraceintree.cpp
@@ -167,7 +167,7 @@ int check_stanza(struct QPTPool * ctx, const size_t id, void * data, void * args
         char buf[MAXPATH] = {};
         memcpy(buf, sa->line.c_str(), sa->line.size());
         struct work work;
-        linetowork(buf, csa->delim, &work);
+        linetowork(buf, sa->line.size(), csa->delim, &work);
 
         // make sure the permissions are correct
         if (st.st_mode != work.statuso.st_mode) {
@@ -246,7 +246,7 @@ int check_stanza(struct QPTPool * ctx, const size_t id, void * data, void * args
         char buf[MAXPATH] = {};
         memcpy(buf, line.c_str(), line.size());
         struct work work;
-        linetowork(buf, csa->delim, &work);
+        linetowork(buf, line.size(), csa->delim, &work);
 
         // extract the basename from the entry name
         char * bufbase = basename(work.name);

--- a/include/bf.h
+++ b/include/bf.h
@@ -274,8 +274,8 @@ struct work {
    struct stat   statuso;
    long long int pinode;
    long long int offset;
-   int           xattrs;
-   char          xattr[MAXXATTR];
+   ssize_t       xattrs_len;
+   char          xattrs[MAXXATTR];
    void*         freeme;
    int           crtime;
    int           ossint1;

--- a/include/trace.h
+++ b/include/trace.h
@@ -80,7 +80,7 @@ int worktofile(FILE * file, char * delim, struct work * work);
 int filetowork(FILE * file, char * delim, struct work * work);
 
 // convert a formatted string to a work struct
-int linetowork(char * line, char * delim, struct work * work);
+int linetowork(char * line, const size_t len, char * delim, struct work * work);
 
 #ifdef __cplusplus
 }

--- a/include/utils.h
+++ b/include/utils.h
@@ -112,7 +112,8 @@ extern struct sum sumout;
 
 int printits(struct work *pwork,int ptid);
 
-int pullxattrs( const char *name, char *bufx);
+ssize_t pullxattrs(const char *filename, char *xattrs, const size_t xattrs_buf_size);
+const char *get_xattr_value(const char *xattrs, const size_t xattr_len, const char *key, const size_t key_len);
 
 int zeroit(struct sum *summary);
 

--- a/src/bfmi.c
+++ b/src/bfmi.c
@@ -208,13 +208,9 @@ int processdir(struct QPTPool * ctx, const size_t id, void * data, void * args)
         SNPRINTF(ltchar,128,"%s",lrow[12]); qwork.statuso.st_nlink = atol(ltchar);
         SNPRINTF(ltchar,128,"%s",lrow[13]); qwork.statuso.st_ino = atoll(ltchar);
         memset(qwork.linkname, 0, sizeof(qwork.linkname)); /* dont have linkname yet */
-        memset(qwork.xattr, 0, sizeof(qwork.xattr));
+        memset(qwork.xattrs, 0, sizeof(qwork.xattrs));
         /* need to get xattre right here */
-        qwork.xattrs=0;
-        qwork.xattrs=strlen(qwork.xattr);
-        if (qwork.xattrs > 0) {
-          qwork.xattrs = 1;
-        }
+        qwork.xattrs_len=0;
         qwork.pinode=passmywork->statuso.st_ino;
         if (!strncmp(qwork.type,"d",1)) {
             if (strcmp(qwork.name, ".") == 0 || strcmp(qwork.name, "..") == 0)
@@ -321,7 +317,7 @@ int processinit(struct QPTPool * ctx) {
      mywork->statuso.st_blksize= 4096;
      mywork->statuso.st_blocks= 1;
      mywork->pinode = 0;
-     memset(mywork->xattr, 0, sizeof(mywork->xattr));
+     memset(mywork->xattrs, 0, sizeof(mywork->xattrs));
      memset(mywork->linkname, 0, sizeof(mywork->linkname));
      //printf("name %s pinodec %s\n",mywork->name,mywork->pinodec);
 

--- a/src/bfti.c
+++ b/src/bfti.c
@@ -117,6 +117,7 @@ static int processdir(struct QPTPool * ctx, const size_t id, void * data, void *
 
     SNPRINTF(passmywork->type,2,"%s","d");
     if (in.printing || in.printdir) {
+      passmywork->xattrs_len = 0;
       printits(passmywork,id);
     }
 

--- a/src/bfwreaddirplus2db.c
+++ b/src/bfwreaddirplus2db.c
@@ -172,12 +172,12 @@ int reprocessdir(void * passv, DIR *dir)
     //printf(" in reprocessdir rebuilding gufi for %s\n",passmywork->name);
 
     /* need to fill this in for the directory as we dont need to do this unless we are making a new gufi db */
-    bzero(passmywork->xattr,sizeof(passmywork->xattr));
+    passmywork->xattrs_len = 0;
+    bzero(passmywork->xattrs,sizeof(passmywork->xattrs));
     bzero(passmywork->linkname,sizeof(passmywork->linkname));
     SNPRINTF(passmywork->type,2,"d");
     if (in.doxattrs > 0) {
-       passmywork->xattrs=0;
-       passmywork->xattrs=pullxattrs(passmywork->name,passmywork->xattr);
+      passmywork->xattrs_len = pullxattrs(passmywork->name,passmywork->xattrs, sizeof(passmywork->xattrs));
     }
 
 
@@ -235,9 +235,9 @@ int reprocessdir(void * passv, DIR *dir)
         //   continue;
         SNPRINTF(qwork.name,MAXPATH,"%s/%s", passmywork->name, entry->d_name);
         lstat(qwork.name, &qwork.statuso);
-        qwork.xattrs=0;
+        /* qwork.xattrs_len = 0; */
         if (in.doxattrs > 0) {
-          qwork.xattrs=pullxattrs(qwork.name,qwork.xattr);
+          qwork.xattrs_len = pullxattrs(qwork.name,qwork.xattrs, sizeof(qwork.xattrs));
         }
         if (S_ISDIR(qwork.statuso.st_mode) ) {
             // this is how the parent gets passed on

--- a/src/dfw.c
+++ b/src/dfw.c
@@ -112,7 +112,7 @@ void listdir(const char *name, long long int level, struct dirent *entry, long l
     bzero(xattr, sizeof(xattr));
     xattrs=0;
     if (xattrit) {
-      xattrs=pullxattrs(name,xattr);
+      xattrs=pullxattrs(name,xattr,sizeof(xattr));
     }
     if (statit+xattrit > 0) {
       bzero(lpath,sizeof(lpath));
@@ -167,7 +167,7 @@ void listdir(const char *name, long long int level, struct dirent *entry, long l
        xattrs=0;
        bzero(xattr, sizeof(xattr));
        if (xattrit) {
-         xattrs=pullxattrs(path,xattr);
+         xattrs=pullxattrs(path,xattr,sizeof(xattr));
        }
         //if (entry->d_type == DT_DIR) {
         if (S_ISDIR(st.st_mode) ) {

--- a/src/gufi_dir2index.c
+++ b/src/gufi_dir2index.c
@@ -194,10 +194,9 @@ int processdir(struct QPTPool * ctx, const size_t id, void * data, void * args) 
             continue;
         }
 
-        e.xattrs=0;
+        /* e.xattrs_len = 0; */
         if (in.doxattrs > 0) {
-            memset(e.xattr, 0, sizeof(e.xattr));
-            e.xattrs = pullxattrs(e.name, e.xattr);
+            e.xattrs_len = pullxattrs(e.name, e.xattrs, sizeof(e.xattrs));
         }
 
         // push subdirectories onto the queue
@@ -401,7 +400,7 @@ struct work * validate_inputs() {
     }
 
     if (in.doxattrs > 0) {
-        root->xattrs = pullxattrs(in.name, root->xattr);
+        root->xattrs_len = pullxattrs(in.name, root->xattrs, sizeof(root->xattrs));
     }
 
     root->level = 0;

--- a/src/gufi_dir2trace.c
+++ b/src/gufi_dir2trace.c
@@ -163,9 +163,9 @@ int processdir(struct QPTPool * ctx, const size_t id, void * data, void * args) 
             continue;
         }
 
-        e.xattrs=0;
+        e.xattrs_len = 0;
         if (in.doxattrs > 0) {
-            e.xattrs = pullxattrs(fullpath, e.xattr);
+            e.xattrs_len = pullxattrs(e.name, e.xattrs, sizeof(e.xattrs));
         }
 
         /* push subdirectories onto the queue */
@@ -275,7 +275,7 @@ struct work * validate_inputs() {
     }
 
     if (in.doxattrs > 0) {
-        root->xattrs = pullxattrs(in.name, root->xattr);
+        root->xattrs_len = pullxattrs(in.name, root->xattrs, sizeof(root->xattrs));
     }
 
     return root;

--- a/src/gufi_trace2index.c
+++ b/src/gufi_trace2index.c
@@ -213,7 +213,7 @@ int processdir(struct QPTPool * ctx, const size_t id, void * data, void * args) 
 
     /* parse the directory data */
     debug_start(dir_linetowork);
-    linetowork(w->line, in.delim, &dir);
+    linetowork(w->line, w->len, in.delim, &dir);
     debug_end(dir_linetowork);
 
     /* create the directory */
@@ -305,7 +305,7 @@ int processdir(struct QPTPool * ctx, const size_t id, void * data, void * args) 
             debug_end(memset_row);
 
             debug_start(entry_linetowork);
-            linetowork(line, in.delim, &row);
+            linetowork(line, len, in.delim, &row);
             debug_end(entry_linetowork)
 
             debug_start(free_call);


### PR DESCRIPTION
key-value pairs are stored as arrays of pairs delimited by \x1f:
```<key>\x1f<value>\x00<key>\x1f<value>\x00```...

```struct work``` ```xattrs``` has been replaced by ```xattrs_len```, and ```xattr``` has been renamed ```xattrs```.
Added ```get_xattr_value``` function to extract value from ```struct work``` ```xattrs```, given a key.