### PR TITLE
Verbose stats and verbose error message

### DIFF
--- a/docs/latex/sections/deploy.tex
+++ b/docs/latex/sections/deploy.tex
@@ -94,7 +94,7 @@ have command forwarders.
 
 These wrappers require a valid GUFI configuration file to function correctly.
 By default, they assume this file is available (with read permissions for all
-GUFI users) at \guficonfigfile; alernatively, different paths can be specified
+GUFI users) at \guficonfigfile; alternatively, different paths can be specified
 via a \texttt{GUFI\_CONFIG} environment variable. These configuration files are
 simple text files containing lines of \texttt{<key>=<value>}.  Duplicate
 configuration keys are overwritten by the bottom-most line. Empty lines and

--- a/scripts/gufi_common.py
+++ b/scripts/gufi_common.py
@@ -65,6 +65,7 @@ import argparse
 import grp
 import pwd
 import re
+import sys
 
 # table names
 SUMMARY     = 'summary'
@@ -257,6 +258,17 @@ def build_query(select, tables, where=None, group_by=None,
 
     return query
 
+# a helper function to show the gufi_query being executed. Helpful for debugging and education.
+def print_query(query_tokens):
+    formatted_string = ""
+    for index, token in enumerate(query_tokens):
+        if token.startswith('-') or index == len(query_tokens)-1:
+            formatted_string += '\n    ' + token
+        else:
+            formatted_string += ' ' + token
+    print('GUFI query is \n  {0}'.format(formatted_string))
+    sys.stdout.flush()
+
 def add_common_flags(parser):
     '''Common GUFI tool flags'''
     parser.add_argument('--delim',
@@ -286,3 +298,7 @@ def add_common_flags(parser):
                         type=str,
                         default=None,
                         help='Name of file containing directory basenames to skip')
+
+    parser.add_argument('--verbose', '-V',
+                        action='store_true',
+                        help='Show the gufi_query being executed')

--- a/scripts/gufi_config.py
+++ b/scripts/gufi_config.py
@@ -82,10 +82,10 @@ class Config(object): # pylint: disable=too-few-public-methods,useless-object-in
         # path string
         if isinstance(config_reference, str):
             with open(config_reference, 'r') as config_file: # pylint: disable=unspecified-encoding
-                self.config = self._read_lines(settings, config_file)
+                self.config = self._read_lines(settings, config_file, config_reference)
         # iterable object containing lines
         elif self._check_iterable(config_reference):
-            self.config = self._read_lines(settings, config_reference)
+            self.config = self._read_lines(settings, config_reference, config_reference)
         else:
             raise TypeError('Cannot convert {0} to a config'.format(type(config_reference)))
 
@@ -98,7 +98,7 @@ class Config(object): # pylint: disable=too-few-public-methods,useless-object-in
         return True
 
     @staticmethod
-    def _read_lines(settings, lines):
+    def _read_lines(settings, lines, path):
         out = {}
         for line in lines:
             line = line.strip()
@@ -121,7 +121,7 @@ class Config(object): # pylint: disable=too-few-public-methods,useless-object-in
 
         for key in settings:
             if key not in out:
-                raise KeyError('Missing Setting {0}'.format(key))
+                raise KeyError('While attempting to parse GUFI config at {0} found missing setting {1}'.format(path, key))
 
         return out
 

--- a/scripts/gufi_find
+++ b/scripts/gufi_find
@@ -139,7 +139,7 @@ def build_aggregation_columns(args):
         for col in [('size', 'INT64'), ('type', 'TEXT')]:
             cols.add(col)
 
-    return list(cols)
+    return sorted(list(cols))
 
 def build_where(args, table, root_uid=0, root_gid=0):
     '''Build the WHERE clause'''
@@ -488,6 +488,7 @@ def help(parser): # pylint: disable=redefined-builtin
     expr.remove('delim')
     expr.remove('inmemory_name')
     expr.remove('skip')
+    expr.remove('verbose')
 
     # print these separately
     gufi_specific = ['numresults', 'largest', 'smallest']
@@ -895,6 +896,9 @@ def run(argv, config_path):
 
     if args.skip:
         query_cmd += ['-k', args.skip]
+
+    if args.verbose:
+        gufi_common.print_query(query_cmd + paths)
 
     if args.fprint:
         with open(args.fprint, 'wb') as out:

--- a/scripts/gufi_getfattr
+++ b/scripts/gufi_getfattr
@@ -230,6 +230,9 @@ def run(argv, config_path):
             '-d', args.delim
         ] + getfattr(args, config, dirname, nondir)
 
