### PR TITLE
dump memory high water mark for gufi_dir2index

### DIFF
--- a/include/utils.h
+++ b/include/utils.h
@@ -165,6 +165,8 @@ size_t present_user_path(const char *path, size_t path_len,
 /* set metadata on given path */
 void set_metadata(const char *path, struct stat *st, struct xattrs *xattrs);
 
+void dump_memory_usage(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/gufi_dir2index.c
+++ b/src/gufi_dir2index.c
@@ -513,6 +513,8 @@ int main(int argc, char *argv[]) {
     fprintf(stdout, "Dirs/Sec:            %.2Lf\n",       thread_count / processtime);
     fprintf(stdout, "Files/Sec:           %.2Lf\n",       total_files / processtime);
 
+    dump_memory_usage();
+
   free_xattr:
     close_template_db(&pa.xattr);
   free_db:

--- a/src/utils.c
+++ b/src/utils.c
@@ -63,6 +63,7 @@ OF SUCH DAMAGE.
 
 
 #include <errno.h>
+#include <fcntl.h>
 #include <limits.h>
 #include <stdarg.h>
 #include <stdlib.h>
@@ -892,4 +893,30 @@ void set_metadata(const char *path, struct stat *st,
         fprintf(stderr, "Error setting atime and mtime of %s: %s (%d)\n",
                 path, strerror(err), err);
     }
+}
+
+void dump_memory_usage(void) {
+    #if defined(DEBUG) && defined(__linux__)
+    int fd = open("/proc/self/status", O_RDONLY);
+    if (fd < 0) {
+        perror("Could not open /proc/self/status");
+        return;
+    }
+
+    char buf[4096] = { 0 };
+    int rc = read(fd, buf, sizeof buf - 1);
+    if (rc < 0) {
+        perror("Could not read /proc/self/status");
+        return;
+    }
+
+    const char *field = "VmHWM";
+    char *p = buf;
+    p = strtok(p, "\n");
+    while (p && strncmp(p, field, strlen(field)))
+        p = strtok(NULL, "\n");
+
+    if (p)
+        printf("%s\n", p);
+    #endif
 }


### PR DESCRIPTION
This dumps the memory RSS high water mark for gufi_dir2index when running on linux with -DDEBUG.

The intention is to make it easier to identify improvements or regressions in memory usage since now no external tools are needed to get peak usage for a run.