### PR TITLE
changes for better memory usage in users of BottomUp (parallel_rmr, etc)

### DIFF
--- a/include/BottomUp.h
+++ b/include/BottomUp.h
@@ -98,9 +98,9 @@ extern "C" {
   the user, so the imeplementation is not opaque.
 */
 struct BottomUp {
-    char name[MAXPATH];
+    char *name;
     size_t name_len;
-    char alt_name[MAXPATH];
+    char *alt_name;
     size_t alt_name_len;
     struct stat st;
     struct {
@@ -180,6 +180,9 @@ int parallel_bottomup(char **root_names, const size_t root_count,
                       , struct OutputBuffers *debug_buffers
                       #endif
 );
+
+/* free a struct BottomUp */
+void bottomup_destroy(void *p);
 
 #ifdef __cplusplus
 }

--- a/include/BottomUp.h
+++ b/include/BottomUp.h
@@ -102,7 +102,6 @@ struct BottomUp {
     size_t name_len;
     char *alt_name;
     size_t alt_name_len;
-    struct stat st;
     struct {
         pthread_mutex_t mutex;
         size_t remaining;

--- a/include/utils.h
+++ b/include/utils.h
@@ -179,6 +179,8 @@ ssize_t write_size(const int fd, const void *data, const size_t size);
 /* read as much as possible up to size bytes */
 ssize_t read_size(const int fd, void *buf, const size_t size);
 
+/* Get a directory file descriptor from a given DIR *, infallibly */
+int gufi_dirfd(DIR *d);
 #ifdef __cplusplus
 }
 #endif

--- a/src/BottomUp.c
+++ b/src/BottomUp.c
@@ -356,7 +356,8 @@ static int descend_to_bottom(QPTPool_t *ctx, const size_t id, void *data, void *
         }
 
         timestamp_create_start(lstat_entry);
-        const int rc = lstat(new_work.name, &new_work.st);
+        struct stat st;
+        const int rc = lstat(new_work.name, &st);
         timestamp_end_print(ua->timestamp_buffers, id, "lstat", lstat_entry);
 
         if (rc != 0) {
@@ -365,7 +366,7 @@ static int descend_to_bottom(QPTPool_t *ctx, const size_t id, void *data, void *
         }
 
         timestamp_create_start(track_entry);
-        if (S_ISDIR(new_work.st.st_mode)) {
+        if (S_ISDIR(st.st_mode)) {
             track(&new_work,
                   ua->user_struct_size, &bu->subdirs,
                   next_level, ua->generate_alt_name);

--- a/src/parallel_rmr.c
+++ b/src/parallel_rmr.c
@@ -143,5 +143,7 @@ int main(int argc, char * argv[]) {
 
     input_fini(&in);
 
+    dump_memory_usage();
+
     return rc?EXIT_FAILURE:EXIT_SUCCESS;
 }


### PR DESCRIPTION
The first two commits are changes that reduce the size of `struct BottomUp`:

- removes a mostly unused embedded `struct stat` 
- removes two fixed 4 KiB buffers, one of which is always unused for parallel_rmr, in favor of dynamically allocating a buffer for pathnames that is only as large as needed

Overall this reduces the size of `struct BottomUp` from 8504 B to 184 B and seems to make a significant difference for parallel_rmr.


The third commit in the series modifies the logic of `descend_to_bottom()` in BottomUp.c to not format pathnames for non-directory nodes unless those nodes are actually processed. This removes an allocation for all the non-dir nodes in cases where those nodes are not processed.