### PR TITLE
remove unnecessary parameter from descend()

### DIFF
--- a/include/utils.h
+++ b/include/utils.h
@@ -121,7 +121,7 @@ struct descend_counters {
  */
 int descend(QPTPool_t *ctx, const size_t id, void *args,
             struct input *in, struct work *work, ino_t inode,
-            DIR *dir, trie_t *skip, const int skip_db,
+            DIR *dir, const int skip_db,
             QPTPoolFunc_t processdir, process_nondir_f processnondir, void *nondir_args,
             struct descend_counters *counters);
 

--- a/src/gufi_dir2index.c
+++ b/src/gufi_dir2index.c
@@ -252,8 +252,7 @@ static int processdir(QPTPool_t *ctx, const size_t id, void *data, void *args) {
 
     struct descend_counters ctrs;
     startdb(nda.db);
-    descend(ctx, id, pa, in, nda.work, nda.ed.statuso.st_ino, dir,
-            in->skip, 0,
+    descend(ctx, id, pa, in, nda.work, nda.ed.statuso.st_ino, dir, 0,
             processdir, process_nondir, &nda,
             &ctrs);
     stopdb(nda.db);

--- a/src/gufi_dir2trace.c
+++ b/src/gufi_dir2trace.c
@@ -177,8 +177,7 @@ static int processdir(QPTPool_t *ctx, const size_t id, void *data, void *args) {
 
     struct descend_counters ctrs;
     descend(ctx, id, pa,
-            in, work, ed.statuso.st_ino,
-            dir, pa->in.skip, 0,
+            in, work, ed.statuso.st_ino, dir, 0,
             processdir, process_nondir, &nda,
             &ctrs);
 

--- a/src/gufi_index2dir.c
+++ b/src/gufi_index2dir.c
@@ -297,7 +297,7 @@ static int processdir(struct QPTPool * ctx, const size_t id, void * data, void *
     }
 
     descend(ctx, id, args, &pa->in, work, dir_st.st_ino,
-            dir, pa->in.skip, 1,
+            dir, 1,
             processdir, NULL, NULL,
             NULL);
 

--- a/src/gufi_treesummary.c
+++ b/src/gufi_treesummary.c
@@ -192,7 +192,7 @@ static int processdir(QPTPool_t *ctx, const size_t id, void *data, void *args) {
                  */
                 descend(ctx, id, pa,
                         &pa->in, passmywork, ed.statuso.st_ino,
-                        dir, pa->in.skip, 0,
+                        dir, 0,
                         processdir, NULL, NULL,
                         NULL);
 

--- a/src/parallel_cpr.c
+++ b/src/parallel_cpr.c
@@ -269,8 +269,7 @@ static int cpr_dir(QPTPool_t *ctx, const size_t id, void *data, void *args) {
 
     /* process children */
     descend(ctx, id, args, in,
-            work, st.st_ino, dir,
-            in->skip, 0,
+            work, st.st_ino, dir, 0,
             cpr_dir,
             enqueue_nondir, &qptp_vals,
             NULL);

--- a/src/utils.c
+++ b/src/utils.c
@@ -389,12 +389,14 @@ size_t SNFORMAT_S(char *dst, const size_t dst_len, size_t count, ...) {
  */
 int descend(QPTPool_t *ctx, const size_t id, void *args,
             struct input *in, struct work *work, ino_t inode,
-            DIR *dir, trie_t *skip_names, const int skip_db,
+            DIR *dir, const int skip_db,
             QPTPoolFunc_t processdir, process_nondir_f processnondir, void *nondir_args,
             struct descend_counters *counters) {
     if (!work) {
         return 1;
     }
+
+    trie_t *skip_names = in->skip;
 
     struct descend_counters ctrs;
     memset(&ctrs, 0, sizeof(ctrs));

--- a/test/unit/googletest/utils.cpp.in
+++ b/test/unit/googletest/utils.cpp.in
@@ -661,15 +661,13 @@ TEST(descend, builddir) {
 
     // bad work; rest of inputs don't matter
     EXPECT_EQ(descend(nullptr, 0, nullptr, nullptr, nullptr, 0, nullptr,
-                      nullptr, 0,
-                      nullptr, nullptr, nullptr,
+                      0, nullptr, nullptr, nullptr,
                       nullptr), 1);
 
     // work->level == in->max_level - not descending
     {
         EXPECT_EQ(descend(nullptr, 0, nullptr, &in, &work, 0, dir,
-                          nullptr, 0,
-                          nullptr,
+                          0, nullptr,
                           nullptr, nullptr,
                           &ctrs), 0);
 
@@ -683,8 +681,7 @@ TEST(descend, builddir) {
     {
         rewinddir(dir);
         in.max_level = 1;
-        EXPECT_EQ(descend(pool, 0, nullptr, &in, &work, 0, dir,
-                          nullptr, 0,
+        EXPECT_EQ(descend(pool, 0, nullptr, &in, &work, 0, dir, 0,
                           [](QPTPool_t *, const size_t, void *data, void *) -> int {
                               free(data);
                               return 0;
@@ -702,8 +699,7 @@ TEST(descend, builddir) {
     // good descend with skip_db
     {
         rewinddir(dir);
-        EXPECT_EQ(descend(pool, 0, nullptr, &in, &work, 0, dir,
-                          nullptr, 1,
+        EXPECT_EQ(descend(pool, 0, nullptr, &in, &work, 0, dir, 1,
                           [](QPTPool_t *, const size_t, void *data, void *) -> int {
                               free(data);
                               return 0;
@@ -721,8 +717,7 @@ TEST(descend, builddir) {
     {
         rewinddir(dir);
         in.subdir_limit = 1;
-        EXPECT_EQ(descend(pool, 0, nullptr, &in, &work, 0, dir,
-                          nullptr, 0,
+        EXPECT_EQ(descend(pool, 0, nullptr, &in, &work, 0, dir, 0,
                           [](QPTPool_t *, const size_t, void *data, void *) -> int {
                               struct work *work = (struct work *) data;
                               if (work->recursion_level == 0) {


### PR DESCRIPTION
descend() in utils.c includes an unnecessary parameter, trie_t *skip_names.

Every caller of descend() passes in this item from a struct input which is already passed as a parameter to descend().

Thus, descend()'s signature can be simplified by removing this extra parameter.