+        if args.verbose:
+            gufi_common.print_query(query_cmd)
+
         query = subprocess.Popen(query_cmd) # pylint: disable=consider-using-with
         query.communicate()                 # block until query finishes
 

--- a/scripts/gufi_ls
+++ b/scripts/gufi_ls
@@ -396,6 +396,9 @@ def run(argv, config_path):
         if args.skip:
             query_cmd += ['-k', args.skip]
 
+        if args.verbose:
+            gufi_common.print_query(query_cmd + [fullpath])
+
         query = subprocess.Popen(query_cmd + [fullpath]) # pylint: disable=consider-using-with
         query.communicate()                              # block until query finishes
 

--- a/scripts/gufi_stat
+++ b/scripts/gufi_stat
@@ -66,6 +66,7 @@ import os
 import subprocess
 import sys
 
+import gufi_common
 import gufi_config
 
 # location of this file
@@ -111,6 +112,11 @@ def parse_args():
                         metavar='FILE',
                         nargs='+')
 
+    # the other scripts call gufi_common.add_common_flags but this one doesn't so we have to copy the verbose add_argument stanza here
+    parser.add_argument('--verbose', '-V',
+                        action='store_true',
+                        help='Show the gufi_query being executed')
+
     return parser
 
 # argv[0] should be the command name
@@ -132,6 +138,9 @@ def run(argv, config_path):
 
     paths = [os.path.normpath(os.path.sep.join([config.indexroot(), path]))
              for path in args.paths]
+
+    if args.verbose:
+        gufi_common.print_query(stat_cmd + paths)
 
     stat = subprocess.Popen(stat_cmd + paths)  # pylint: disable=consider-using-with
     stat.communicate()                         # block until stat finishes

--- a/scripts/gufi_stats
+++ b/scripts/gufi_stats
@@ -1186,6 +1186,9 @@ def run(argv, config_path):
     if args.skip:
         query_cmd += ['-k', args.skip]
 
+    if args.verbose:
+        gufi_common.print_query(query_cmd + [args.path])
+
     query = subprocess.Popen(query_cmd + [args.path]) # pylint: disable=consider-using-with
     query.communicate()                               # block until query finishes
 

--- a/test/regression/gufi_find.expected
+++ b/test/regression/gufi_find.expected
@@ -11,7 +11,7 @@ expression may consist of:
     mindepth mmin mtime name newer
     path printf readable regex samefile
     size true type uid user
-    verbose writable
+    writable
 
 GUFI Specific Flags (--):
 

--- a/test/regression/gufi_find.expected
+++ b/test/regression/gufi_find.expected
@@ -11,7 +11,7 @@ expression may consist of:
     mindepth mmin mtime name newer
     path printf readable regex samefile
     size true type uid user
-    writable
+    verbose writable
 
 GUFI Specific Flags (--):
 
@@ -523,6 +523,33 @@ directory/readonly
 directory/executable
 old_file
 
+$ gufi_find --verbose --largest -type f
+GUFI query is
+   gufi_query
+    -n 1
+    -B 4096
+    -a
+    -d
+    -I CREATE TABLE out (name TEXT, size INT64, type TEXT)
+    -S INSERT INTO out SELECT rpath(sname, sroll), size, type FROM vrsummary WHERE ((type == 'f')) ORDER BY size DESC, name ASC
+    -E INSERT INTO out SELECT rpath(sname, sroll) || '/' || name, size, type FROM vrpentries WHERE ((type == 'f')) ORDER BY size DESC, name ASC
+    -J INSERT INTO aggregate SELECT name, size, type FROM out WHERE ((type == 'f')) ORDER BY size DESC, name ASC
+    -K CREATE TABLE aggregate (name TEXT, size INT64, type TEXT)
+    -G SELECT name FROM aggregate WHERE ((type == 'f')) ORDER BY size DESC, name ASC
+    prefix
+1MB
+1KB
+unusual#? directory ,/unusual, name?#
+repeat_name
+leaf_directory/leaf_file2
+leaf_directory/leaf_file1
+.hidden
+directory/subdirectory/repeat_name
+directory/writable
+directory/readonly
+directory/executable
+old_file
+
 $ gufi_find directory leaf_directory
 directory
 directory/executable
