### PR TITLE
Lustre plugin for gufi_dir2index

### DIFF
--- a/contrib/CMakeLists.txt
+++ b/contrib/CMakeLists.txt
@@ -132,3 +132,11 @@ foreach(file ${USEFUL})
 endforeach()
 
 add_subdirectory(CI)
+
+# See if lustre-devel is installed by checking if the lustreapi.h header is in a standard include path.
+find_path(LUSTRE_PLUGIN "lustre/lustreapi.h")
+# If so, build the lustre example plugin:
+if (LUSTRE_PLUGIN)
+  add_library(lustre_plugin SHARED lustre_plugin.c)
+  target_link_libraries(lustre_plugin lustreapi)
+endif()

--- a/contrib/lustre_plugin.c
+++ b/contrib/lustre_plugin.c
@@ -1,0 +1,420 @@
+/*
+This file is part of GUFI, which is part of MarFS, which is released
+under the BSD license.
+
+
+Copyright (c) 2017, Los Alamos National Security (LANS), LLC
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation and/or
+other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors
+may be used to endorse or promote products derived from this software without
+specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+From Los Alamos National Security, LLC:
+LA-CC-15-039
+
+Copyright (c) 2017, Los Alamos National Security, LLC All rights reserved.
+Copyright 2017. Los Alamos National Security, LLC. This software was produced
+under U.S. Government contract DE-AC52-06NA25396 for Los Alamos National
+Laboratory (LANL), which is operated by Los Alamos National Security, LLC for
+the U.S. Department of Energy. The U.S. Government has rights to use,
+reproduce, and distribute this software.  NEITHER THE GOVERNMENT NOR LOS
+ALAMOS NATIONAL SECURITY, LLC MAKES ANY WARRANTY, EXPRESS OR IMPLIED, OR
+ASSUMES ANY LIABILITY FOR THE USE OF THIS SOFTWARE.  If software is
+modified to produce derivative works, such modified software should be
+clearly marked, so as not to confuse it with the version available from
+LANL.
+
+THIS SOFTWARE IS PROVIDED BY LOS ALAMOS NATIONAL SECURITY, LLC AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL LOS ALAMOS NATIONAL SECURITY, LLC OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+OF SUCH DAMAGE.
+*/
+
+
+
+/*
+ * An example Lustre plugin for GUFI.
+ *
+ * If the lustre and lustre-devel RPMs are installed on the machine that is used to build GUFI, then this plugin
+ * should be built automatically. If you want to build it manually (for example, because the lustre source is available
+ * but not installed into a standard path), you can do so like this:
+ *
+ *     # set based on the lustre source location on your machine:
+ *     $ export LUSTRE_INCLUDE_DIR=/home/$USER/lustre-release/lustre/include
+ *     $ export LUSTRE_LIBRARY_DIR=/home/$USER/lustre-release/lustre/utils/.libs
+ *
+ *     $ cd contrib
+ *
+ *     $ gcc -g -c -fPIC -I../build/deps/sqlite3/include -I../include -I$LUSTRE_INCLUDE_DIR -I$LUSTRE_INCLUDE_DIR/uapi lustre_plugin.c
+ *
+ *     $ gcc -shared -o liblustre_plugin.so lustre_plugin.o -L$LUSTRE_LIBRARY_DIR -llustreapi
+ *
+ *  Note that this includes the sqlite3 header from the GUFI sources, but this should not
+ *  statically link sqlite3. Instead, it should dynamically link to the sqlite3 symbols in
+ *  the main GUFI binary when this code is dlopen()ed.
+ *
+ *  Run like this:
+ *
+ *      # if the lustreapi library is not installed in a standard location:
+ *      $ export LD_LIBRARY_PATH=$LUSTRE_LIBRARY_DIR
+ *
+ *      $ cd build
+ *      $ ./src/gufi_dir2index -U ../contrib/liblustre_plugin.so -n1 /mnt/lustre /tmp/gufi_index/
+ */
+
+#include <errno.h>
+#include <inttypes.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "plugin.h"
+#include "sqlite3.h"
+#include "lustre/lustreapi.h"
+
+static char *my_basename(char *path) {
+    char *base = path;
+    char *p = path;
+    int next_component = 0;
+
+    while (*p) {
+        if (next_component) {
+            base = p;
+            next_component = 0;
+        }
+
+        if (*p == '/') {
+            next_component = 1;
+        }
+
+        p++;
+    }
+
+    return base;
+}
+
+/*
+ * This struct tracks the number of components seen on each OST. For each file
+ * processed, and for each component of that file, add one to the count for
+ * that particular OST.
+ */
+struct stripe_tracker {
+    /*
+     * num_components[i] stores the number of components that have been seen
+     * on the OST with index i.
+     */
+    uint64_t *stripe_count;
+    /*
+     * Stores the size of the num_components table. This needs to grow when we see a
+     * new OST number that is higher than the maximum index in the table so far.
+     */
+    uint32_t array_size;
+    /*
+     * Tracks the highest OST index seen. This will likely be smaller than the
+     * array size, so separately tracking it means we don't have to loop through the
+     * useless high indexes in the stripe_count array when saving the stripe info
+     * to the database.
+     */
+    uint32_t max_ost_idx;
+};
+
+/*
+ * Allocate and Initialize a new stripe_tracker.
+ */
+static struct stripe_tracker *new_stripe_tracker(void) {
+    uint32_t initial_size = 64;
+
+    struct stripe_tracker *new = malloc(sizeof *new);
+    if (!new) {
+        return NULL;
+    }
+
+    new->stripe_count = calloc(initial_size, sizeof(*new->stripe_count));
+    if (!new->stripe_count) {
+        free(new);
+        return NULL;
+    }
+
+    new->array_size = initial_size;
+
+    new->max_ost_idx = 0;
+
+    return new;
+}
+
+/*
+ * Clean up a stripe_tracker, freeing its allocations.
+ */
+static void destroy_stripe_tracker(struct stripe_tracker *p) {
+    if (p) {
+        free(p->stripe_count);
+    }
+
+    free(p);
+}
+
+/*
+ * If necessary, grow the stripe_count array in `s` to be large enough to
+ * accomodate `ost_index`.
+ *
+ * Returns 0 if growing succeeded, or 1 if it failed.
+ */
+static int grow_stripe_tracker(struct stripe_tracker *s, uint32_t ost_index) {
+    if (ost_index > s->max_ost_idx) {
+        s->max_ost_idx = ost_index;
+    }
+    if (ost_index < s->array_size) {
+        /* Nothing needs to be done: yay! */
+        return 0;
+    }
+
+    uint32_t new_size = s->array_size;
+
+    while (ost_index >= new_size) {
+        if (new_size >= UINT32_MAX / 2) {
+            /* In case we somehow get a filesystem with an insane number of OSTs,
+             * don't let that overflow and ruin our array: */
+            return 1;
+        }
+        new_size *= 2;
+    }
+
+    uint64_t *new_array = realloc(s->stripe_count, new_size);
+    if (!new_array) {
+        return 1;
+    }
+
+    /* The new space is not initialized, so do that now: */
+    memset(new_array + s->array_size, 0, new_size - s->array_size);
+
+    s->stripe_count = new_array;
+    s->array_size = new_size;
+
+    return 0;
+}
+
+/*
+ * Given the `stripe_array` which contains `stripe_count` stripes, increment
+ * the count for each OST that the stripe lives on.
+ */
+static void track_file_stripes(struct stripe_tracker *s,
+                               struct lov_user_ost_data_v1 *stripe_array,
+                               uint16_t stripe_count) {
+    for (int i = 0; i < stripe_count; i++) {
+        uint32_t ost_index = stripe_array[i].l_ost_idx;
+        if (grow_stripe_tracker(s, ost_index)) {
+            /* Just give up if we couldn't grow the stripe array large enough :( */
+            fprintf(stderr, "lustre plugin: could not allocate memory, information may be incomplete");
+            return;
+        }
+
+        s->stripe_count[ost_index] += 1;
+    }
+}
+
+/*
+ * Set up initial state for tracking Lustre stripe info.
+ */
+void *db_init(sqlite3 *db) {
+    struct stripe_tracker *state = new_stripe_tracker();
+    if (!state) {
+        fprintf(stderr, "lustre plugin: could not allocate memory to track stripe info");
+        return NULL;
+    }
+
+    char *text = "CREATE TABLE lustre_osts (ost_index INTEGER PRIMARY KEY, num_files INTEGER);"
+                 "CREATE TABLE lustre_fids (name TEXT, fid BLOB);";
+    char *error;
+
+    int res = sqlite3_exec(db, text, NULL, NULL, &error);
+    if (res != SQLITE_OK) {
+        fprintf(stderr, "lustre plugin: db_init(): error executing statement: %d %s\n", res, error);
+    }
+
+    sqlite3_free(error);
+
+    return state;
+}
+
+/*
+ * Save stripe tracking info to the database and clean up state.
+ */
+void db_exit(sqlite3 *db, void *user_data) {
+    struct stripe_tracker *state = (struct stripe_tracker *) user_data;
+
+    for (uint32_t i = 0; i <= state->max_ost_idx; i++) {
+        char *text = sqlite3_mprintf("INSERT INTO lustre_osts VALUES(%" PRIu32 ", %" PRIu64 ");",
+                i, state->stripe_count[i]);
+        char *error;
+
+        int res = sqlite3_exec(db, text, NULL, NULL, &error);
+        if (res != SQLITE_OK) {
+            fprintf(stderr, "lustre plugin: db_exit(): error executing statement: %d %s\n",
+                    res, error);
+        }
+
+        sqlite3_free(text);
+        sqlite3_free(error);
+    }
+
+    destroy_stripe_tracker(state);
+};
+
+/*
+ * This method of determining the maximum possible size of a `lov_user_md` was suggested by
+ *      man 3 llapi_file_get_stripe
+ */
+static const size_t v1_size = sizeof(struct lov_user_md_v1) + LOV_MAX_STRIPE_COUNT * sizeof(struct lov_user_ost_data_v1);
+static const size_t v3_size = sizeof(struct lov_user_md_v3) + LOV_MAX_STRIPE_COUNT * sizeof(struct lov_user_ost_data_v1);
+static const size_t lum_size = v1_size > v3_size ? v1_size : v3_size;
+
+static void *alloc_lum() {
+    return calloc(1, lum_size);
+}
+
+/*
+ * Insert an entry into the database "lustre_fids" table with the FID of this file or directory.
+ * For the entries in the directory described by this DB, the key is the entry name.
+ * For the directory itself, the key is the empty string, "".
+ */
+static void insert_fid(char *path, sqlite3 *db, void *user_data, int is_child_entry) {
+    struct lu_fid fid;
+    int res = llapi_path2fid(path, &fid);
+    if (res) {
+        fprintf(stderr, "lustre plugin: error getting FID for %s: %s\n",
+                path, strerror(errno));
+        return;
+    }
+
+    /* The key is either the entry name, or if this is for the directory itself, an empty string. */
+    if (is_child_entry) {
+        path = my_basename(path);
+    } else {
+        path = "";
+    }
+
+    char *text = sqlite3_mprintf("INSERT INTO lustre_fids (name, fid) VALUES('%s', (?));", path);
+    sqlite3_stmt *statement;
+    res = sqlite3_prepare_v2(db, text, -1, &statement, NULL);
+    if (res != SQLITE_OK) {
+        fprintf(stderr, "lustre plugin: process_dir(): error in sqlite3_prepare_v2(): %d\n", res);
+        goto out;
+    };
+
+    /*
+     * Interpret the FID as a string of bytes. This is a little bit fragile in that the FID is built
+     * of integers, not bytes, so this would break if a DB is read on a system with a different
+     * endianness than the system which wrote it. In practice, AFAIK Lustre only runs on little-endian
+     * systems so this should be fine.
+     */
+    void *data = &fid;
+    int len = sizeof fid;
+    res = sqlite3_bind_blob(statement, 1, data, len, SQLITE_STATIC);
+    if (res != SQLITE_OK) {
+        fprintf(stderr, "lustre plugin: process_dir(): error in sqlite3_bind_blob(): %d\n", res);
+        goto out_finalize;
+    };
+
+    res = sqlite3_step(statement);
+    if (res != SQLITE_DONE) {
+        fprintf(stderr, "lustre plugin: process_dir(): error in sqlite3_step(): %d\n", res);
+    };
+
+  out_finalize:
+    sqlite3_finalize(statement);
+
+  out:
+    sqlite3_free(text);
+}
+
+void process_file(char *path, sqlite3 *db, void *user_data) {
+    insert_fid(path, db, user_data, 1);
+
+    sqlite3_stmt *statement;
+
+    struct lov_user_md *layout_info = alloc_lum();
+
+    int res = llapi_file_get_stripe(path, layout_info);
+
+    if (res) {
+        fprintf(stderr, "lustre plugin: error getting stripe info for %s: %s\n",
+                path, strerror(errno));
+        free(layout_info);
+        return;
+    }
+
+    char *text = sqlite3_mprintf("UPDATE entries SET ossint4 = %d where name = '%q';",
+            layout_info->lmm_stripe_size, my_basename(path));
+    char *error;
+
+    res = sqlite3_exec(db, text, NULL, NULL, &error);
+    if (res != SQLITE_OK) {
+        fprintf(stderr, "lustre plugin: process_file(): error executing statement: %d %s\n",
+                res, error);
+        goto out;
+    }
+
+    struct lov_user_ost_data_v1 *stripe_array;
+    uint16_t stripe_count;
+
+    if (layout_info->lmm_magic == LOV_USER_MAGIC_V1) {
+        struct lov_user_md_v1 *v1= (struct lov_user_md_v1 *) layout_info;
+        stripe_array = v1->lmm_objects;
+        stripe_count = v1->lmm_stripe_count;
+    } else if (layout_info->lmm_magic == LOV_USER_MAGIC_V3) {
+        struct lov_user_md_v3 *v3= (struct lov_user_md_v3 *) layout_info;
+        stripe_array = v3->lmm_objects;
+        stripe_count = v3->lmm_stripe_count;
+    } else {
+        fprintf(stderr, "lustre plugin: unknown layout format on file %s: %d\n", path, layout_info->lmm_magic);
+        goto out;
+    }
+
+    struct stripe_tracker *tracker = (struct stripe_tracker *) user_data;
+    track_file_stripes(tracker, stripe_array, stripe_count);
+
+  out:
+    free(layout_info);
+    sqlite3_free(error);
+    sqlite3_free(text);
+}
+
+void process_dir(char *path, sqlite3 *db, void *user_data) {
+    insert_fid(path, db, user_data, 0);
+}
+
+struct plugin_operations GUFI_PLUGIN_SYMBOL = {
+    .db_init = db_init,
+    .process_dir = process_dir,
+    .process_file = process_file,
+    .db_exit = db_exit,
+};

