### PR TITLE
Reduce struct OutputBuffers contention

### DIFF
--- a/include/OutputBuffers.h
+++ b/include/OutputBuffers.h
@@ -80,25 +80,31 @@ extern "C" {
 */
 
 /* Single Buffer */
+/* Should only be used by a single thread at a time */
 struct OutputBuffer {
-    char * buf;
+    void * buf;
     size_t capacity;
     size_t filled;
-    size_t count;     /* GUFI specific; counter for number of rows that were buffered here */
+    size_t count;     /* GUFI specific; counter for number of rows that were buffered here; these are not reset after flushes */
 };
 
-size_t OutputBuffer_flush(pthread_mutex_t * print_mutex, struct OutputBuffer * obuf, FILE * out);
+/* returns how much was written; should be either 0 or size */
+size_t OutputBuffer_write(struct OutputBuffer * obuf, const void * buf, const size_t size, const int increment_count);
+
+/* returns how much was flushed (output from fwrite; no fflush) */
+size_t OutputBuffer_flush(struct OutputBuffer * obuf, FILE * out);
 
 /* Buffers for all threads */
 struct OutputBuffers {
+    pthread_mutex_t *mutex;
+    size_t count;
     struct OutputBuffer * buffers;
-    pthread_mutex_t mutex;
 };
 
-struct OutputBuffers * OutputBuffers_init(struct OutputBuffers * obufs, const size_t count, const size_t capacity);
-size_t OutputBuffers_flush_single(struct OutputBuffers * obufs, const size_t count, FILE * out);
-size_t OutputBuffers_flush_multiple(struct OutputBuffers * obufs, const size_t count, FILE ** out);
-void OutputBuffers_destroy(struct OutputBuffers * obufs, const size_t count);
+struct OutputBuffers * OutputBuffers_init(struct OutputBuffers * obufs, const size_t count, const size_t capacity, pthread_mutex_t *global_mutex);
+size_t OutputBuffers_flush_to_single(struct OutputBuffers * obufs, FILE * out);
+size_t OutputBuffers_flush_to_multiple(struct OutputBuffers * obufs, FILE ** out);
+void OutputBuffers_destroy(struct OutputBuffers * obufs);
 
 #ifdef __cplusplus
 }