@@ -653,7 +680,7 @@ usage: gufi_find [-help] [-maxdepth levels] [-mindepth levels] [--version]
                  [-uid n] [-user uname] [-writable] [-fprint file]
                  [-ls | -printf format] [--numresults n]
                  [--smallest | --largest] [--delim c] [--in-memory-name name]
-                 [--aggregate-name name] [--skip-file filename]
+                 [--aggregate-name name] [--skip-file filename] [--verbose]
 gufi_find: error: argument -atime: abc is not a valid numeric argument
 
 $ gufi_find -unknown-predicate

--- a/test/regression/gufi_find.sh.in
+++ b/test/regression/gufi_find.sh.in
@@ -162,6 +162,9 @@ run_no_sort "${GUFI_FIND} --numresults 5"
 run_no_sort "${GUFI_FIND} --smallest -type f"
 run_no_sort "${GUFI_FIND} --largest  -type f"
 
+# check the verbose flag
+run_no_sort "${GUFI_FIND} --verbose --largest -type f"
+
 # multiple input directories
 run_sort "${GUFI_FIND} ${BASENAME}/directory ${BASENAME}/leaf_directory"
 

--- a/test/regression/gufi_getfattr.expected
+++ b/test/regression/gufi_getfattr.expected
@@ -3,6 +3,7 @@ usage: gufi_getfattr [--help] [--version] [--name NAME] [--dump]
                      [--match PATTERN] [--only-values] [--recursive]
                      [--delim c] [--in-memory-name name]
                      [--aggregate-name name] [--skip-file filename]
+                     [--verbose]
                      path [path ...]
 
 GUFI version of getfattr
@@ -36,9 +37,22 @@ options:
   --aggregate-name name
                         Name of final database when aggregation is performed
   --skip-file filename  Name of file containing directory basenames to skip
+  --verbose, -V         Show the gufi_query being executed
 
 # prefix
 $ gufi_getfattr .
+
+# prefix with --verbose
+$ gufi_getfattr --verbose .
+GUFI query is
+   gufi_query
+    -n 1
+    -B 4096
+    -d
+    -x
+    -a
+    -S SELECT rpath(sname, sroll), xattr_name FROM vrxsummary WHERE ((name REGEXP '^.$')) AND (isroot == 1) AND (xattr_name REGEXP '^user\.')
+    .
 
 # 0 xattrs
 $ gufi_getfattr prefix