--- a/include/bf.h
+++ b/include/bf.h
@@ -70,6 +70,7 @@ OF SUCH DAMAGE.
 
 #include "SinglyLinkedList.h"
 #include "compress.h"
+#include "plugin.h"
 #include "str.h"
 #include "trie.h"
 #include "xattrs.h"
@@ -286,6 +287,15 @@ struct input {
     * used by BottomUp programs
     */
    int check_already_processed;
+
+    /*
+    * Holds pointers to plugin functions for running custom user code to manipulate the databases.
+    * These will be NULL if no plugin was specified.
+    */
+   const struct plugin_operations *plugin_ops;
+
+   /* A handle to a plugin shared library, or NULL if no plugin is being used. */
+   void *plugin_handle;
 };
 
 struct input *input_init(struct input *in);

--- a/include/plugin.h
+++ b/include/plugin.h
@@ -1,0 +1,104 @@
+/*
+This file is part of GUFI, which is part of MarFS, which is released
+under the BSD license.
+
+
+Copyright (c) 2017, Los Alamos National Security (LANS), LLC
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation and/or
+other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors
+may be used to endorse or promote products derived from this software without
+specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+From Los Alamos National Security, LLC:
+LA-CC-15-039
+
+Copyright (c) 2017, Los Alamos National Security, LLC All rights reserved.
+Copyright 2017. Los Alamos National Security, LLC. This software was produced
+under U.S. Government contract DE-AC52-06NA25396 for Los Alamos National
+Laboratory (LANL), which is operated by Los Alamos National Security, LLC for
+the U.S. Department of Energy. The U.S. Government has rights to use,
+reproduce, and distribute this software.  NEITHER THE GOVERNMENT NOR LOS
+ALAMOS NATIONAL SECURITY, LLC MAKES ANY WARRANTY, EXPRESS OR IMPLIED, OR
+ASSUMES ANY LIABILITY FOR THE USE OF THIS SOFTWARE.  If software is
+modified to produce derivative works, such modified software should be
+clearly marked, so as not to confuse it with the version available from
+LANL.
+
+THIS SOFTWARE IS PROVIDED BY LOS ALAMOS NATIONAL SECURITY, LLC AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL LOS ALAMOS NATIONAL SECURITY, LLC OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+OF SUCH DAMAGE.
+*/
+
+#ifndef PLUGIN_H
+#define PLUGIN_H
+
+#include <sqlite3.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * Plugins should create a `struct plugin_operations` with this name to be exported to the
+ * GUFI code.
+  */
+#define GUFI_PLUGIN_SYMBOL gufi_plugin_operations
+#define GUFI_PLUGIN_SYMBOL_STR "gufi_plugin_operations"
+
+/*
+ * Operations for a user-defined plugin library, allowing the user to make custom
+ * modifications to the databases as GUFI runs.
+ */
+struct plugin_operations {
+    /*
+     * Give the user an opportunity to initialize any state. The returned pointer
+     * is passed to all subsequent operations as `user_data`.
+     */
+    void *(*db_init)(sqlite3 *db);
+    /* Process a directory. */
+    void (*process_dir)(char *path, sqlite3 *db, void *user_data);
+    /* Process a file */
+    void (*process_file)(char *path, sqlite3 *db, void *user_data);
+    /*
+     * Clean up any state, and write out any final data to the database, for example
+     * a summary containing information from each of the files seen.
+     */
+    void (*db_exit)(sqlite3 *db, void *user_data);
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -116,6 +116,8 @@ if (QPTPOOL_SWAP)
   )
 endif()
 