--- a/src/debug.c
+++ b/src/debug.c
@@ -89,7 +89,9 @@ int print_timer(struct OutputBuffers * obufs, const size_t id, char * str, const
     if (len <= capacity) {
         /* if there's not enough space in the buffer to fit the new row, flush it first */
         if ((obufs->buffers[id].filled + len) > capacity) {
-            OutputBuffer_flush(&obufs->mutex, &obufs->buffers[id], stderr);
+            pthread_mutex_lock(obufs->mutex);
+            OutputBuffer_flush(&obufs->buffers[id], stderr);
+            pthread_mutex_unlock(obufs->mutex);
         }
 
         char * buf = obufs->buffers[id].buf;

--- a/src/gufi_query.c
+++ b/src/gufi_query.c
@@ -1088,9 +1088,9 @@ int main(int argc, char *argv[])
 
     /* clear out buffered data */
     #if defined(DEBUG) && defined(CUMULATIVE_TIMES) || BENCHMARK
-    const size_t rows = 0;
-    for(size_t i = 0; i < args.outbuf_buffers->count; i++) {
-        rows += args.outputbuffers->buffers[i].count;
+    size_t rows = 0;
+    for(size_t i = 0; i < args.output_buffers.count; i++) {
+        rows += args.output_buffers.buffers[i].count;
     }
     #endif
     OutputBuffers_flush_to_multiple(&args.output_buffers, gts.outfd);

--- a/test/googletest/CMakeLists.txt
+++ b/test/googletest/CMakeLists.txt
@@ -67,7 +67,7 @@ include(CheckLanguage)
 
 if (CMAKE_CXX_COMPILER)
   include_directories( ${DEP_INSTALL_PREFIX}/googletest/include)
-  add_executable(googletests bf.cpp QueuePerThreadPool.cpp sll.cpp trace.cpp utils.cpp)
+  add_executable(googletests bf.cpp OutputBuffers.cpp QueuePerThreadPool.cpp sll.cpp trace.cpp utils.cpp)
   target_link_libraries(googletests -L${DEP_INSTALL_PREFIX}/googletest/lib -L${DEP_INSTALL_PREFIX}/googletest/lib64 gtest gtest_main ${COMMON_LIBRARIES})
 
   add_test(NAME googletests COMMAND googletests)

--- a/test/googletest/OutputBuffers.cpp
+++ b/test/googletest/OutputBuffers.cpp
@@ -1,0 +1,187 @@
+/*
+This file is part of GUFI, which is part of MarFS, which is released
+under the BSD license.
+
+
+Copyright (c) 2017, Los Alamos National Security (LANS), LLC
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation and/or
+other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors
+may be used to endorse or promote products derived from this software without
+specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+From Los Alamos National Security, LLC:
+LA-CC-15-039
+
+Copyright (c) 2017, Los Alamos National Security, LLC All rights reserved.
+Copyright 2017. Los Alamos National Security, LLC. This software was produced
+under U.S. Government contract DE-AC52-06NA25396 for Los Alamos National
+Laboratory (LANL), which is operated by Los Alamos National Security, LLC for
+the U.S. Department of Energy. The U.S. Government has rights to use,
+reproduce, and distribute this software.  NEITHER THE GOVERNMENT NOR LOS
+ALAMOS NATIONAL SECURITY, LLC MAKES ANY WARRANTY, EXPRESS OR IMPLIED, OR
+ASSUMES ANY LIABILITY FOR THE USE OF THIS SOFTWARE.  If software is
+modified to produce derivative works, such modified software should be
+clearly marked, so as not to confuse it with the version available from
+LANL.
+
+THIS SOFTWARE IS PROVIDED BY LOS ALAMOS NATIONAL SECURITY, LLC AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL LOS ALAMOS NATIONAL SECURITY, LLC OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+OF SUCH DAMAGE.
+*/
+
+
+
+#include <gtest/gtest.h>
+
+
+#include "OutputBuffers.h"
+
+
+extern "C" {
+    struct OutputBuffer * OutputBuffer_init(struct OutputBuffer * obuf, const size_t capacity);
+    void OutputBuffer_destroy(struct OutputBuffer * obuf);
+}
+
+const char STR[] = "string";
+const std::size_t LEN = strlen(STR); // includes the null terminator
+
+TEST(OutputBuffer, use) {
+
+    struct OutputBuffer obuf;
+    ASSERT_EQ(OutputBuffer_init(&obuf, LEN), &obuf);
+    EXPECT_EQ(obuf.capacity, LEN);
+    EXPECT_EQ(obuf.filled, (std::size_t) 0);
+    EXPECT_EQ(obuf.count, (std::size_t) 0);
+
+    // fill up all but one octet of buffer
+    EXPECT_EQ(OutputBuffer_write(&obuf, STR, LEN, 1), LEN);
+    EXPECT_EQ(obuf.filled, LEN);
+    EXPECT_EQ(obuf.count, (std::size_t) 1);
+
+    // attempt to overflow buffer
+    EXPECT_EQ(OutputBuffer_write(&obuf, STR, LEN, 1), (std::size_t) 0);
+    EXPECT_EQ(obuf.filled, LEN);
+    EXPECT_EQ(obuf.count, (std::size_t) 1);
+
+    // flush buffer to a file
+    char buf[4096];
+    FILE * file = fmemopen(buf, sizeof(buf), "w");
+    ASSERT_NE(file, nullptr);
+
+    EXPECT_EQ(OutputBuffer_flush(&obuf, file), LEN);
+    EXPECT_EQ(obuf.capacity, LEN);
+    EXPECT_EQ(obuf.filled, (std::size_t) 0);
+
+    fclose(file);
+
+    // write more to the buffer (start of buffer)
+    EXPECT_EQ(OutputBuffer_write(&obuf, STR, LEN, 1), LEN);
+    EXPECT_EQ(obuf.filled, LEN);
+    EXPECT_EQ(obuf.count, (std::size_t) 2);
+
+    // one copy in the file
+    EXPECT_STREQ(buf, STR);
+
+    // one copy in the buffer
+    EXPECT_STREQ((char *) obuf.buf, STR);
+
+    EXPECT_NO_THROW(OutputBuffer_destroy(&obuf));
+}
+
+TEST(OutputBuffers, usse) {
+    pthread_mutex_t mutex;
+    ASSERT_EQ(pthread_mutex_init(&mutex, nullptr), 0);
+
+    const std::size_t buffer_count = 2;
+    struct OutputBuffers obufs;
+    ASSERT_EQ(OutputBuffers_init(&obufs, buffer_count, LEN, &mutex), &obufs);
+    EXPECT_EQ(obufs.mutex, &mutex);
+    ASSERT_NE(obufs.buffers, nullptr);
+
+    for(std::size_t i = 0; i < buffer_count; i++) {
+        struct OutputBuffer & obuf = obufs.buffers[i];
+        EXPECT_EQ(obuf.capacity, LEN);
+        EXPECT_EQ(obuf.filled, (std::size_t) 0);
+        EXPECT_EQ(obuf.count, (std::size_t) 0);
+    }
+
+    // flush buffers to a file
+    {
+        ASSERT_EQ(OutputBuffer_write(&obufs.buffers[0], STR, LEN, 0), LEN);
+        ASSERT_EQ(OutputBuffer_write(&obufs.buffers[1], STR, LEN, 0), LEN);
+
+        char buf[4096];
+        FILE * file = fmemopen(buf, sizeof(buf), "w");
+        ASSERT_NE(file, nullptr);
+
+        EXPECT_EQ(OutputBuffers_flush_to_single(&obufs, file), LEN + LEN);
+        fclose(file);
+
+        char two_strs[4096];
+        snprintf(two_strs, 4096, "%s%s", STR, STR);
+        EXPECT_STREQ(buf, two_strs);
+    }
+
+    // flush buffers to multiple files
+    {
+        ASSERT_EQ(OutputBuffer_write(&obufs.buffers[0], STR, LEN, 0), LEN);
+        ASSERT_EQ(OutputBuffer_write(&obufs.buffers[1], STR, LEN, 0), LEN);
+
+        char buf1[4096];
+        FILE * file1 = fmemopen(buf1, sizeof(buf1), "w");
+        ASSERT_NE(file1, nullptr);
+
+        // flush buffer to a file
+        char buf2[4096];
+        FILE * file2 = fmemopen(buf2, sizeof(buf2), "w");
+        ASSERT_NE(file2, nullptr);
+
+        FILE *files[] = {file1, file2};
+
+        EXPECT_EQ(OutputBuffers_flush_to_multiple(&obufs, files), LEN + LEN);
+
+        fclose(file2);
+        fclose(file1);
+
+        EXPECT_STREQ(buf1, STR);
+        EXPECT_STREQ(buf2, STR);
+    }
+
+    // check if mutex is still valid
+    EXPECT_EQ(pthread_mutex_lock(&mutex), 0);
+    EXPECT_EQ(pthread_mutex_unlock(&mutex), 0);
+
+    EXPECT_NO_THROW(OutputBuffers_destroy(&obufs));
+    EXPECT_EQ(pthread_mutex_destroy(&mutex), 0);
+}


### PR DESCRIPTION
A global mutex for a `struct OutputBuffers` creates contention between threads writing to their own `struct OutputBuffer`, so `struct OutputBuffer` was given a mutex. However, if no output file prefix is provided, all of the `struct OutputBuffer`s will write to the same file (`stdout`), which is a race condition. A global mutex is created if no output file prefix is provided to prevent this.

<del>`gufi_dir2trace` still has the race condition
    - writes are done directly to the output file, not `OutputBuffers` - need to change
    - simply using mutexes requires wrapping the entire loop of processdir, which causes too much contention
    - See #54 and #55 
</del>
`OutputBuffer` and `OutputBuffers` api rework
    - `OutputBuffer_flush` no longer locks since it does not care who else is accessing the file
    - Added `OutputBuffer_write` to do `memcpy`s like in `gufi_query`
    - `OutputBuffers_*` after `init` do not take in the size any more - it is stored in the struct

Added `OutputBuffer` and `OutputBuffers` tests