### PR TITLE
small change so folks can test gufi without needing a config at /etc

### DIFF
--- a/docs/latex/sections/deploy.tex
+++ b/docs/latex/sections/deploy.tex
@@ -92,16 +92,16 @@ extract useful information (see the user guide for more details). The
 server has the actual implementation of the wrappers while the clients
 have command forwarders.
 
-These wrappers require configuration files located at
-\guficonfigfile (with read permissions for all GUFI users)
-to function. These configuration files are simple text files
-containing lines of \texttt{<key>=<value>}. Duplicate configuration
-keys are overwritten by the bottom-most line. Empty lines and lines
-starting with \# are ignored. The server and client require different
+These wrappers require a valid GUFI configuration file to function correctly.
+By default, they assume this file is available (with read permissions for all
+GUFI users) at \guficonfigfile; alernatively, different paths can be specified
+via a \texttt{GUFI_CONFIG} environment variable. These configuration files are
+simple text files containing lines of \texttt{<key>=<value>}.  Duplicate
+configuration keys are overwritten by the bottom-most line. Empty lines and
+lines starting with \# are ignored. The server and client require different
 configuration values. Example configuration files can be found in the
 \texttt{config} directory of the GUFI source, as well as in the build
-directory. The corresponding examples will also be installed with
-GUFI.
+directory. The corresponding examples will also be installed with GUFI.
 
 If a server and client exist on the same node, the server and client
 configuration file may be combined into one file.

--- a/docs/latex/sections/deploy.tex
+++ b/docs/latex/sections/deploy.tex
@@ -95,7 +95,7 @@ have command forwarders.
 These wrappers require a valid GUFI configuration file to function correctly.
 By default, they assume this file is available (with read permissions for all
 GUFI users) at \guficonfigfile; alernatively, different paths can be specified
-via a \texttt{GUFI_CONFIG} environment variable. These configuration files are
+via a \texttt{GUFI\_CONFIG} environment variable. These configuration files are
 simple text files containing lines of \texttt{<key>=<value>}.  Duplicate
 configuration keys are overwritten by the bottom-most line. Empty lines and
 lines starting with \# are ignored. The server and client require different

--- a/docs/latex/sections/user_env.tex
+++ b/docs/latex/sections/user_env.tex
@@ -71,4 +71,4 @@ all GUFI users called \guficonfigfile. This file specifies where the
 GUFI server is, as the actual GUFI trees are not expected to be
 locally available. For experimental GUFI installations such as testing
 and developing, alternative paths to the GUFI configuration file can
-be specified via a \texttt{GUFI_CONFIG} environment variable.
+be specified via a \texttt{GUFI\_CONFIG} environment variable.

--- a/docs/latex/sections/user_env.tex
+++ b/docs/latex/sections/user_env.tex
@@ -69,4 +69,6 @@ that access the actual implementations of these files.
 There should be a file readable (but not necessarily modifiable) by
 all GUFI users called \guficonfigfile. This file specifies where the
 GUFI server is, as the actual GUFI trees are not expected to be
-locally available.
+locally available. For experimental GUFI installations such as testing
+and developing, alternative paths to the GUFI configuration file can
+be specified via a \texttt{GUFI_CONFIG} environment variable.

--- a/scripts/gufi_config.py
+++ b/scripts/gufi_config.py
@@ -72,11 +72,10 @@ DEFAULT_PATH = '/etc/GUFI/config'
 
 # helper function to allow configurable paths to the gufi config file
 def config_path():
-  global DEFAULT_PATH
-  gufi_env_config='GUFI_CONFIG'
-  if gufi_env_config in os.environ:
-    DEFAULT_PATH = os.environ[gufi_env_config]
-  return DEFAULT_PATH
+  try:
+    return os.environ['GUFI_CONFIG']
+  except KeyError:
+    return DEFAULT_PATH
 
 class Config(object): # pylint: disable=too-few-public-methods,useless-object-inheritance
     def __init__(self, settings, config_reference=DEFAULT_PATH):

--- a/scripts/gufi_config.py
+++ b/scripts/gufi_config.py
@@ -72,9 +72,10 @@ DEFAULT_PATH = '/etc/GUFI/config'
 
 # helper function to allow configurable paths to the gufi config file
 def config_path():
-  try:
-    return os.environ['GUFI_CONFIG']
-  except KeyError:
+  gufi_config_env = 'GUFI_CONFIG'
+  if gufi_config_env in os.environ:
+    return os.environ[gufi_config_env]
+  else:
     return DEFAULT_PATH
 
 class Config(object): # pylint: disable=too-few-public-methods,useless-object-inheritance

--- a/scripts/gufi_config.py
+++ b/scripts/gufi_config.py
@@ -67,8 +67,12 @@ import sys
 
 import gufi_common
 
-# default configuration file location
-DEFAULT_PATH = '/etc/GUFI/config'
+# configuration file location
+gufi_env_config='GUFI_CONFIG'
+if gufi_env_config in os.environ:
+  DEFAULT_PATH = os.environ[gufi_env_config]
+else:
+  DEFAULT_PATH = '/etc/GUFI/config'
 
 class Config(object): # pylint: disable=too-few-public-methods,useless-object-inheritance
     def __init__(self, settings, config_reference=DEFAULT_PATH):

--- a/scripts/gufi_config.py
+++ b/scripts/gufi_config.py
@@ -72,10 +72,10 @@ DEFAULT_PATH = '/etc/GUFI/config'
 
 # helper function to allow configurable paths to the gufi config file
 def config_path():