+set(CMAKE_ENABLE_EXPORTS TRUE)
+
 add_library(GUFI STATIC ${GUFI_SOURCES})
 add_dependencies(GUFI install_dependencies)
 target_compile_definitions(GUFI PUBLIC SQLITE_CORE)

--- a/src/gufi_dir2index.c
+++ b/src/gufi_dir2index.c
@@ -149,13 +149,6 @@ static int process_nondir(struct work *entry, struct entry_data *ed, void *args)
         external_read_file(in, entry, process_external, nda->db);
     }
 
-    /* get entry relative path (use extra buffer to prevent memcpy overlap) */
-    char relpath[MAXPATH];
-    const size_t relpath_len = SNFORMAT_S(relpath, MAXPATH, 1,
-                                          entry->name + entry->root_parent.len, entry->name_len - entry->root_parent.len);
-    /* overwrite full path with relative path */
-    entry->name_len = SNFORMAT_S(entry->name, MAXPATH, 1, relpath, relpath_len);
-
     /* update summary table */
     sumit(&nda->summary, entry, ed);
 

--- a/test/regression/CMakeLists.txt
+++ b/test/regression/CMakeLists.txt
@@ -90,6 +90,7 @@ set(BINARIES
   gufi_query
   gufi_stat_bin
   querydbs
+  gufi_plugin
 
   gufi_vt
   run_vt

--- a/test/regression/gufi_dir2index.expected
+++ b/test/regression/gufi_dir2index.expected
@@ -13,6 +13,7 @@ options:
   -M <bytes>             target memory footprint
   -s <path>              File name prefix for swap files
   -C <count>             Number of subdirectories allowed to be enqueued for parallel processing. Any remainders will be processed in-situ
+  -U <library_name>      plugin library for modifying db entries
   -e                     compress work items
   -q                     check that external databases are valid before tracking during indexing
   -D <filename>          File containing paths at single level to index (not including starting path). Must also use -y

--- a/test/regression/gufi_plugin.expected
+++ b/test/regression/gufi_plugin.expected
@@ -1,0 +1,21 @@
+$ gufi_dir2index -U gufi_test_plugin -x prefix search
+Creating GUFI Index search with 1 threads
+Total Dirs:          6
+Total Non-Dirs:      14
+
+
+# test plugin summary output:
+$ gufi_query -d " " -E "SELECT * FROM plugin_test_summary;" prefix
+directory 1
+directory 1
+directory 1
+directory 1
+directory 1
+directory 1
+file 0
+file 1
+file 2
+file 2
+file 3
+file 6
+

--- a/test/regression/gufi_plugin.sh.in
+++ b/test/regression/gufi_plugin.sh.in
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 # This file is part of GUFI, which is part of MarFS, which is released
 # under the BSD license.
 #
@@ -60,71 +61,26 @@
 
 
 
-# allow for the test working directory to be moved
-set(TEST_WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}" CACHE PATH "Directory to run tests in")
-execute_process(COMMAND "${CMAKE_COMMAND}" -E make_directory "${TEST_WORKING_DIRECTORY}"
-    COMMAND_ERROR_IS_FATAL ANY)
+set -e
+source @CMAKE_CURRENT_BINARY_DIR@/setup.sh 1
 
-# add regression tests
-add_subdirectory(regression)
+OUTPUT="gufi_plugin.out"
 
-# make sure unit tests work first
-add_subdirectory(unit)
+(
+# remove preexisting indicies
+rm -rf "${SEARCH}"
 
-# copy test scripts into the test directory within the build directory
-# list these explicitly to prevent random garbage from getting in
-foreach(TEST
-    bfwiflat2gufitest
-    dfw2gufitest
-    gitest.py
-    gufitest.py
-    robinhoodin
-    runbffuse
-    runbfq
-    runbfqforfuse
-    runbfti
-    runbfwi
-    runbfwreaddirplus2db
-    runbfwreaddirplus2db.orig
-    rundfw
-    rungenuidgidsummaryavoidentriesscan
-    rungroupfilespacehog
-    rungroupfilespacehogusesummary
-    runlistschemadb
-    runlisttablesdb
-    runoldbigfiles
-    runquerydbs
-    runuidgidsummary
-    runuidgidummary
-    runuserfilespacehog
-    runuserfilespacehogusesummary
-    runtests
-  )
-  # copy the script into the build directory for easy access
-  configure_file("${TEST}" "${TEST}" @ONLY)
-endforeach()
+# generate the index
+run_no_sort "${GUFI_DIR2INDEX} -U ${GUFI_TEST_PLUGIN} -x ${SRCDIR} ${SEARCH}"
 
-set(TESTTAR "${CMAKE_CURRENT_SOURCE_DIR}/testdir.tar")
-set(TESTDIR "${TEST_WORKING_DIRECTORY}/testdir")
-set(TESTDST "${TEST_WORKING_DIRECTORY}/gary")
+echo
+echo "# test plugin summary output:"
 
-add_test(
-  NAME gary
-  COMMAND "${CMAKE_COMMAND}" -E env "PATH=${DEP_INSTALL_PREFIX}/sqlite3/bin:$ENV{PATH}" "${CMAKE_CURRENT_BINARY_DIR}/runtests" "${TESTTAR}" "${TESTDIR}" "${TESTDST}"
-  WORKING_DIRECTORY "${TEST_WORKING_DIRECTORY}")
-set_tests_properties(gary PROPERTIES LABELS "manual")
+# make sure the plugin_test_summary table has the expected values for file and directory count:
+# (`sort` needed to obtain predictable order of results)
+run_sort "${GUFI_QUERY} -d \" \" -E \"SELECT * FROM plugin_test_summary;\" ${INDEXROOT}"
 
-# add_test(NAME gufitest COMMAND gufitest.py all)
-# set_tests_properties(gufitest PROPERTIES LABELS manual)
+) | remove_indexing_time | replace | tee "${OUTPUT}"
 
-add_library(test_plugin SHARED test_plugin.c)
-
-if (APPLE OR DARWIN)
-  # Apple needs to be told to explicitly not try to resolve symbols at compile time when
-  # building the plugin. (They will be resolved dynamically when the plugin is dlopen()ed).
-  target_link_libraries(test_plugin -Wl,-undefined -Wl,dynamic_lookup)
-elseif(CYGWIN)
-  # Cygwin needs to use an "import library" (reference: https://cygwin.com/cygwin-ug-net/dll.html)
-  # to get the symbol definitions it uses from gufi_dir2index.
-  target_link_libraries(test_plugin "${CMAKE_BINARY_DIR}/src/libgufi_dir2index.dll.a")
-endif()
+@DIFF@ @CMAKE_CURRENT_BINARY_DIR@/gufi_plugin.expected "${OUTPUT}"
+rm "${OUTPUT}"

--- a/test/regression/setup.sh.in
+++ b/test/regression/setup.sh.in
@@ -192,6 +192,17 @@ GUFI_QUERY_DISTRIBUTED="@CMAKE_BINARY_DIR@/scripts/distributed/gufi_query"
 GUFI_ROLLUP_DISTRIBUTED="@CMAKE_BINARY_DIR@/scripts/distributed/gufi_rollup"
 GUFI_TREESUMMARY_ALL_DISTRIBUTED="@CMAKE_BINARY_DIR@/scripts/distributed/gufi_treesummary_all"
 
+# test plugin path depends on the environment:
+# shellcheck disable=SC2194
+case "@CMAKE_SYSTEM_NAME@" in
+    "APPLE" | "Darwin")
+        GUFI_TEST_PLUGIN="@CMAKE_BINARY_DIR@/test/libtest_plugin.dylib"
+        ;;
+    "Linux" | "CYGWIN")
+        GUFI_TEST_PLUGIN="@CMAKE_BINARY_DIR@/test/libtest_plugin.so"
+        ;;
+esac
+
 AWK="@AWK@"
 COLUMN="@COLUMN@"
 DIFF="@DIFF@"
