### PR TITLE
Use fstatat(2) instead of lstat(2) when processing files during indexing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.a
 *.o
+*.swp
 *.pyc
 db.db
 build

--- a/include/bf.h
+++ b/include/bf.h
@@ -301,6 +301,7 @@ struct work {
 
 /* extra data used by entries that does not depend on data from other directories */
 struct entry_data {
+   int           parent_fd;    /* holds an FD that can be used for fstatat(2), etc. */
    char          type;
    char          linkname[MAXPATH];
    uint8_t       lstat_called;

--- a/src/gufi_dir2index.c
+++ b/src/gufi_dir2index.c
@@ -64,6 +64,7 @@ OF SUCH DAMAGE.
 
 #include <errno.h>
 #include <dirent.h>
+#include <fcntl.h>
 #include <inttypes.h>
 #include <stdlib.h>
 #include <string.h>
@@ -129,7 +130,9 @@ static int process_nondir(struct work *entry, struct entry_data *ed, void *args)
     struct input *in = nda->in;
 
     if (!ed->lstat_called) {
-        if (lstat(entry->name, &ed->statuso) != 0) {
+        char *basename = entry->name + entry->name_len - entry->basename_len;
+
+        if (fstatat(ed->parent_fd, basename, &ed->statuso, AT_SYMLINK_NOFOLLOW) != 0) {
             return 1;
         }
     }

--- a/src/gufi_dir2trace.c
+++ b/src/gufi_dir2trace.c
@@ -106,8 +106,10 @@ static int process_external(struct input *in, void *args,
 static int process_nondir(struct work *entry, struct entry_data *ed, void *args) {
     struct NondirArgs *nda = (struct NondirArgs *) args;
     if (!ed->lstat_called) {
-        if (lstat(entry->name, &ed->statuso) != 0) {
-            return 0;
+        char *basename = entry->name + entry->name_len - entry->basename_len;
+
+        if (fstatat(ed->parent_fd, basename, &ed->statuso, AT_SYMLINK_NOFOLLOW) != 0) {
+            return 1;
         }
 
         if (ed->type == 'l') {


### PR DESCRIPTION
Pathname resolution has a significant overhead during
GUFI indexing. Using the _at variant of stat(2) when processing
files means less work is required to resolve the paths.

Profiling GUFI runs with flamegraphs suggests that this is an
effective change to reduce the overhead of pathname resolution.
I observed the time spent resolving names go from ~ 14% using
lstat(2) down to ~ 6% using fstatat(2), in one example run on an
NFS filestystem with approx. 450,000 files.

----

Example flamegraphs attached, zoom in on `vfs_statx -> filename_lookup` under `process_work` 

![gufi_dir2trace_fstatat](https://github.com/user-attachments/assets/243d31ff-0da6-410b-b745-534305108a24)
![gufi_dir2trace_lstat](https://github.com/user-attachments/assets/8b435ca6-79ea-4ae9-a37e-3cad8c1c6699)
