### PR TITLE
handle errors in zlib uncompress()

### DIFF
--- a/include/compress.h
+++ b/include/compress.h
@@ -90,7 +90,7 @@ typedef struct compressed {
 void *compress_struct(const int comp, void *src, const size_t struct_len);
 
 /* initialize dst with pointer to valid buffer */
-int decompress_struct(void **dst, void *src, const size_t struct_len);
+void decompress_struct(void **dst, void *src, const size_t struct_len);
 
 /*
  * used is the struct that was used for operations (decompressed or original data)

--- a/test/unit/googletest/compress.cpp
+++ b/test/unit/googletest/compress.cpp
@@ -67,9 +67,10 @@ OF SUCH DAMAGE.
 #include "compress.h"
 
 // only visible here
+#define TEST_DATA_LEN 1ULL << 10
 typedef struct {
     compressed_t comp;
-    char data[1ULL << 10];
+    char data[TEST_DATA_LEN];
 } data_t;
 
 static const size_t DATA_LEN = sizeof(data_t);
@@ -88,7 +89,7 @@ TEST(compress, off) {
     EXPECT_EQ(c->len, (size_t) 0);
 
     data_t *decompressed = nullptr;
-    EXPECT_EQ(decompress_struct((void **) &decompressed, compressed, DATA_LEN), 0);
+    decompress_struct((void **) &decompressed, compressed, DATA_LEN);
     EXPECT_EQ(decompressed, compressed);
 
     free_struct(decompressed, compressed, 0);
@@ -109,8 +110,10 @@ TEST(compress, on) {
 
     data_t stack;
     data_t *decompressed = &stack;
-    EXPECT_EQ(decompress_struct((void **) &decompressed, compressed, DATA_LEN), 0);
+    decompress_struct((void **) &decompressed, compressed, DATA_LEN);
     EXPECT_NE(decompressed, compressed);
+
+    EXPECT_EQ(memcmp(src.data, decompressed->data, TEST_DATA_LEN), 0);
 
     // compressed was freed, decompressed points to stack address
     free_struct(decompressed, compressed, 0);
@@ -153,16 +156,5 @@ TEST(compress_zlib, bad) {
     EXPECT_EQ(dst->len, (std::size_t) 0);
 
     free(dst);
-}
-
-TEST(decompress_zlib, bad) {
-    compressed_t src; // should not be freed
-    src.yes = 1;
-    src.len = 0;
-
-    compressed_t dst;
-    compressed_t *dstp = &dst;
-
-    ASSERT_NO_THROW(decompress_struct((void **) &dstp, &src, sizeof(src)));
 }
 #endif


### PR DESCRIPTION
Currently errors in zlib's uncompress() function are ignored, which in the worst case could mean continuing to run the program with memory corruption or unexpected results.

There are two error conditions that can be encountered. This patch makes the program abort if it encounters either.

- Running out of memory: while this is a valid condition and could be handled, the program is unlikely to be able to make any useful progress if it cannot allocate memory, and aborting means we don't have to add error handling code for this case.

- Invalid or corrupt data: because this program is the source of all data that it uncompresses, it should never encounter an invalid or corrupt zlib stream. If it does, that indicates a memory bug, and panicking is the safest course of action.

Because decompress_struct() now aborts on all error conditions, it is changed to return void. This simplifies callers of this code as they do not have to worry about handling error cases.