@@ -240,6 +251,7 @@ replace() {
     s/${GUFI_STAT//\//\\/}/gufi_stat/g;
     s/${GUFI_STATS//\//\\/}/gufi_stats/g;
     s/${GUFI_STAT_BIN//\//\\/}/gufi_stat_bin/g
+    s/${GUFI_TEST_PLUGIN//\//\\/}/gufi_test_plugin/g;
     s/${GUFI_TRACE2DIR//\//\\/}/gufi_trace2dir/g;
     s/${GUFI_TRACE2INDEX//\//\\/}/gufi_trace2index/g;
     s/${GUFI_TREESUMMARY//\//\\/}/gufi_treesummary/g;

--- a/test/test_plugin.c
+++ b/test/test_plugin.c
@@ -1,0 +1,175 @@
+/*
+This file is part of GUFI, which is part of MarFS, which is released
+under the BSD license.
+
+
+Copyright (c) 2017, Los Alamos National Security (LANS), LLC
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation and/or
+other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors
+may be used to endorse or promote products derived from this software without
+specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+From Los Alamos National Security, LLC:
+LA-CC-15-039
+
+Copyright (c) 2017, Los Alamos National Security, LLC All rights reserved.
+Copyright 2017. Los Alamos National Security, LLC. This software was produced
+under U.S. Government contract DE-AC52-06NA25396 for Los Alamos National
+Laboratory (LANL), which is operated by Los Alamos National Security, LLC for
+the U.S. Department of Energy. The U.S. Government has rights to use,
+reproduce, and distribute this software.  NEITHER THE GOVERNMENT NOR LOS
+ALAMOS NATIONAL SECURITY, LLC MAKES ANY WARRANTY, EXPRESS OR IMPLIED, OR
+ASSUMES ANY LIABILITY FOR THE USE OF THIS SOFTWARE.  If software is
+modified to produce derivative works, such modified software should be
+clearly marked, so as not to confuse it with the version available from
+LANL.
+
+THIS SOFTWARE IS PROVIDED BY LOS ALAMOS NATIONAL SECURITY, LLC AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL LOS ALAMOS NATIONAL SECURITY, LLC OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+OF SUCH DAMAGE.
+*/
+
+
+
+/*
+ * A simple plugin for gufi_dir2index used for testing purposes.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "plugin.h"
+#include "sqlite3.h"
+
+struct state {
+    int n_files;
+    int n_dirs;
+};
+
+static struct state *new_state(void) {
+    struct state *new = calloc(1, sizeof *new);
+
+    return new;
+}
+
+static void cleanup_state(struct state *p) {
+    free(p);
+}
+
+/*
+ * Set up initial state for test plugin.
+ */
+static void *db_init(sqlite3 *db) {
+    struct state *state = new_state();
+
+    char *text = "CREATE TABLE plugin_test_files (id INTEGER PRIMARY KEY AUTOINCREMENT, filename TEXT);"
+        "CREATE TABLE plugin_test_directories (id INTEGER PRIMARY KEY AUTOINCREMENT, dirname TEXT);"
+        "CREATE TABLE plugin_test_summary (filetype TEXT PRIMARY KEY, count INTEGER, CHECK (filetype IN ('file', 'directory')));";
+    char *error;
+
+    int res = sqlite3_exec(db, text, NULL, NULL, &error);
+    if (res != SQLITE_OK) {
+        fprintf(stderr, "test plugin: db_init(): error executing statement: %d %s\n", res, error);
+    }
+
+    sqlite3_free(error);
+
+    return state;
+}
+
+/*
+ * Save state to the database and clean up state.
+ */
+static void db_exit(sqlite3 *db, void *user_data) {
+    struct state *p = (struct state *) user_data;
+
+    char *text = sqlite3_mprintf("INSERT INTO plugin_test_summary (filetype, count) VALUES ('file', %d);"
+            "INSERT INTO plugin_test_summary (filetype, count) VALUES ('directory', %d);",
+            p->n_files, p->n_dirs);
+    char *error;
+
+    int res = sqlite3_exec(db, text, NULL, NULL, &error);
+    if (res != SQLITE_OK) {
+        fprintf(stderr, "test plugin: db_exit(): error executing statement: %d %s\n",
+                res, error);
+    }
+
+    sqlite3_free(text);
+    sqlite3_free(error);
+
+    cleanup_state(p);
+}
+
+static void process_file(char *path, sqlite3 *db, void *user_data) {
+    struct state *p = (struct state *) user_data;
+
+    char *text = sqlite3_mprintf("INSERT INTO plugin_test_files (filename) VALUES ('%s');", path);
+    char *error;
+
+    int res = sqlite3_exec(db, text, NULL, NULL, &error);
+    if (res == SQLITE_OK) {
+        p->n_files += 1;
+    } else {
+        fprintf(stderr, "test plugin: process_file(): error executing statement: %d %s\n",
+                res, error);
+    }
+
+    sqlite3_free(text);
+    sqlite3_free(error);
+}
+
+static void process_dir(char *path, sqlite3 *db, void *user_data) {
+    struct state *p = (struct state *) user_data;
+
+    char *text = sqlite3_mprintf("INSERT INTO plugin_test_directories (dirname) VALUES ('%s');", path);
+    char *error;
+
+    int res = sqlite3_exec(db, text, NULL, NULL, &error);
+    if (res == SQLITE_OK) {
+        p->n_dirs += 1;
+    } else {
+        fprintf(stderr, "test plugin: process_dir(): error executing statement: %d %s\n",
+                res, error);
+    }
+
+    sqlite3_free(text);
+    sqlite3_free(error);
+}
+
+struct plugin_operations GUFI_PLUGIN_SYMBOL = {
+    .db_init = db_init,
+    .process_dir = process_dir,
+    .process_file = process_file,
+    .db_exit = db_exit,
+};


### PR DESCRIPTION
This change adds the ability to pass a plugin library to run user-specific code during gufi_dir2index.

The plugin included here gathers Lustre stripe information and FIDs for each file/directory and stores it into the sqlite3 database.