--- a/test/regression/gufi_getfattr.sh.in
+++ b/test/regression/gufi_getfattr.sh.in
@@ -72,6 +72,9 @@ do_tests() {
     echo "# ${SEARCH}"
     run_sort "${GUFI_GETFATTR} ."
 
+    echo "# ${SEARCH} with --verbose"
+    run_no_sort "${GUFI_GETFATTR} --verbose ."
+
     # no flags
     echo "# 0 xattrs"
     run_sort "${GUFI_GETFATTR} ${BASENAME}"

--- a/test/regression/gufi_ls.expected
+++ b/test/regression/gufi_ls.expected
@@ -3,7 +3,7 @@ usage: gufi_ls [--help] [--version] [-a] [-A] [--block-size BLOCK_SIZE] [-B]
                [--full-time] [-G] [-h] [-i] [-l] [-r] [-R] [-s] [-S]
                [--time-style {full-iso,iso,locale,long-iso}] [-t] [--delim c]
                [--in-memory-name name] [--aggregate-name name]
-               [--skip-file filename]
+               [--skip-file filename] [--verbose]
                [paths ...]
 
 GUFI version of ls
@@ -38,8 +38,37 @@ options:
   --aggregate-name name
                         Name of final database when aggregation is performed
   --skip-file filename  Name of file containing directory basenames to skip
+  --verbose, -V         Show the gufi_query being executed
 
 $ gufi_ls
+prefix
+
+$ gufi_ls --verbose
+GUFI query is
+   gufi_query
+    -n 1
+    -y 0
+    -z 2
+    -I CREATE TABLE out (fullpath TEXT, name TEXT, type TEXT, inode INT64, nlink INT64, size INT64, mode INT64, uid INT64, gid INT64, blksize INT64, blocks INT64, mtime INT64, atime INT64, ctime INT64, linkname TEXT, xattr_names TEXT, pinode INT64);
+    -S INSERT INTO out SELECT rpath(sname, sroll), basename(name), type, inode, nlink, size, mode, uid, gid, blksize, blocks, mtime, atime, ctime, linkname, xattr_names, pinode FROM vrsummary WHERE (name REGEXP '^(?![\.]).*$') AND (
+    CASE level()
+        WHEN 0 THEN
+            CASE rollupscore
+                WHEN 0 THEN FALSE
+                WHEN 1 THEN (isroot == 0 AND depth == 1)
+            END
+        WHEN 1 THEN
+            (isroot == 1 AND depth == 0)
+    END
+)
+    -E INSERT INTO out SELECT rpath(sname, sroll) || '/' || name, name, type, inode, nlink, size, mode, uid, gid, blksize, blocks, mtime, atime, ctime, linkname, xattr_names, pinode FROM vrpentries WHERE (name REGEXP '^(?![\.]).*$') AND (atroot == 1) AND (level() == 0)
+    -K CREATE TABLE aggregate (fullpath TEXT, name TEXT, type TEXT, inode INT64, nlink INT64, size INT64, mode INT64, uid INT64, gid INT64, blksize INT64, blocks INT64, mtime INT64, atime INT64, ctime INT64, linkname TEXT, xattr_names TEXT, pinode INT64);
+    -J INSERT INTO aggregate SELECT * FROM out
+    -G SELECT name AS display_name FROM aggregate ORDER BY display_name COLLATE NOCASE ASC
+    -a
+    -B 4096
+    -d
+    prefix
 prefix
 
 $ gufi_ls -R
@@ -313,7 +342,7 @@ usage: gufi_ls [--help] [--version] [-a] [-A] [--block-size BLOCK_SIZE] [-B]
                [--full-time] [-G] [-h] [-i] [-l] [-r] [-R] [-s] [-S]
                [--time-style {full-iso,iso,locale,long-iso}] [-t] [--delim c]
                [--in-memory-name name] [--aggregate-name name]
-               [--skip-file filename]
+               [--skip-file filename] [--verbose]
                [paths ...]
 gufi_ls: error: argument --block-size: Invalid --block-size argument: 'YiB'
 
@@ -322,7 +351,7 @@ usage: gufi_ls [--help] [--version] [-a] [-A] [--block-size BLOCK_SIZE] [-B]
                [--full-time] [-G] [-h] [-i] [-l] [-r] [-R] [-s] [-S]
                [--time-style {full-iso,iso,locale,long-iso}] [-t] [--delim c]
                [--in-memory-name name] [--aggregate-name name]
-               [--skip-file filename]
+               [--skip-file filename] [--verbose]
                [paths ...]
 gufi_ls: error: argument --block-size: Invalid --block-size argument: '-'
 
@@ -331,7 +360,7 @@ usage: gufi_ls [--help] [--version] [-a] [-A] [--block-size BLOCK_SIZE] [-B]
                [--full-time] [-G] [-h] [-i] [-l] [-r] [-R] [-s] [-S]
                [--time-style {full-iso,iso,locale,long-iso}] [-t] [--delim c]
                [--in-memory-name name] [--aggregate-name name]
-               [--skip-file filename]
+               [--skip-file filename] [--verbose]
                [paths ...]
 gufi_ls: error: argument --block-size: Invalid --block-size argument: '-1GB'
 
@@ -340,7 +369,7 @@ usage: gufi_ls [--help] [--version] [-a] [-A] [--block-size BLOCK_SIZE] [-B]
                [--full-time] [-G] [-h] [-i] [-l] [-r] [-R] [-s] [-S]
                [--time-style {full-iso,iso,locale,long-iso}] [-t] [--delim c]
                [--in-memory-name name] [--aggregate-name name]
-               [--skip-file filename]
+               [--skip-file filename] [--verbose]
                [paths ...]
 gufi_ls: error: argument --block-size: Invalid --block-size argument: '0GB'
 

--- a/test/regression/gufi_ls.sh.in
+++ b/test/regression/gufi_ls.sh.in
@@ -71,6 +71,7 @@ BACKUP="backup~"
 (
 run_no_sort "${GUFI_LS} --help" | replace_argparse
 run_no_sort "${GUFI_LS}"
+run_no_sort "${GUFI_LS} --verbose"
 run_no_sort "${GUFI_LS} -R" # Issue #49
 run_no_sort "${GUFI_LS} ${BASENAME}"
 run_no_sort "${GUFI_LS} ${BASENAME} -a"

--- a/test/regression/gufi_stat.expected
+++ b/test/regression/gufi_stat.expected
@@ -1,5 +1,6 @@
 $ gufi_stat --help
-usage: gufi_stat [-c FORMAT] [-t] [--help] [--version] FILE [FILE ...]
+usage: gufi_stat [-c FORMAT] [-t] [--help] [--version] [--verbose]
+                 FILE [FILE ...]
 
 GUFI version of stat
 
@@ -13,6 +14,7 @@ options:
   -t, --terse           print the information in terse form
   --help                display this help and exit
   --version             output version information and exit
+  --verbose, -V         Show the gufi_query being executed
 
 # first line of default print
   File: '.hidden'
@@ -43,6 +45,13 @@ repeat_name 13
 unusual#? directory
 
 $ gufi_stat --format '%N %n %a %A %d %D %f %F %m %s %w %W %x %X %y %Y\n' "prefix/.hidden"
+'prefix/.hidden' prefix/.hidden 664 -rw-rw-r-- ? ? 81b4 regular file   9 - 0 1970-01-01 00:00:09 +0000 9 1970-01-01 00:00:09 +0000 9
+
+$ gufi_stat --verbose --format '%N %n %a %A %d %D %f %F %m %s %w %W %x %X %y %Y\n' "prefix/.hidden"
+GUFI query is
+   gufi_stat_bin
+    -f %N %n %a %A %d %D %f %F %m %s %w %W %x %X %y %Y\n
+    prefix/.hidden
 'prefix/.hidden' prefix/.hidden 664 -rw-rw-r-- ? ? 81b4 regular file   9 - 0 1970-01-01 00:00:09 +0000 9 1970-01-01 00:00:09 +0000 9
 
 gufi_stat --terse "prefix/.hidden"

--- a/test/regression/gufi_stat.sh.in
+++ b/test/regression/gufi_stat.sh.in
@@ -102,6 +102,8 @@ echo
 
 run_no_sort "${GUFI_STAT} --format '%N %n %a %A %d %D %f %F %m %s %w %W %x %X %y %Y\n' \"${BASENAME}/${fixed_size[0]}\""
 
+run_no_sort "${GUFI_STAT} --verbose --format '%N %n %a %A %d %D %f %F %m %s %w %W %x %X %y %Y\n' \"${BASENAME}/${fixed_size[0]}\""
+
 echo "${GUFI_STAT} --terse \"${BASENAME}/${fixed_size[0]}\"" | replace
 ${GUFI_STAT} --terse "${BASENAME}/${fixed_size[0]}" | @AWK@ "{ \$3=0; \$5=${TEST_USER_ID}; \$6=${TEST_GROUP_ID}; \$16=0; print }"
 

--- a/test/regression/gufi_stats.expected
+++ b/test/regression/gufi_stats.expected
@@ -2,7 +2,7 @@ $ gufi_stats --help
 usage: gufi_stats [--help] [--version] [--recursive | --cumulative]
                   [--order order] [--num-results n] [--uid u] [--delim c]
                   [--in-memory-name name] [--aggregate-name name]
-                  [--skip-file filename]
+                  [--skip-file filename] [--verbose]
                   {depth,filesize,filecount,linkcount,dircount,leaf-dirs,leaf-depth,leaf-files,leaf-links,extensions,total-filesize,total-filecount,total-linkcount,total-dircount,total-leaf-files,total-leaf-links,files-per-level,links-per-level,dirs-per-level,filesize-log2-bins,filesize-log1024-bins,dirfilecount-log2-bins,dirfilecount-log1024-bins,average-leaf-files,average-leaf-links,average-leaf-size,median-leaf-files,median-leaf-links,median-leaf-size,duplicate-names,uid-size,gid-size}
                   [path]
 GUFI statistics
@@ -34,11 +34,12 @@ options:
   --aggregate-name name
                         Name of final database when aggregation is performed
   --skip-file filename  Name of file containing directory basenames to skip
+  --verbose, -V         Show the gufi_query being executed
 $ gufi_stats -r -c
 usage: gufi_stats [--help] [--version] [--recursive | --cumulative]
                   [--order order] [--num-results n] [--uid u] [--delim c]
                   [--in-memory-name name] [--aggregate-name name]
-                  [--skip-file filename]
+                  [--skip-file filename] [--verbose]
                   {depth,filesize,filecount,linkcount,dircount,leaf-dirs,leaf-depth,leaf-files,leaf-links,extensions,total-filesize,total-filecount,total-linkcount,total-dircount,total-leaf-files,total-leaf-links,files-per-level,links-per-level,dirs-per-level,filesize-log2-bins,filesize-log1024-bins,dirfilecount-log2-bins,dirfilecount-log1024-bins,average-leaf-files,average-leaf-links,average-leaf-size,median-leaf-files,median-leaf-links,median-leaf-size,duplicate-names,uid-size,gid-size}
                   [path]
 gufi_stats: error: argument --cumulative/-c: not allowed with argument --recursive/-r
@@ -51,6 +52,22 @@ directory 1
 directory/subdirectory 2
 leaf_directory 1
 unusual#? directory , 1
+
+$ gufi_stats --verbose depth "prefix"
+GUFI query is
+   gufi_query
+    -n 1
+    -B 4096
+    -d
+    -I CREATE TABLE out(name TEXT)
+    -S INSERT INTO out SELECT rpath(sname, sroll) FROM vrsummary
+    -J INSERT INTO aggregate SELECT * FROM out
+    -K CREATE TABLE aggregate(name TEXT)
+    -G SELECT CASE length(name) WHEN 0 THEN 0 ELSE length(name) - length(replace(name, '/', '')) END FROM aggregate ORDER BY name ASC
+    -y 0
+    -z 0
+    prefix
+0
 
 $ gufi_stats    filesize "prefix"
 1049622

--- a/test/regression/gufi_stats.sh.in
+++ b/test/regression/gufi_stats.sh.in
@@ -84,6 +84,8 @@ run_no_sort "${GUFI_STATS} -r -c"  | replace_argparse | sed '/^$/d;'
 run "${GUFI_STATS}    depth \"${BASENAME}\""
 run "${GUFI_STATS} -r depth \"${BASENAME}\""
 
+run_no_sort "${GUFI_STATS} --verbose depth \"${BASENAME}\""
+
 run "${GUFI_STATS}    filesize \"${BASENAME}\""
 run "${GUFI_STATS} -r filesize \"${BASENAME}\""
 


### PR DESCRIPTION
Two small changes here:
1. I always get confused when I don't have a config in /etc/GUFI and I'm not running my modified version which allows configurable values of gufi config path. This change prints an explanatory error message so it will be clear when other people (including myself) run without a gufi config in /etc/GUFI
2. Added verbose mode to gufi_stats to print the actual gufi_query. Useful for debugging and for people learning how it works.