### PR TITLE
gufi_dir2trace prefix argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ make install
 # create a GUFI Index
 gufi_dir2index <src_dir> <index_dir>
 -or-
-gufi_dir2trace -o <trace_file_prefix> <src_dir>
+gufi_dir2trace <src_dir> <trace_file_prefix>
 cat <trace_file_prefix>.* > <trace_file>
 gufi_trace2index <trace_file> <index_dir>
 

--- a/src/gufi_dir2index.c
+++ b/src/gufi_dir2index.c
@@ -305,10 +305,9 @@ struct work * validate_inputs() {
     }
 
     // check if the source directory can be accessed
-    static mode_t PERMS = R_OK | X_OK;
-    if ((root->statuso.st_mode & PERMS) != PERMS) {
+    if (access(root->name, R_OK | X_OK) != 0) {
         fprintf(stderr, "couldn't access input dir '%s': %s\n",
-                in.name, strerror(errno));
+                root->name, strerror(errno));
         free(root);
         return NULL;
     }

--- a/src/gufi_dir2trace.c
+++ b/src/gufi_dir2trace.c
@@ -202,8 +202,6 @@ int processdir(struct QPTPool * ctx, const size_t id, void * data, void * args) 
             SNPRINTF(e.name, MAXPATH, "%s/%s", work_name + in.name_len, entry->d_name);
         }
 
-        fprintf(stderr, "%s\n", e.name);
-
         worktofile(gts.outfd[id], in.delim, &e);
     }
 
@@ -283,12 +281,13 @@ struct work * validate_inputs() {
 }
 
 void sub_help() {
-    printf("input_dir         walk this tree to produce trace file\n");
+    printf("input_dir            walk this tree to produce trace file\n");
+    printf("output_prefix        prefix of output files (<prefix>.<tid>)\n");
     printf("\n");
 }
 
 int main(int argc, char * argv[]) {
-    int idx = parse_cmd_line(argc, argv, "hHn:xd:o:", 1, "input_dir", &in);
+    int idx = parse_cmd_line(argc, argv, "hHn:xd:", 1, "input_dir output_prefix", &in);
     if (in.helped)
         sub_help();
     if (idx < 0)
@@ -297,12 +296,14 @@ int main(int argc, char * argv[]) {
         /* parse positional args, following the options */
         int retval = 0;
         INSTALL_STR(in.name,     argv[idx++], MAXPATH, "input_dir");
+        INSTALL_STR(in.outfilen, argv[idx++], MAXPATH, "output_prefix");
 
         if (retval)
             return retval;
 
         /* add 1 more for the separator that is placed between this string and the entry */
         in.name_len = strlen(in.name) + 1;
+        in.outfile = 1;
     }
 
     /* get first work item by validating inputs */

--- a/src/gufi_dir2trace.c
+++ b/src/gufi_dir2trace.c
@@ -238,10 +238,9 @@ struct work * validate_inputs() {
     }
 
     /* check if the source directory can be accessed */
-    static mode_t PERMS = R_OK | X_OK;
-    if ((root->statuso.st_mode & PERMS) != PERMS) {
+    if (access(root->name, R_OK | X_OK) != 0) {
         fprintf(stderr, "couldn't access input dir '%s': %s\n",
-                in.name, strerror(errno));
+                root->name, strerror(errno));
         free(root);
         return NULL;
     }

--- a/test/runbfwi
+++ b/test/runbfwi
@@ -144,18 +144,8 @@ fi
 
 
 
-# run bfwi and send output to screen
-echo
-echo "out to screen"
-
 echo $CLEAN_GUFI
 $CLEAN_GUFI
-
-echo $DIR2TRACE -n 2 -x $SOURCE
-$DIR2TRACE -n 2 -x $SOURCE
-
-
-
 
 # run to output files testout.*
 echo
@@ -165,8 +155,8 @@ echo $CLEAN_GUFI
 $CLEAN_GUFI
 rm -f testout*
 
-echo $DIR2TRACE -n 2 -x -o testout $SOURCE
-$DIR2TRACE -n 2 -x -o testout $SOURCE
+echo $DIR2TRACE -n 2 -x $SOURCE testout
+$DIR2TRACE -n 2 -x $SOURCE testout
 
 ls -l testout*
 for F in testout*; do echo; echo $F; cat $F; done


### PR DESCRIPTION
Now, instead of calling `gufi_dir2trace -o <prefix> <src>`, call `gufi_dir2trace <src> <prefix>`.