-  gufi_config_env = 'GUFI_CONFIG'
-  if gufi_config_env in os.environ:
-    return os.environ[gufi_config_env]
-  return DEFAULT_PATH
+    gufi_config_env = 'GUFI_CONFIG'
+    if gufi_config_env in os.environ:
+        return os.environ[gufi_config_env]
+    return DEFAULT_PATH
 
 class Config(object): # pylint: disable=too-few-public-methods,useless-object-inheritance
     def __init__(self, settings, config_reference=DEFAULT_PATH):

--- a/scripts/gufi_config.py
+++ b/scripts/gufi_config.py
@@ -75,8 +75,7 @@ def config_path():
   gufi_config_env = 'GUFI_CONFIG'
   if gufi_config_env in os.environ:
     return os.environ[gufi_config_env]
-  else:
-    return DEFAULT_PATH
+  return DEFAULT_PATH
 
 class Config(object): # pylint: disable=too-few-public-methods,useless-object-inheritance
     def __init__(self, settings, config_reference=DEFAULT_PATH):

--- a/scripts/gufi_config.py
+++ b/scripts/gufi_config.py
@@ -68,11 +68,16 @@ import sys
 import gufi_common
 
 # configuration file location
-gufi_env_config='GUFI_CONFIG'
-if gufi_env_config in os.environ:
-  DEFAULT_PATH = os.environ[gufi_env_config]
-else:
-  DEFAULT_PATH = '/etc/GUFI/config'
+DEFAULT_PATH = '/etc/GUFI/config'
+
+# helper function to allow configurable paths to the gufi config file
+def config_path():
+  global DEFAULT_PATH
+  gufi_env_config='GUFI_CONFIG'
+  if gufi_env_config in os.environ:
+    DEFAULT_PATH = os.environ[gufi_env_config]
+  return DEFAULT_PATH
+
 
 class Config(object): # pylint: disable=too-few-public-methods,useless-object-inheritance
     def __init__(self, settings, config_reference=DEFAULT_PATH):

--- a/scripts/gufi_config.py
+++ b/scripts/gufi_config.py
@@ -78,7 +78,6 @@ def config_path():
     DEFAULT_PATH = os.environ[gufi_env_config]
   return DEFAULT_PATH
 
-
 class Config(object): # pylint: disable=too-few-public-methods,useless-object-inheritance
     def __init__(self, settings, config_reference=DEFAULT_PATH):
         # path string
@@ -120,7 +119,6 @@ class Config(object): # pylint: disable=too-few-public-methods,useless-object-in
                     out[key] = settings[key](value)
                 else:
                     out[key] = value
-
 
         for key in settings:
             if key not in out:

--- a/scripts/gufi_find
+++ b/scripts/gufi_find
@@ -906,4 +906,4 @@ def run(argv, config_path):
     return query.returncode
 
 if __name__ == '__main__':
-    sys.exit(run(sys.argv, gufi_config.DEFAULT_PATH))
+    sys.exit(run(sys.argv, gufi_config.config_path()))

--- a/scripts/gufi_getfattr
+++ b/scripts/gufi_getfattr
@@ -239,4 +239,4 @@ def run(argv, config_path):
     return rc
 
 if __name__ == '__main__':
-    sys.exit(run(sys.argv, gufi_config.DEFAULT_PATH))
+    sys.exit(run(sys.argv, gufi_config.config_path()))

--- a/scripts/gufi_ls
+++ b/scripts/gufi_ls
@@ -405,4 +405,4 @@ def run(argv, config_path):
     return rc
 
 if __name__ == '__main__':
-    sys.exit(run(sys.argv, gufi_config.DEFAULT_PATH))
+    sys.exit(run(sys.argv, gufi_config.config_path()))

--- a/scripts/gufi_stat
+++ b/scripts/gufi_stat
@@ -139,4 +139,4 @@ def run(argv, config_path):
     return stat.returncode
 
 if __name__ == '__main__':
-    sys.exit(run(sys.argv, gufi_config.DEFAULT_PATH))
+    sys.exit(run(sys.argv, gufi_config.config_path()))

--- a/scripts/gufi_stats
+++ b/scripts/gufi_stats
@@ -1182,4 +1182,4 @@ def run(argv, config_path):
     return query.returncode
 
 if __name__ == '__main__':
-    sys.exit(run(sys.argv, gufi_config.DEFAULT_PATH))
+    sys.exit(run(sys.argv, gufi_config.config_path()))

--- a/test/unit/python/test_gufi_config.py
+++ b/test/unit/python/test_gufi_config.py
@@ -95,6 +95,11 @@ class TestServerConfig(unittest.TestCase):
 
     def setUp(self): # pylint: disable=invalid-name
         self.pairs = copy.deepcopy(TestServerConfig.default)
+        self.original_environ = os.environ.copy() # save this since we change it to test GUFI_CONFIG
+
+    def tearDown(self):
+        os.environ.clear()
+        os.environ.update(self.original_environ)
 
     def check_values(self, config):
         self.assertEqual(TestServerConfig.default[gufi_config.Server.THREADS],
@@ -135,6 +140,16 @@ class TestServerConfig(unittest.TestCase):
 
     def test_bad_outputbuffer(self):
         self.bad_int(gufi_config.Server.OUTPUTBUFFER, ['-1', '', 'abc'])
+
+    # test the ability to change config path with an env var
+    def test_default_path(self):
+        if 'GUFI_CONFIG' in os.environ:
+            del os.environ['GUFI_CONFIG']
+        self.assertEqual(gufi_config.config_path(), gufi_config.DEFAULT_PATH)
+
+    def test_custom_path_from_env(self):
+        os.environ['GUFI_CONFIG'] = '/custom/path'
+        self.assertEqual(gufi_config.config_path(), '/custom/path')
 
 class TestClientConfig(unittest.TestCase):
     default = {


### PR DESCRIPTION
Can use an env var to change the location of gufi config used by tools like gufi_stats. Useful when running without root.