### PR TITLE
WIP / Experiment: reference counting directory FDs to keep them alive longer

### DIFF
--- a/include/QueuePerThreadPool.h
+++ b/include/QueuePerThreadPool.h
@@ -115,6 +115,7 @@ QPTPool_t *QPTPool_init_with_props(const size_t nthreads, void *args,
                                    const uint64_t queue_limit, const char *swap_prefix,
                                    const uint64_t steal_num, const uint64_t steal_denom);
 
+void QPTPool_set_destructor(QPTPool_t *pool, void (*destructor)(void *));
 /*
  * QPTPool_init only allocates memory - call this to start threads
  *

--- a/include/bf.h
+++ b/include/bf.h
@@ -337,20 +337,6 @@ typedef enum {
 } CleanUpTasks;
 
 /*
- * A reference-counted directory handle.
- */
-struct dir_rc {
-   DIR *dir;
-   uint64_t rc;
-};
-
-struct dir_rc *open_dir_rc(int optional_fd, char *path);
-int get_dir_fd(struct dir_rc *dir);
-void dir_inc(struct dir_rc *dir);
-struct dir_rc *dir_clone(struct dir_rc *dir);
-void dir_dec(struct dir_rc *dir);
-
-/*
  * Minimum data needs to be passed around between threads.
  *
  * struct work generally should not be allocated directly - the helper
@@ -386,6 +372,20 @@ size_t struct_work_size(struct work *w);
 struct work *new_work_with_name(const char *prefix, const size_t prefix_len,
                                 const char *basename, const size_t basename_len);
 void free_work(struct work *w);
+
+/*
+ * A reference-counted directory handle.
+ */
+struct dir_rc {
+   DIR *dir;
+   uint64_t rc;
+};
+
+struct dir_rc *open_dir_rc(struct work *w);
+int get_dir_fd(struct dir_rc *dir);
+void dir_inc(struct dir_rc *dir);
+struct dir_rc *dir_clone(struct dir_rc *dir);
+void dir_dec(struct dir_rc *dir);
 
 /* extra data used by entries that does not depend on data from other directories */
 struct entry_data {

--- a/include/bf.h
+++ b/include/bf.h
@@ -65,6 +65,7 @@ OF SUCH DAMAGE.
 #ifndef BF_H
 #define BF_H
 
+#include <dirent.h>
 #include <inttypes.h>
 #include <sys/stat.h>
 
@@ -336,6 +337,19 @@ typedef enum {
 } CleanUpTasks;
 
 /*
+ * A reference-counted directory handle.
+ */
+struct dir_rc {
+   DIR *dir;
+   uint64_t rc;
+};
+
+struct dir_rc *open_dir_rc(int optional_fd, char *path);
+int get_dir_fd(struct dir_rc *dir);
+void dir_inc(struct dir_rc *dir);
+void dir_dec(struct dir_rc *dir);
+
+/*
  * Minimum data needs to be passed around between threads.
  *
  * struct work generally should not be allocated directly - the helper
@@ -356,6 +370,9 @@ struct work {
    size_t        basename_len;           /* can usually get through readdir */
    long long int pinode;
    size_t        recursion_level;
+
+   /* an optional reference to the parent dir -- to keep it alive */
+   struct dir_rc	*parent_dir;
 
    /* probably shouldn't be here */
    char *        fullpath;

--- a/include/bf.h
+++ b/include/bf.h
@@ -371,7 +371,7 @@ struct work {
 size_t struct_work_size(struct work *w);
 struct work *new_work_with_name(const char *prefix, const size_t prefix_len,
                                 const char *basename, const size_t basename_len);
-void free_work(struct work *w);
+void free_work(void *p);
 
 /*
  * A reference-counted directory handle.

--- a/include/bf.h
+++ b/include/bf.h
@@ -384,6 +384,7 @@ struct work {
 size_t struct_work_size(struct work *w);
 struct work *new_work_with_name(const char *prefix, const size_t prefix_len,
                                 const char *basename, const size_t basename_len);
+void free_work(struct work *w);
 
 /* extra data used by entries that does not depend on data from other directories */
 struct entry_data {

--- a/include/bf.h
+++ b/include/bf.h
@@ -347,6 +347,7 @@ struct dir_rc {
 struct dir_rc *open_dir_rc(int optional_fd, char *path);
 int get_dir_fd(struct dir_rc *dir);
 void dir_inc(struct dir_rc *dir);
+struct dir_rc *dir_clone(struct dir_rc *dir);
 void dir_dec(struct dir_rc *dir);
 
 /*

--- a/include/bf.h
+++ b/include/bf.h
@@ -379,11 +379,11 @@ void free_work(void *p);
 struct dir_rc {
    DIR *dir;
    uint64_t rc;
+   int dont_clone;
 };
 
 struct dir_rc *open_dir_rc(struct work *w);
 int get_dir_fd(struct dir_rc *dir);
-void dir_inc(struct dir_rc *dir);
 struct dir_rc *dir_clone(struct dir_rc *dir);
 void dir_dec(struct dir_rc *dir);
 

--- a/include/descend.h
+++ b/include/descend.h
@@ -90,7 +90,7 @@ struct descend_counters {
  */
 int descend(QPTPool_t *ctx, const size_t id, void *args,
             struct input *in, struct work *work, ino_t inode,
-            DIR *dir, const int skip_db,
+            struct dir_rc *d_rc, const int skip_db,
             QPTPool_f processdir, process_nondir_f processnondir, void *nondir_args,
             struct descend_counters *counters);
 

--- a/src/bf.c
+++ b/src/bf.c
@@ -704,7 +704,8 @@ struct work *new_work_with_name(const char *prefix, const size_t prefix_len,
     return w;
 }
 
-void free_work(struct work *w) {
+void free_work(void *p) {
+    struct work *w = (struct work *) p;
     dir_dec(w->parent_dir);
     free(w);
 }

--- a/src/bf.c
+++ b/src/bf.c
@@ -637,6 +637,15 @@ void dir_inc(struct dir_rc *dir) {
 }
 
 /*
+ * Clone a `dir_rc`.
+ * This increments the refcount and returns a pointer to the dir_rc to the caller.
+ */
+struct dir_rc *dir_clone(struct dir_rc *dir) {
+    dir_inc(dir);
+    return dir;
+}
+
+/*
  * Decrement the reference count for a dir_rc, and free it if that was the last reference.
  */
 void dir_dec(struct dir_rc *dir) {

--- a/src/bf.c
+++ b/src/bf.c
@@ -640,9 +640,11 @@ void dir_inc(struct dir_rc *dir) {
  * Decrement the reference count for a dir_rc, and free it if that was the last reference.
  */
 void dir_dec(struct dir_rc *dir) {
-    if (__atomic_sub_fetch(&dir->rc, 1, __ATOMIC_ACQ_REL) == 0) {
-        closedir(dir->dir);
-        free(dir);
+    if (dir) {
+        if (__atomic_sub_fetch(&dir->rc, 1, __ATOMIC_ACQ_REL) == 0) {
+            closedir(dir->dir);
+            free(dir);
+        }
     }
 }
 
@@ -683,4 +685,9 @@ struct work *new_work_with_name(const char *prefix, const size_t prefix_len,
     w->basename_len = basename_len;
 
     return w;
+}
+
+void free_work(struct work *w) {
+    dir_dec(w->parent_dir);
+    free(w);
 }

--- a/src/descend.c
+++ b/src/descend.c
@@ -127,6 +127,7 @@ int descend(QPTPool_t *ctx, const size_t id, void *args,
             }
 
             struct work *child = new_work_with_name(work->name, work->name_len, dir_child->d_name, len);
+            child->parent_dir = dir_clone(d_rc);
 
             struct entry_data child_ed;
             memset(&child_ed, 0, sizeof(child_ed));

--- a/src/descend.c
+++ b/src/descend.c
@@ -90,12 +90,14 @@ static int work_serialize_and_free(const int fd, QPTPool_f func, void *work, siz
  */
 int descend(QPTPool_t *ctx, const size_t id, void *args,
             struct input *in, struct work *work, ino_t inode,
-            DIR *dir, const int skip_db,
+            struct dir_rc *d_rc, const int skip_db,
             QPTPool_f processdir, process_nondir_f processnondir, void *nondir_args,
             struct descend_counters *counters) {
     if (!work) {
         return 1;
     }
+
+    DIR *dir = d_rc->dir;
 
     trie_t *skip_names = in->skip;
 

--- a/src/descend.c
+++ b/src/descend.c
@@ -199,7 +199,7 @@ int descend(QPTPool_t *ctx, const size_t id, void *args,
                 }
                 else {
                     /* skip enqueuing and just free */
-                    free(child);
+                    free_work(child);
                 }
                 continue;
             }
@@ -215,7 +215,7 @@ int descend(QPTPool_t *ctx, const size_t id, void *args,
             }
             else {
                 /* other types are not stored */
-                free(child);
+                free_work(child);
                 continue;
             }
 
@@ -239,7 +239,7 @@ int descend(QPTPool_t *ctx, const size_t id, void *args,
                 }
             }
 
-            free(child);
+            free_work(child);
         }
     }
 

--- a/src/gufi_dir2index.c
+++ b/src/gufi_dir2index.c
@@ -203,7 +203,7 @@ static int processdir(QPTPool_t *ctx, const size_t id, void *data, void *args) {
         goto cleanup;
     }
 
-    struct dir_rc *dir_rc = open_dir_rc(-1, nda.work->name);
+    struct dir_rc *dir_rc = open_dir_rc(nda.work);
     if (!dir_rc) {
         const int err = errno;
         fprintf(stderr, "Error: Could not open directory \"%s\": %s (%d)\n", nda.work->name, strerror(err), err);

--- a/src/gufi_dir2index.c
+++ b/src/gufi_dir2index.c
@@ -323,7 +323,7 @@ static int processdir(QPTPool_t *ctx, const size_t id, void *data, void *args) {
     }
 
     free(nda.topath);
-    free(nda.work);
+    free_work(nda.work);
 
     return rc;
 }

--- a/src/gufi_dir2index.c
+++ b/src/gufi_dir2index.c
@@ -189,8 +189,6 @@ static int processdir(QPTPool_t *ctx, const size_t id, void *data, void *args) {
     nda.topath     = NULL;
     nda.ed.type    = 'd';
 
-    DIR *dir = NULL;
-
     decompress_work(&nda.work, data);
 
     const int process_dbdb = ((pa->in.min_level <= nda.work->level) &&
@@ -210,7 +208,6 @@ static int processdir(QPTPool_t *ctx, const size_t id, void *data, void *args) {
         rc = 1;
         goto cleanup;
     }
-    dir = dir_rc->dir;
 
     /* offset by work->root_len to remove prefix */
     nda.topath_len = nda.in->nameto.len + 1 + nda.work->name_len - nda.work->root_parent.len;
@@ -235,7 +232,7 @@ static int processdir(QPTPool_t *ctx, const size_t id, void *data, void *args) {
         if (err != EEXIST) {
             fprintf(stderr, "mkdir %s failure: %d %s\n", nda.topath, err, strerror(err));
             rc = 1;
-            goto cleanup;
+            goto cleanup_dir;
         }
     }
 
@@ -250,7 +247,7 @@ static int processdir(QPTPool_t *ctx, const size_t id, void *data, void *args) {
 
         if (!nda.db) {
             rc = 1;
-            goto cleanup;
+            goto cleanup_dir;
         }
 
         /* prepare to insert into the database */
@@ -315,9 +312,10 @@ static int processdir(QPTPool_t *ctx, const size_t id, void *data, void *args) {
     chmod(nda.topath, nda.ed.statuso.st_mode);
     chown(nda.topath, nda.ed.statuso.st_uid, nda.ed.statuso.st_gid);
 
-  cleanup:
+  cleanup_dir:
     dir_dec(dir_rc);
 
+  cleanup:
     if (process_dbdb) {
         pa->total_dirs[id]++;
         pa->total_nondirs[id] += ctrs.nondirs_processed;

--- a/src/gufi_dir2trace.c
+++ b/src/gufi_dir2trace.c
@@ -136,7 +136,7 @@ static int processdir(QPTPool_t *ctx, const size_t id, void *data, void *args) {
 
     decompress_work(&work, data);
 
-    struct dir_rc *dir_rc = open_dir_rc(-1, work->name);
+    struct dir_rc *dir_rc = open_dir_rc(work);
     if (!dir_rc) {
         rc = 1;
         goto cleanup;

--- a/src/gufi_dir2trace.c
+++ b/src/gufi_dir2trace.c
@@ -136,11 +136,12 @@ static int processdir(QPTPool_t *ctx, const size_t id, void *data, void *args) {
 
     decompress_work(&work, data);
 
-    DIR *dir = opendir(work->name);
-    if (!dir) {
+    struct dir_rc *dir_rc = open_dir_rc(-1, work->name);
+    if (!dir_rc) {
         rc = 1;
         goto cleanup;
     }
+    DIR *dir = dir_rc->dir;
 
     memset(&ed, 0, sizeof(ed));
     if (lstat(work->name, &ed.statuso) != 0) {
@@ -171,12 +172,12 @@ static int processdir(QPTPool_t *ctx, const size_t id, void *data, void *args) {
 
     struct descend_counters ctrs;
     descend(ctx, id, pa,
-            in, work, ed.statuso.st_ino, dir, 0,
+            in, work, ed.statuso.st_ino, dir_rc, 0,
             processdir, process_nondir, &nda,
             &ctrs);
 
   cleanup:
-    closedir(dir);
+    dir_dec(dir_rc);
 
     free_work(work);
 

--- a/src/gufi_dir2trace.c
+++ b/src/gufi_dir2trace.c
@@ -141,7 +141,6 @@ static int processdir(QPTPool_t *ctx, const size_t id, void *data, void *args) {
         rc = 1;
         goto cleanup;
     }
-    DIR *dir = dir_rc->dir;
 
     memset(&ed, 0, sizeof(ed));
     if (lstat(work->name, &ed.statuso) != 0) {

--- a/src/gufi_dir2trace.c
+++ b/src/gufi_dir2trace.c
@@ -178,7 +178,7 @@ static int processdir(QPTPool_t *ctx, const size_t id, void *data, void *args) {
   cleanup:
     closedir(dir);
 
-    free(work);
+    free_work(work);
 
     pa->total_files[id] += ctrs.nondirs_processed;
 

--- a/src/gufi_index2dir.c
+++ b/src/gufi_index2dir.c
@@ -265,7 +265,7 @@ static int processdir(struct QPTPool * ctx, const size_t id, void * data, void *
     sqlite3 *db = NULL;
     int rc = 0;
 
-    struct dir_rc *dir_rc = open_dir_rc(-1, work->name);
+    struct dir_rc *dir_rc = open_dir_rc(work);
     if (!dir_rc) {
         fprintf(stderr, "Could not open directory \"%s\"\n", work->name);
         rc = 1;

--- a/src/gufi_index2dir.c
+++ b/src/gufi_index2dir.c
@@ -271,7 +271,6 @@ static int processdir(struct QPTPool * ctx, const size_t id, void * data, void *
         rc = 1;
         goto cleanup;
     }
-    DIR *dir = dir_rc->dir;
 
     // get source directory info
     struct stat dir_st;

--- a/src/gufi_index2dir.c
+++ b/src/gufi_index2dir.c
@@ -265,12 +265,13 @@ static int processdir(struct QPTPool * ctx, const size_t id, void * data, void *
     sqlite3 *db = NULL;
     int rc = 0;
 
-    DIR *dir = opendir(work->name);
-    if (!dir) {
+    struct dir_rc *dir_rc = open_dir_rc(-1, work->name);
+    if (!dir_rc) {
         fprintf(stderr, "Could not open directory \"%s\"\n", work->name);
         rc = 1;
         goto cleanup;
     }
+    DIR *dir = dir_rc->dir;
 
     // get source directory info
     struct stat dir_st;
@@ -297,7 +298,7 @@ static int processdir(struct QPTPool * ctx, const size_t id, void * data, void *
     }
 
     descend(ctx, id, args, &pa->in, work, dir_st.st_ino,
-            dir, 1,
+            dir_rc, 1,
             processdir, NULL, NULL,
             NULL);
 
@@ -355,7 +356,7 @@ static int processdir(struct QPTPool * ctx, const size_t id, void * data, void *
     closedb(db);
     db = NULL;
 
-    closedir(dir);
+    dir_dec(dir_rc);
 
     free_work(work);
 

--- a/src/gufi_index2dir.c
+++ b/src/gufi_index2dir.c
@@ -357,7 +357,7 @@ static int processdir(struct QPTPool * ctx, const size_t id, void * data, void *
 
     closedir(dir);
 
-    free(work);
+    free_work(work);
 
     return rc;
 }

--- a/src/gufi_treesummary.c
+++ b/src/gufi_treesummary.c
@@ -134,7 +134,7 @@ static int processdir(QPTPool_t *ctx, const size_t id, void *data, void *args) {
         goto out_free;
     }
 
-    struct dir_rc *dir_rc = open_dir_rc(-1, passmywork->name);
+    struct dir_rc *dir_rc = open_dir_rc(passmywork);
     if (!dir_rc) {
         goto out_free;
     }

--- a/src/gufi_treesummary.c
+++ b/src/gufi_treesummary.c
@@ -138,7 +138,6 @@ static int processdir(QPTPool_t *ctx, const size_t id, void *data, void *args) {
     if (!dir_rc) {
         goto out_free;
     }
-    DIR *dir = dir_rc->dir;
 
     if (pa->in.printdir) {
         ed.type = 'd';

--- a/src/gufi_treesummary.c
+++ b/src/gufi_treesummary.c
@@ -211,7 +211,7 @@ static int processdir(QPTPool_t *ctx, const size_t id, void *data, void *args) {
     closedir(dir);
 
   out_free:
-    free(passmywork);
+    free_work(passmywork);
 
     return 0;
 }

--- a/src/gufi_treesummary.c
+++ b/src/gufi_treesummary.c
@@ -134,10 +134,11 @@ static int processdir(QPTPool_t *ctx, const size_t id, void *data, void *args) {
         goto out_free;
     }
 
-    DIR *dir = opendir(passmywork->name);
-    if (!dir) {
+    struct dir_rc *dir_rc = open_dir_rc(-1, passmywork->name);
+    if (!dir_rc) {
         goto out_free;
     }
+    DIR *dir = dir_rc->dir;
 
     if (pa->in.printdir) {
         ed.type = 'd';
@@ -192,7 +193,7 @@ static int processdir(QPTPool_t *ctx, const size_t id, void *data, void *args) {
                  */
                 descend(ctx, id, pa,
                         &pa->in, passmywork, ed.statuso.st_ino,
-                        dir, 0,
+                        dir_rc, 0,
                         processdir, NULL, NULL,
                         NULL);
 
@@ -208,7 +209,7 @@ static int processdir(QPTPool_t *ctx, const size_t id, void *data, void *args) {
     }
 
     closedb(db);
-    closedir(dir);
+    dir_dec(dir_rc);
 
   out_free:
     free_work(passmywork);

--- a/src/parallel_cpr.c
+++ b/src/parallel_cpr.c
@@ -394,7 +394,7 @@ int main(int argc, char * argv[]) {
                 cpr_link(work, &ed, &in);
             }
 
-            free(work);
+            free_work(work);
         }
         else if (S_ISREG(st.st_mode)) {
             struct work_data *wd = calloc(1, sizeof(*wd) + work->name_len + 1);
@@ -410,7 +410,7 @@ int main(int argc, char * argv[]) {
 
             QPTPool_enqueue(pool, 0, cpr_file, wd);
 
-            free(work);
+            free_work(work);
         }
         else {
             free(work);

--- a/src/parallel_cpr.c
+++ b/src/parallel_cpr.c
@@ -231,7 +231,7 @@ static int cpr_dir(QPTPool_t *ctx, const size_t id, void *data, void *args) {
 
     int rc = 0;
 
-    struct dir_rc *dir_rc = open_dir_rc(-1, work->name);
+    struct dir_rc *dir_rc = open_dir_rc(work);
     if (!dir_rc) {
         print_error_and_goto("Could not open_directory", work->name, cleanup);
     }

--- a/src/parallel_cpr.c
+++ b/src/parallel_cpr.c
@@ -235,7 +235,6 @@ static int cpr_dir(QPTPool_t *ctx, const size_t id, void *data, void *args) {
     if (!dir_rc) {
         print_error_and_goto("Could not open_directory", work->name, cleanup);
     }
-    DIR *dir = dir_rc->dir;
 
     struct stat st;
     if (lstat(work->name, &st) != 0) {

--- a/test/unit/googletest/descend.cpp.in
+++ b/test/unit/googletest/descend.cpp.in
@@ -93,7 +93,7 @@ TEST(descend, builddir) {
     const char root[] = "@CMAKE_BINARY_DIR@";
     struct work *work = new_work_with_name(nullptr, 0, root, strlen(root));
 
-    struct dir_rc *dir_rc = open_dir_rc(-1, work->name);
+    struct dir_rc *dir_rc = open_dir_rc(work);
     ASSERT_NE(dir_rc, nullptr);
     DIR *dir = dir_rc->dir;
 
@@ -249,7 +249,7 @@ TEST(descend, swap) {
     // descend to swap
     struct work *work = new_work_with_name(nullptr, 0, root, strlen(root));
 
-    struct dir_rc *dir_rc = open_dir_rc(-1, work->name);
+    struct dir_rc *dir_rc = open_dir_rc(work);
     ASSERT_NE(dir_rc, nullptr);
     DIR *dir = dir_rc->dir;
 

--- a/test/unit/googletest/descend.cpp.in
+++ b/test/unit/googletest/descend.cpp.in
@@ -93,8 +93,9 @@ TEST(descend, builddir) {
     const char root[] = "@CMAKE_BINARY_DIR@";
     struct work *work = new_work_with_name(nullptr, 0, root, strlen(root));
 
-    DIR *dir = opendir(work->name);
-    ASSERT_NE(dir, nullptr);
+    struct dir_rc *dir_rc = open_dir_rc(-1, work->name);
+    ASSERT_NE(dir_rc, nullptr);
+    DIR *dir = dir_rc->dir;
 
     QPTPool_t *pool = QPTPool_init(1, nullptr);
     ASSERT_NE(pool, nullptr);
@@ -111,7 +112,7 @@ TEST(descend, builddir) {
     {
         in.max_level = 0;
         work->level = 1;
-        EXPECT_EQ(descend(nullptr, 0, nullptr, &in, work, 0, dir,
+        EXPECT_EQ(descend(nullptr, 0, nullptr, &in, work, 0, dir_rc,
                           0, nullptr,
                           nullptr, nullptr,
                           &ctrs), 0);
@@ -127,7 +128,7 @@ TEST(descend, builddir) {
         rewinddir(dir);
         in.max_level = 1;
         work->level = 0;
-        EXPECT_EQ(descend(pool, 0, nullptr, &in, work, 0, dir, 0,
+        EXPECT_EQ(descend(pool, 0, nullptr, &in, work, 0, dir_rc, 0,
                           [](QPTPool_t *, const size_t, void *data, void *) -> int {
                               free(data);
                               return 0;
@@ -145,7 +146,7 @@ TEST(descend, builddir) {
     // good descend with skip_db
     {
         rewinddir(dir);
-        EXPECT_EQ(descend(pool, 0, nullptr, &in, work, 0, dir, 1,
+        EXPECT_EQ(descend(pool, 0, nullptr, &in, work, 0, dir_rc, 1,
                           [](QPTPool_t *, const size_t, void *data, void *) -> int {
                               free(data);
                               return 0;
@@ -163,7 +164,7 @@ TEST(descend, builddir) {
     {
         rewinddir(dir);
         in.subdir_limit = 1;
-        EXPECT_EQ(descend(pool, 0, nullptr, &in, work, 0, dir, 0,
+        EXPECT_EQ(descend(pool, 0, nullptr, &in, work, 0, dir_rc, 0,
                           [](QPTPool_t *, const size_t, void *data, void *) -> int {
                               free(data);
                               return 0;
@@ -248,12 +249,13 @@ TEST(descend, swap) {
     // descend to swap
     struct work *work = new_work_with_name(nullptr, 0, root, strlen(root));
 
-    DIR *dir = opendir(work->name);
-    ASSERT_NE(dir, nullptr);
+    struct dir_rc *dir_rc = open_dir_rc(-1, work->name);
+    ASSERT_NE(dir_rc, nullptr);
+    DIR *dir = dir_rc->dir;
 
     struct descend_counters ctrs;
 
-    EXPECT_EQ(descend(pool, 0, nullptr, &in, work, 0, dir, 0,
+    EXPECT_EQ(descend(pool, 0, nullptr, &in, work, 0, dir_rc, 0,
                       [](QPTPool_t *, const size_t, void *data, void *) -> int {
                           free(data);
                           return 0;

--- a/test/unit/googletest/descend.cpp.in
+++ b/test/unit/googletest/descend.cpp.in
@@ -100,6 +100,7 @@ TEST(descend, builddir) {
     QPTPool_t *pool = QPTPool_init(1, nullptr);
     ASSERT_NE(pool, nullptr);
     EXPECT_EQ(QPTPool_start(pool), 0);
+    QPTPool_set_destructor(pool, (void (*)(void *)) free_work);
 
     struct descend_counters ctrs;
 
@@ -130,7 +131,7 @@ TEST(descend, builddir) {
         work->level = 0;
         EXPECT_EQ(descend(pool, 0, nullptr, &in, work, 0, dir_rc, 0,
                           [](QPTPool_t *, const size_t, void *data, void *) -> int {
-                              free(data);
+                              free_work(data);
                               return 0;
                           },
                           nullptr, nullptr,
@@ -148,7 +149,7 @@ TEST(descend, builddir) {
         rewinddir(dir);
         EXPECT_EQ(descend(pool, 0, nullptr, &in, work, 0, dir_rc, 1,
                           [](QPTPool_t *, const size_t, void *data, void *) -> int {
-                              free(data);
+                              free_work(data);
                               return 0;
                           },
                           nullptr, nullptr,
@@ -166,7 +167,7 @@ TEST(descend, builddir) {
         in.subdir_limit = 1;
         EXPECT_EQ(descend(pool, 0, nullptr, &in, work, 0, dir_rc, 0,
                           [](QPTPool_t *, const size_t, void *data, void *) -> int {
-                              free(data);
+                              free_work(data);
                               return 0;
                           },
                           nullptr, nullptr,
@@ -181,9 +182,9 @@ TEST(descend, builddir) {
     QPTPool_stop(pool);
     QPTPool_destroy(pool);
 
-    EXPECT_EQ(closedir(dir),    0);
     free_work(work);
     dir_dec(dir_rc);
+
     EXPECT_EQ(unlink(pipename), 0);
     EXPECT_EQ(unlink(linkname), 0);
 }
@@ -210,6 +211,7 @@ TEST(descend, swap) {
     ASSERT_NE(pool, nullptr);
     EXPECT_EQ(QPTPool_set_queue_limit(pool, 1), 0); // if the WAIT queue already has 1 item, swap out the new item
     EXPECT_EQ(QPTPool_start(pool), 0);
+    QPTPool_set_destructor(pool, (void (*)(void *)) free_work);
 
     // enqueue stuck thread
     pthread_mutex_lock(&args.mutex);
@@ -252,13 +254,12 @@ TEST(descend, swap) {
 
     struct dir_rc *dir_rc = open_dir_rc(work);
     ASSERT_NE(dir_rc, nullptr);
-    DIR *dir = dir_rc->dir;
 
     struct descend_counters ctrs;
 
     EXPECT_EQ(descend(pool, 0, nullptr, &in, work, 0, dir_rc, 0,
                       [](QPTPool_t *, const size_t, void *data, void *) -> int {
-                          free(data);
+                          free_work(data);
                           return 0;
                       },
                       nullptr, nullptr,
@@ -273,7 +274,6 @@ TEST(descend, swap) {
     QPTPool_stop(pool);
     QPTPool_destroy(pool);
 
-    EXPECT_EQ(closedir(dir), 0);
     free_work(work);
     dir_dec(dir_rc);
 

--- a/test/unit/googletest/descend.cpp.in
+++ b/test/unit/googletest/descend.cpp.in
@@ -182,7 +182,8 @@ TEST(descend, builddir) {
     QPTPool_destroy(pool);
 
     EXPECT_EQ(closedir(dir),    0);
-    free(work);
+    free_work(work);
+    dir_dec(dir_rc);
     EXPECT_EQ(unlink(pipename), 0);
     EXPECT_EQ(unlink(linkname), 0);
 }
@@ -273,7 +274,8 @@ TEST(descend, swap) {
     QPTPool_destroy(pool);
 
     EXPECT_EQ(closedir(dir), 0);
-    free(work);
+    free_work(work);
+    dir_dec(dir_rc);
 
     EXPECT_EQ(remove(root), 0);
 }


### PR DESCRIPTION
This is a _work-in-progress, experimental_ branch that tests refcounting dir FDs with the goal of keeping them alive while there are still children waiting to be processed.

The idea is to see if this helps the cache behavior on Lustre with the Lustre inode cache disabled.

This also enables using openat() in the processdir() functions in order to reduce pathname resolution overhead.