### PR TITLE
argument parser

### DIFF
--- a/contrib/stats/snapshot.py
+++ b/contrib/stats/snapshot.py
@@ -125,9 +125,9 @@ def parse_args(argv, now):
                         help='path to gufi_query executable')
     parser.add_argument('--threads', '-n',   metavar='count',   type=get_positive,     default=1,
                         help='thread count')
-    parser.add_argument('--min-level', '-y', metavar='level',   type=get_non_negative, default=0,
+    parser.add_argument('--min-level', metavar='level',   type=get_non_negative, default=0,
                         help='level to start querying (min_level <= current_level)')
-    parser.add_argument('--max-level', '-z', metavar='level',   type=get_non_negative, default=(1 << 64) - 1,
+    parser.add_argument('--max-level', metavar='level',   type=get_non_negative, default=(1 << 64) - 1,
                         help='level to stop querying (current_level < max_level)')
 
     return parser.parse_args(argv[1:])
@@ -379,8 +379,8 @@ def flatten_index(args):                         # pylint: disable=too-many-loca
         args.gufi_query,
         '-n', str(args.threads),
         '-x',
-        '-y', str(args.min_level),
-        '-z', str(args.max_level),
+        '--min-level', str(args.min_level),
+        '--max-level', str(args.max_level),
         '-O', args.flatdb,
         '-I', I,
         '-T', T,

--- a/contrib/treediff.c
+++ b/contrib/treediff.c
@@ -346,8 +346,11 @@ static void sub_help(void) {
 }
 
 int main(int argc, char *argv[]) {
+    const struct option options[] = {
+        FLAG_HELP, FLAG_DEBUG, FLAG_THREADS, FLAG_MAX_LEVEL, FLAG_SKIP, FLAG_END
+    };
     struct PoolArgs pa;
-    int idx = parse_cmd_line(argc, argv, "hHn:z:k:", 2, "lhs rhs", &pa.in);
+    int idx = parse_cmd_line(argc, argv, options, 2, "lhs rhs", &pa.in);
     if (pa.in.helped)
         sub_help();
     if (idx < 0)

--- a/docs/gufi_query
+++ b/docs/gufi_query
@@ -78,28 +78,42 @@ gufi_query - breadth first walk of a GUFI tree.  We optionally perform queries
 
 Usage: gufi_query [options] GUFI_tree ...
 options:
-  -h                 help
-  -H                 show assigned input values (debugging)
-  -T <SQL_tsum>      SQL for tree-summary table
-  -S <SQL_sum>       SQL for summary table
-  -E <SQL_ent>       SQL for entries table
-  -P                 print directories as they are encountered
-  -a                 AND/OR (SQL query combination)
-  -p                 print file-names
-  -n <threads>       number of threads
-  -o <out_fname>     output file (one-per-thread, with thread-id suffix), implies -e 1
-  -d <delim>         delimiter (one char)  [use 'x' for 0x1E]
-  -O <out_DB>        output DB, implies -e 1
-  -I <SQL_init>      SQL init
-  -F <SQL_fin>       SQL cleanup
-  -y <min level>     minimum level to go down
-  -z <max level>     maximum level to go down
-  -G <SQL_aggregate> SQL for aggregated results (deaults to "SELECT * FROM entries")
-  -J <SQL_interm>    SQL for intermediate results (deaults to "SELECT * FROM entries")
-  -e <0 or 1>        0 for aggregate, 1 for print without aggregating (implied by -o and -O)
-  -m                 Keep mtime and atime same on the database files
-  -B <buffer size>   size of each thread's output buffer in bytes
-  -w                 open the database files in read-write mode instead of read only mode
+  -h, --help                        help
+  -H, --debug                       show assigned input values (debugging)
+  -v, --version                     version
+  -T <SQL_tsum>                     SQL for tree-summary table
+  -S <SQL_sum>                      SQL for summary table
+  -E <SQL_ent>                      SQL for entries table
+  -a <0|1|2>                        0 - if returned row, run next SQL, else stop (continue descent) (default)
+                                    1 - skip T, run S and E whether or not a row was returned (old -a)
+                                    2 - run T, S, and E whether or not a row was returned
+  -n, --threads <threads>           number of threads
+  -j, --terse-form                  print the information in terse form
+  -o, --output-file <out_fname>     output file (one-per-thread, with thread-id suffix)
+  -d, --delim <delim>               delimiter (one char)  [use 'x' for 0x1E]
+  -O, --output-db <out_DB>          output DB
+  -u                                prefix row with 1 int column count and each column with 1 octet type and 1 size_t length
+  -I <SQL_init>                     SQL init
+  -F <SQL_fin>                      SQL cleanup
+      --min-level <min level>       minimum level to go down
+      --max-level <max level>       maximum level to go down
+  -J <SQL_interm>                   SQL for intermediate results
+  -K <create aggregate>             SQL to create the final aggregation table
+  -G <SQL_aggregate>                SQL for aggregated results
+  -m                                Keep mtime and atime same on the database files
+  -B, --buffer-size <buffer size>   size of each thread's output buffer in bytes
+  -w, --read-write                  open the database files in read-write mode instead of read only mode
+  -x, --xattrs                      index/query xattrs
+  -k, --skip <filename>             file containing directory names to skip
+  -M <bytes>                        target memory footprint
+  -s, --swap-prefix <path>          File name prefix for swap files
+  -p, --path <path>                 Source path prefix for %s in SQL
+  -e                                compress work items
+  -Q <basename>
+     <table>
+     <template>.<table>
+     <view>                         External database file basename, per-attach table name, template + table name, and the resultant view
+  -D <filename>                     File containing paths at single level to index (not including starting path). Must also use --min-level
 
 GUFI_tree         find GUFI index-tree here
 

--- a/include/bf.h
+++ b/include/bf.h
@@ -65,6 +65,7 @@ OF SUCH DAMAGE.
 #ifndef BF_H
 #define BF_H
 
+#include <getopt.h>
 #include <inttypes.h>
 #include <stdlib.h> /* EXIT_SUCCESS and EXIT_FAILURE */
 #include <sys/stat.h>
@@ -87,6 +88,174 @@ extern "C" {
 #define DBNAME "db.db"
 #define DBNAME_LEN (sizeof(DBNAME) - 1)
 #define GETLINE_DEFAULT_SIZE 750 /* magic number */
+
+#define FLAG_HELP_SHORT 'h'
+#define FLAG_HELP_LONG "help"
+#define FLAG_HELP {FLAG_HELP_LONG, no_argument, NULL, FLAG_HELP_SHORT}
+
+#define FLAG_DEBUG_SHORT 'H'
+#define FLAG_DEBUG_LONG "debug"
+#define FLAG_DEBUG {FLAG_DEBUG_LONG, no_argument, NULL, FLAG_DEBUG_SHORT}
+
+#define FLAG_VERSION_SHORT 'v'
+#define FLAG_VERSION_LONG "version"
+#define FLAG_VERSION {FLAG_VERSION_LONG, no_argument, NULL, FLAG_VERSION_SHORT}
+
+#define FLAG_XATTRS_SHORT 'x'
+#define FLAG_XATTRS_LONG "xattrs"
+#define FLAG_XATTRS {FLAG_XATTRS_LONG, no_argument, NULL, FLAG_XATTRS_SHORT}
+
+#define FLAG_PRINTDIR_SHORT 'P'
+#define FLAG_PRINTDIR {"", no_argument, NULL, FLAG_PRINTDIR_SHORT}
+
+#define FLAG_BUILDINDEX_SHORT 'b'
+#define FLAG_BUILDINDEX {"", no_argument, NULL, FLAG_BUILDINDEX_SHORT}
+
+#define FLAG_PROCESS_SQL_SHORT 'a'
+#define FLAG_PROCESS_SQL {"", required_argument, NULL, FLAG_PROCESS_SQL_SHORT}
+
+#define FLAG_THREADS_SHORT 'n'
+#define FLAG_THREADS_LONG "threads"
+#define FLAG_THREADS {FLAG_THREADS_LONG, required_argument, NULL, FLAG_THREADS_SHORT}
+
+#define FLAG_DELIM_SHORT 'd'
+#define FLAG_DELIM_LONG "delim"
+#define FLAG_DELIM {FLAG_DELIM_LONG, required_argument, NULL, FLAG_DELIM_SHORT}
+
+#define FLAG_OUTPUT_FILE_SHORT 'o'
+#define FLAG_OUTPUT_FILE_LONG "output-file"
+#define FLAG_OUTPUT_FILE {FLAG_OUTPUT_FILE_LONG, required_argument, NULL, FLAG_OUTPUT_FILE_SHORT}
+
+#define FLAG_OUTPUT_DB_SHORT 'O'
+#define FLAG_OUTPUT_DB_LONG "output-db"
+#define FLAG_OUTPUT_DB {FLAG_OUTPUT_DB_LONG, required_argument, NULL, FLAG_OUTPUT_DB_SHORT}
+
+#define FLAG_PREFIX_SHORT 'u'
+#define FLAG_PREFIX {"", no_argument, NULL, FLAG_PREFIX_SHORT}
+
+#define FLAG_SQL_INIT_SHORT 'I'
+#define FLAG_SQL_INIT {"", required_argument, NULL, FLAG_SQL_INIT_SHORT}
+
+#define FLAG_SQL_TSUM_SHORT 'T'
+#define FLAG_SQL_TSUM {"", required_argument, NULL, FLAG_SQL_TSUM_SHORT}
+
+#define FLAG_SQL_SUM_SHORT 'S'
+#define FLAG_SQL_SUM {"", required_argument, NULL, FLAG_SQL_SUM_SHORT}
+
+#define FLAG_SQL_ENT_SHORT 'E'
+#define FLAG_SQL_ENT {"", required_argument, NULL, FLAG_SQL_ENT_SHORT}
+
+#define FLAG_SQL_FIN_SHORT 'F'
+#define FLAG_SQL_FIN {"", required_argument, NULL, FLAG_SQL_FIN_SHORT}
+
+#define FLAG_INSERT_FILE_LINK_SHORT 'r'
+#define FLAG_INSERT_FILE_LINK {"", no_argument, NULL, FLAG_INSERT_FILE_LINK_SHORT}
+
+#define FLAG_INSERT_DIR_SHORT 'R'
+#define FLAG_INSERT_DIR {"", no_argument, NULL, FLAG_INSERT_DIR_SHORT}
+
+#define FLAG_SUSPECT_DIR_SHORT 'Y'
+#define FLAG_SUSPECT_DIR {"", no_argument, NULL, FLAG_SUSPECT_DIR_SHORT}
+
+#define FLAG_SUSPECT_FILE_LINK_SHORT 'Z'
+#define FLAG_SUSPECT_FILE_LINK {"", no_argument, NULL, FLAG_SUSPECT_FILE_LINK_SHORT}
+
+#define FLAG_INSUSPECT_SHORT 'W'
+#define FLAG_INSUSPECT {"", required_argument, NULL, FLAG_INSUSPECT_SHORT}
+
+#define FLAG_SUSPECT_METHOD_SHORT 'A'
+#define FLAG_SUSPECT_METHOD {"", required_argument, NULL, FLAG_SUSPECT_METHOD_SHORT}
+
+#define FLAG_STRIDE_SHORT 'g'
+#define FLAG_STRIDE {"", required_argument, NULL, FLAG_STRIDE_SHORT}
+
+#define FLAG_SUSPECT_TIME_SHORT 'c'
+#define FLAG_SUSPECT_TIME {"", required_argument, NULL, FLAG_SUSPECT_TIME_SHORT}
+
+#define FLAG_SQL_INTERM_SHORT 'J'
+#define FLAG_SQL_INTERM {"", required_argument, NULL, FLAG_SQL_INTERM_SHORT}
+
+#define FLAG_SQL_CREATE_AGG_SHORT 'K'
+#define FLAG_SQL_CREATE_AGG {"", required_argument, NULL, FLAG_SQL_CREATE_AGG_SHORT}
+
+#define FLAG_SQL_AGG_SHORT 'G'
+#define FLAG_SQL_AGG {"", required_argument, NULL, FLAG_SQL_AGG_SHORT}
+
+#define FLAG_KEEP_MATIME_SHORT 'm'
+#define FLAG_KEEP_MATIME {"", no_argument, NULL, FLAG_KEEP_MATIME_SHORT}
+
+#define FLAG_BUFFER_SIZE_SHORT 'B'
+#define FLAG_BUFFER_SIZE_LONG "buffer-size"
+#define FLAG_BUFFER_SIZE {FLAG_BUFFER_SIZE_LONG, required_argument, NULL, FLAG_BUFFER_SIZE_SHORT}
+
+#define FLAG_READ_WRITE_SHORT 'w'
+#define FLAG_READ_WRITE_LONG "read-write"
+#define FLAG_READ_WRITE {FLAG_READ_WRITE_LONG, no_argument, NULL, FLAG_READ_WRITE_SHORT}
+
+#define FLAG_FORMAT_SHORT 'f'
+#define FLAG_FORMAT_LONG "format"
+#define FLAG_FORMAT {FLAG_FORMAT_LONG, required_argument, NULL, FLAG_FORMAT_SHORT}
+
+#define FLAG_TERSE_FORMAT_SHORT 'j'
+#define FLAG_TERSE_FORMAT_LONG "terse-format"
+#define FLAG_TERSE_FORMAT {FLAG_TERSE_FORMAT_LONG, no_argument, NULL, FLAG_TERSE_FORMAT_SHORT}
+
+#define FLAG_DRY_RUN_SHORT 'X'
+#define FLAG_DRY_RUN_LONG "dry-run"
+#define FLAG_DRY_RUN {FLAG_DRY_RUN_LONG, no_argument, NULL, FLAG_DRY_RUN_SHORT}
+
+#define FLAG_MAX_IN_DIR_SHORT 'L'
+#define FLAG_MAX_IN_DIR {"", required_argument, NULL, FLAG_MAX_IN_DIR_SHORT}
+
+#define FLAG_SKIP_SHORT 'k'
+#define FLAG_SKIP_LONG "skip"
+#define FLAG_SKIP {FLAG_SKIP_LONG, required_argument, NULL, FLAG_SKIP_SHORT}
+
+#define FLAG_TARGET_MEMORY_FOOTPRINT_SHORT 'M'
+#define FLAG_TARGET_MEMORY_FOOTPRINT {"", required_argument, NULL, FLAG_TARGET_MEMORY_FOOTPRINT_SHORT}
+
+#define FLAG_SUBDIR_LIMIT_SHORT 'C'
+#define FLAG_SUBDIR_LIMIT {"", required_argument, NULL, FLAG_SUBDIR_LIMIT_SHORT}
+
+#define FLAG_COMPRESS_SHORT 'e'
+#define FLAG_COMPRESS {"", no_argument, NULL, FLAG_COMPRESS_SHORT}
+
+#define FLAG_CHECK_EXTDB_VALID_SHORT 'q'
+#define FLAG_CHECK_EXTDB_VALID {"", no_argument, NULL, FLAG_CHECK_EXTDB_VALID_SHORT}
+
+#define FLAG_EXTERNAL_ATTACH_SHORT 'Q'
+#define FLAG_EXTERNAL_ATTACH {"", required_argument, NULL, FLAG_EXTERNAL_ATTACH_SHORT}
+
+#define FLAG_SWAP_PREFIX_SHORT 's'
+#define FLAG_SWAP_PREFIX_LONG "swap-prefix"
+#define FLAG_SWAP_PREFIX {FLAG_SWAP_PREFIX_LONG, required_argument, NULL, FLAG_SWAP_PREFIX_SHORT}
+
+#define FLAG_PATH_SHORT 'p'
+#define FLAG_PATH_LONG "path"
+#define FLAG_PATH {FLAG_PATH_LONG, required_argument, NULL, FLAG_PATH_SHORT}
+
+#define FLAG_SUBTREE_LIST_SHORT 'D'
+#define FLAG_SUBTREE_LIST {"", required_argument, NULL, FLAG_SUBTREE_LIST_SHORT}
+
+#define FLAG_ALREADY_PROCESSED_SHORT 'l'
+#define FLAG_ALREADY_PROCESSED {"", no_argument, NULL, FLAG_ALREADY_PROCESSED_SHORT}
+
+#define FLAG_PLUGIN_SHORT 'U'
+#define FLAG_PLUGIN {"", required_argument, NULL, FLAG_PLUGIN_SHORT}
+
+#define FLAG_FILTER_TYPE_SHORT 't'
+#define FLAG_FILTER_TYPE_LONG "filter-type"
+#define FLAG_FILTER_TYPE {FLAG_FILTER_TYPE_LONG, required_argument, NULL, FLAG_FILTER_TYPE_SHORT}
+
+#define FLAG_MIN_LEVEL_SHORT 1000
+#define FLAG_MIN_LEVEL_LONG "min-level"
+#define FLAG_MIN_LEVEL {FLAG_MIN_LEVEL_LONG, required_argument, NULL, FLAG_MIN_LEVEL_SHORT}
+
+#define FLAG_MAX_LEVEL_SHORT 1001
+#define FLAG_MAX_LEVEL_LONG "max-level"
+#define FLAG_MAX_LEVEL {FLAG_MAX_LEVEL_LONG, required_argument, NULL, FLAG_MAX_LEVEL_SHORT}
+
+#define FLAG_END {NULL, 0, NULL, 0}
 
 struct sum {
     long long int totfiles;
@@ -153,179 +322,181 @@ typedef enum OutputMethod {
 } OutputMethod_t;
 
 enum filter_type {
-  FILTER_TYPE_FILE = 1,
-  FILTER_TYPE_DIR  = 2,
-  FILTER_TYPE_LINK = 4
+    FILTER_TYPE_FILE = 1,
+    FILTER_TYPE_DIR  = 2,
+    FILTER_TYPE_LINK = 4
 };
 
 struct input {
-   refstr_t  name;
-   refstr_t  nameto;
-   int process_xattrs;
-   struct {
-       uid_t uid;
-       gid_t gid;
-   } nobody;
+    refstr_t  name;
+    refstr_t  nameto;
+    int process_xattrs;
+    struct {
+        uid_t uid;
+        gid_t gid;
+    } nobody;
 
-   struct {
-       /* set up per-thread intermidate tables */
-       refstr_t init;
+    struct {
+        /* set up per-thread intermidate tables */
+        refstr_t init;
 
-       refstr_t tsum;
-       refstr_t sum;
-       refstr_t ent;
+        refstr_t tsum;
+        refstr_t sum;
+        refstr_t ent;
 
-       /* if not aggregating, output results */
-       /* if aggregating, insert into aggregate table */
-       refstr_t intermediate;
+        /* if not aggregating, output results */
+        /* if aggregating, insert into aggregate table */
+        refstr_t intermediate;
 
-       /* set up final aggregation table */
-       refstr_t init_agg;
+        /* set up final aggregation table */
+        refstr_t init_agg;
 
-       /* query table containing aggregated results */
-       refstr_t agg;
+        /* query table containing aggregated results */
+        refstr_t agg;
 
-       refstr_t fin;
-   } sql;
+        refstr_t fin;
+    } sql;
 
-   refstr_t source_prefix; /* for {s} and spath() since the source directory is not stored in the index */
-
-   /*
-    * if the SQL has any formatting in it,
-    * store (at least) the positions of the
-    * first character being replaced
-    *
-    * each item should be malloc-ed
-    */
-   struct {
-       sll_t tsum;
-       sll_t sum;
-       sll_t ent;
-   } sql_format;
-
-   /*
-    * if outputting to STDOUT or OUTFILE, get list of
-    * types of final output to prefix columns with
-    *
-    * set up by gufi_query but cleaned up by input_fini
-    */
-   struct {
-       int prefix;
-
-       /* set if not aggregating */
-       int *tsum;
-       int *sum;
-       int *ent;
-
-       /* set if aggregating */
-       int *agg;
-   } types;
-
-   int  printdir;
-   int  helped;               /* support parsing of per-app sub-options */
-   int  printed_version;
-   char delim;
-   int  buildindex;
-   size_t maxthreads;
-   AFlag_t process_sql;       /* what to do if an SQL statement returns/doesn't return 1 row */
-   int  insertdir;                // added for bfwreaddirplus2db
-   int  insertfl;                 // added for bfwreaddirplus2db
-   int  suspectd;                 // added for bfwreaddirplus2db for how to default suspect directories 0 - not supsect 1 - suspect
-   int  suspectfl;                // added for bfwreaddirplus2db for how to default suspect file/link 0 - not suspect 1 - suspect
-   refstr_t insuspect;            // added for bfwreaddirplus2db input path for suspects file
-   int  suspectfile;              // added for bfwreaddirplus2db flag for if we are processing suspects file
-   int  suspectmethod;            // added for bfwreaddirplus2db flag for if we are processing suspects what method do we use
-   int  stride;                   // added for bfwreaddirplus2db stride size control striping inodes to output dbs default 0(nostriping)
-   int  suspecttime;              // added for bfwreaddirplus2db time for suspect comparison in seconds since epoch
-   size_t min_level;              // minimum level of recursion to reach before running queries
-   size_t max_level;              // maximum level of recursion to run queries on
-   int dry_run;
-
-   OutputMethod_t output;
-   refstr_t outname;
-
-   int keep_matime;
-
-   size_t output_buffer_size;
-   int open_flags;
-
-   /* used by gufi_query (cumulative times) and gufi_stat (regular output) */
-   int terse;
-
-   /* only used by gufi_stat */
-   int format_set;
-   refstr_t format;
-
-   /* only used by rollup */
-   size_t max_in_dir;
-
-   /* trie containing directory basenames to skip during tree traversal */
-   trie_t *skip;
-   size_t skip_count;
-
-   /* attempt to drain QPTPool work items until this memory footprint is reached */
-   uint64_t target_memory_footprint;
-
-   /*
-    * If a directory has more than this many subdirectories,
-    * subdirectories discovered past this number will be processed
-    * in-situ rather than in a separate thread.
-    *
-    * This is a size_t rather than a fixed width integer because if a
-    * directory has more than a few thousand subdirectories, it is
-    * probably too big.
-    */
-   size_t subdir_limit;
-
-   /* compress work items (if compression library was found) */
-   int compress;
-
-   /* check if a listed external db is valid when indexing (-q) */
-   int check_extdb_valid;
-
-   /* used when querying (-Q) */
-   sll_t external_attach;     /* list of eus_t */
-
-   /* prefix of swap files */
-   refstr_t swap_prefix;
-
-   /* directory paths to process at -y level > 0 */
-   refstr_t subtree_list;
-
-   /*
-    * if a directory has already been
-    * processed, do not descend further
-    *
-    * used by BottomUp programs
-    */
-   int check_already_processed;
+    refstr_t source_prefix; /* for {s} and spath() since the source directory is not stored in the index */
 
     /*
-    * Holds pointers to plugin functions for running custom user code to manipulate the databases.
-    * These will be NULL if no plugin was specified.
-    */
-   const struct plugin_operations *plugin_ops;
+     * if the SQL has any formatting in it,
+     * store (at least) the positions of the
+     * first character being replaced
+     *
+     * each item should be malloc-ed
+     */
+    struct {
+        sll_t tsum;
+        sll_t sum;
+        sll_t ent;
+    } sql_format;
 
-   /* A handle to a plugin shared library, or NULL if no plugin is being used. */
-   void *plugin_handle;
+    /*
+     * if outputting to STDOUT or OUTFILE, get list of
+     * types of final output to prefix columns with
+     *
+     * set up by gufi_query but cleaned up by input_fini
+     */
+    struct {
+        int prefix;
 
-   /* only used by parallel_find */
-   int filter_types;
+        /* set if not aggregating */
+        int *tsum;
+        int *sum;
+        int *ent;
+
+        /* set if aggregating */
+        int *agg;
+    } types;
+
+    int  printdir;
+    int  helped;                   /* support parsing of per-app sub-options */
+    int  printed_version;
+    char delim;
+    int  buildindex;
+    size_t maxthreads;
+    AFlag_t process_sql;           /* what to do if an SQL statement returns/doesn't return 1 row */
+    int  insertdir;                /* added for bfwreaddirplus2db */
+    int  insertfl;                 /* added for bfwreaddirplus2db */
+    int  suspectd;                 /* added for bfwreaddirplus2db for how to default suspect directories 0 - not supsect 1 - suspect */
+    int  suspectfl;                /* added for bfwreaddirplus2db for how to default suspect file/link 0 - not suspect 1 - suspect */
+    refstr_t insuspect;            /* added for bfwreaddirplus2db input path for suspects file */
+    int  suspectfile;              /* added for bfwreaddirplus2db flag for if we are processing suspects file */
+    int  suspectmethod;            /* added for bfwreaddirplus2db flag for if we are processing suspects what method do we use */
+    int  stride;                   /* added for bfwreaddirplus2db stride size control striping inodes to output dbs default 0(nostriping) */
+    int  suspecttime;              /* added for bfwreaddirplus2db time for suspect comparison in seconds since epoch */
+    size_t min_level;              /* minimum level of recursion to reach before running queries */
+    size_t max_level;              /* maximum level of recursion to run queries on */
+    int dry_run;
+
+    OutputMethod_t output;
+    refstr_t outname;
+
+    int keep_matime;
+
+    size_t output_buffer_size;
+    int open_flags;
+
+    /* used by gufi_query (cumulative times) and gufi_stat (regular output) */
+    int terse;
+
+    /* only used by gufi_stat */
+    int format_set;
+    refstr_t format;
+
+    /* only used by rollup */
+    size_t max_in_dir;
+
+    /* trie containing directory basenames to skip during tree traversal */
+    trie_t *skip;
+    size_t skip_count;
+
+    /* attempt to drain QPTPool work items until this memory footprint is reached */
+    uint64_t target_memory_footprint;
+
+    /*
+     * If a directory has more than this many subdirectories,
+     * subdirectories discovered past this number will be processed
+     * in-situ rather than in a separate thread.
+     *
+     * This is a size_t rather than a fixed width integer because if a
+     * directory has more than a few thousand subdirectories, it is
+     * probably too big.
+     */
+    size_t subdir_limit;
+
+    /* compress work items (if compression library was found) */
+    int compress;
+
+    /* check if a listed external db is valid when indexing (-q) */
+    int check_extdb_valid;
+
+    /* used when querying (-Q) */
+    sll_t external_attach;     /* list of eus_t */
+
+    /* prefix of swap files */
+    refstr_t swap_prefix;
+
+    /* directory paths to process at -y level > 0 */
+    refstr_t subtree_list;
+
+    /*
+     * if a directory has already been
+     * processed, do not descend further
+     *
+     * used by BottomUp programs
+     */
+    int check_already_processed;
+
+    /*
+     * Holds pointers to plugin functions for running custom user code to manipulate the databases.
+     * These will be NULL if no plugin was specified.
+     */
+    const struct plugin_operations *plugin_ops;
+
+    /* A handle to a plugin shared library, or NULL if no plugin is being used. */
+    void *plugin_handle;
+
+    /* only used by parallel_find */
+    int filter_types;
 };
 
 struct input *input_init(struct input *in);
 void input_fini(struct input *in);
 
 void print_help(const char *prog_name,
-                const char *getopt_str,
+                const struct option *options,
                 const char *positional_args_help_str);
 
 /* DEBUGGING */
 void show_input(struct input*in, int retval);
 
+char *build_getopt_str(const struct option *option);
+
 int parse_cmd_line(int         argc,
                    char       *argv[],
-                   const char *getopt_str,
+                   const struct option *options,
                    int         n_positional,
                    const char *positional_args_help_str,
                    struct input *in);
@@ -367,9 +538,9 @@ INSTALL_NUMBER_PROTOTYPE(SIZE, size_t, "%zu");
 INSTALL_NUMBER_PROTOTYPE(UINT64, uint64_t, "%" PRIu64);
 
 typedef enum {
-   DO_FREE   = 0x01,
-   CLOSE_DIR = 0x02,
-   CLOSE_DB  = 0x04,
+    DO_FREE   = 0x01,
+    CLOSE_DIR = 0x02,
+    CLOSE_DB  = 0x04,
 } CleanUpTasks;
 
 typedef enum {
@@ -389,25 +560,25 @@ typedef enum {
  * storage for name.
  */
 struct work {
-   compressed_t  compressed;
-   refstr_t      orig_root;              /* argv[i] */
-   refstr_t      root_parent;            /* dirname(realpath(argv[i])) */
-   size_t        root_basename_len;      /* strlen(basename(argv[i])) */
-   size_t        level;
-   char          *name;                  /* points to memory located after struct work */
-   size_t        name_len;               /* == strlen(name) - meaning excludes NUL! */
-   size_t        basename_len;           /* can usually get through readdir */
-   struct stat   statuso;
-   time_t        crtime;
-   StatCalled    stat_called;
-   long long int pinode;
-   size_t        recursion_level;
+    compressed_t  compressed;
+    refstr_t      orig_root;              /* argv[i] */
+    refstr_t      root_parent;            /* dirname(realpath(argv[i])) */
+    size_t        root_basename_len;      /* strlen(basename(argv[i])) */
+    size_t        level;
+    char          *name;                  /* points to memory located after struct work */
+    size_t        name_len;               /* == strlen(name) - meaning excludes NUL! */
+    size_t        basename_len;           /* can usually get through readdir */
+    struct stat   statuso;
+    time_t        crtime;
+    StatCalled    stat_called;
+    long long int pinode;
+    size_t        recursion_level;
 
-   /* probably shouldn't be here */
-   char *        fullpath;
-   size_t        fullpath_len;
+    /* probably shouldn't be here */
+    char *        fullpath;
+    size_t        fullpath_len;
 
-   /* name is actually here, but not using flexible arrays */
+    /* name is actually here, but not using flexible arrays */
 };
 
 size_t struct_work_size(struct work *w);
@@ -416,19 +587,19 @@ struct work *new_work_with_name(const char *prefix, const size_t prefix_len,
 
 /* extra data used by entries that does not depend on data from other directories */
 struct entry_data {
-   int           parent_fd;    /* holds an FD that can be used for fstatat(2), etc. */
-   char          type;
-   char          linkname[MAXPATH];
-   long long int offset;
-   struct xattrs xattrs;
-   int           ossint1;
-   int           ossint2;
-   int           ossint3;
-   int           ossint4;
-   char          osstext1[MAXXATTR];
-   char          osstext2[MAXXATTR];
-   char          pinodec[128];
-   int           suspect;  // added for bfwreaddirplus2db for suspect
+    int           parent_fd;    /* holds an FD that can be used for fstatat(2), etc. */
+    char          type;
+    char          linkname[MAXPATH];
+    long long int offset;
+    struct xattrs xattrs;
+    int           ossint1;
+    int           ossint2;
+    int           ossint3;
+    int           ossint4;
+    char          osstext1[MAXXATTR];
+    char          osstext2[MAXXATTR];
+    char          pinodec[128];
+    int           suspect;  // added for bfwreaddirplus2db for suspect
 };
 
 extern const char fielddelim;

--- a/include/compress.h
+++ b/include/compress.h
@@ -82,12 +82,6 @@ typedef struct compressed {
     size_t          len;      /* includes self; only meaningful if yes == 1 */
 } compressed_t;
 
-#if HAVE_ZLIB /* or any other algorithm */
-#define COMPRESS_OPT "e"
-#else
-#define COMPRESS_OPT
-#endif
-
 void *compress_struct(const int comp, void *src, const size_t struct_len);
 
 void decompress_struct(void **dst, void *src);

--- a/include/utils.h
+++ b/include/utils.h
@@ -173,7 +173,7 @@ int doing_partial_walk(struct input *in, const size_t root_count);
 
 /*
  * attach directory paths directly to the root path and
- * run starting at -y instead of walking to -y first
+ * run starting at --min-level instead of walking to --min-level first
  *
  * used by gufi_dir2index and gufi_dir2trace
  */

--- a/scripts/bash_completion
+++ b/scripts/bash_completion
@@ -90,7 +90,7 @@ __gufi() {
         # return all entries in the directory and directory names in subdirectories
         matches=$("${gufi_query}" \
             -a 1 \
-            -z 2 \
+            --max-level 2 \
             -d $' ' \
             -I "CREATE TABLE out(name TEXT);" \
             -S "INSERT INTO out SELECT name || '/' FROM summary WHERE (level() == 1);" \
@@ -117,7 +117,7 @@ __gufi() {
         # search the index for matches on the name
         matches=$("${gufi_query}" \
             -a 1 \
-            -z 2 \
+            --max-level 2 \
             -d " " \
             -I "CREATE TABLE out(name TEXT);" \
             -S "INSERT INTO out SELECT name || '/' FROM summary WHERE (name REGEXP '^${name}') AND (level() == 1);" \

--- a/scripts/distributed/gufi_dir2index
+++ b/scripts/distributed/gufi_dir2index
@@ -68,7 +68,7 @@ def subtree_cmd(args, filename, _idx, _target):
     return [
         args.gufi_dir2index,
         '-n', str(args.threads),
-        '-y', str(args.level),
+        '--min-level', str(args.level),
         '-D', filename,
         args.input_dir,
         args.output_dir,
@@ -78,7 +78,7 @@ def top_cmd(args, _target):
     return [
         args.gufi_dir2index,
         '-n', str(args.threads),
-        '-z', str(args.level - 1),
+        '--max-level', str(args.level - 1),
         args.input_dir,
         args.output_dir,
     ]

--- a/scripts/distributed/gufi_dir2trace
+++ b/scripts/distributed/gufi_dir2trace
@@ -69,7 +69,7 @@ def subtree_cmd(args, filename, idx, _target):
         args.gufi_dir2trace,
         '-d', args.delim,
         '-n', str(args.threads),
-        '-y', str(args.level),
+        '--min-level', str(args.level),
         '-D', filename,
         args.input_dir,
         '{0}.{1}'.format(args.output_prefix, idx),
@@ -80,7 +80,7 @@ def top_cmd(args, _target):
         args.gufi_dir2trace,
         '-d', args.delim,
         '-n', str(args.threads),
-        '-z', str(args.level - 1),
+        '--max-level', str(args.level - 1),
         args.input_dir,
         args.output_prefix,
     ]

--- a/scripts/distributed/gufi_query
+++ b/scripts/distributed/gufi_query
@@ -82,7 +82,7 @@ def subtree_cmd(args, filename, idx, target):
         args.gufi_query,
         '-n', str(args.threads),
         '-d', str(args.delim),
-        '-y', str(args.level),
+        '--min-level', str(args.level),
         '-D', filename,
     ]
 
@@ -98,7 +98,7 @@ def top_cmd(args, target):
         args.gufi_query,
         '-n', str(args.threads),
         '-d', str(args.delim),
-        '-z', str(args.level - 1),
+        '--max-level', str(args.level - 1),
     ]
 
     if args.distributor == 'ssh':

--- a/scripts/distributed/gufi_rollup
+++ b/scripts/distributed/gufi_rollup
@@ -68,7 +68,7 @@ def subtree_cmd(args, filename, _idx, _target):
     return [
         args.gufi_rollup,
         '-n', str(args.threads),
-        '-y', str(args.level),
+        '--min-level', str(args.level),
         '-D', filename,
         args.GUFI_tree
     ]
@@ -77,7 +77,7 @@ def top_cmd(args, _target):
     return [
         args.gufi_rollup,
         '-n', str(args.threads),
-        '-z', str(args.level), # no -1: need to get rollupscore from subtree roots
+        '--max-level', str(args.level), # no -1: need to get rollupscore from subtree roots
         '-l',
         args.GUFI_tree
     ]

--- a/scripts/distributed/gufi_treesummary_all
+++ b/scripts/distributed/gufi_treesummary_all
@@ -68,7 +68,7 @@ def subtree_cmd(args, filename, _idx, _target):
     return [
         args.gufi_treesummary_all,
         '-n', str(args.threads),
-        '-y', str(args.level),
+        '--min-level', str(args.level),
         '-D', filename,
         args.GUFI_tree
     ]
@@ -77,7 +77,7 @@ def top_cmd(args, _target):
     return [
         args.gufi_treesummary_all,
         '-n', str(args.threads),
-        '-z', str(args.level - 1),
+        '--max-level', str(args.level - 1),
         args.GUFI_tree
     ]
 

--- a/scripts/distributed/gufi_unrollup
+++ b/scripts/distributed/gufi_unrollup
@@ -68,7 +68,7 @@ def subtree_cmd(args, filename, _idx, _target):
     return [
         args.gufi_unrollup,
         '-n', str(args.threads),
-        '-y', str(args.level),
+        '--min-level', str(args.level),
         '-D', filename,
         args.GUFI_tree
     ]
@@ -77,7 +77,7 @@ def top_cmd(args, _target):
     return [
         args.gufi_unrollup,
         '-n', str(args.threads),
-        '-z', str(args.level),
+        '--max-level', str(args.level),
         args.GUFI_tree
     ]
 

--- a/scripts/distributed/parallel_find.sh.in
+++ b/scripts/distributed/parallel_find.sh.in
@@ -67,4 +67,4 @@ root="$1"
 level="$2"
 threads="$3"
 
-parallel_find -n "${threads}" -y "${level}" -z "${level}" -t d -f "%P\n" "${root}"
+parallel_find -n "${threads}" --min-level "${level}" --max-level "${level}" -t d -f "%P\n" "${root}"

--- a/scripts/gufi_du
+++ b/scripts/gufi_du
@@ -155,8 +155,8 @@ def nondir(args, name):
 
     # isroot is set to 1 since the size should be used for --total
     return [
-        '-y', '0',
-        '-z', '0',
+        '--min-level', '0',
+        '--max-level', '0',
         '-E', 'SELECT level(), 1, {0}, rpath(sname, sroll) || \'/\' || name FROM {1} WHERE name == \'{2}\';'.format(E_col,
                                                                                                                     gufi_common.VRPENTRIES,
                                                                                                                     name),
@@ -191,8 +191,8 @@ def separate_dirs(args):
     # summarize is turned on -> get only input path
     if args.summarize:
         return [
-        '-y', '0',
-        '-z', '0',
+        '--min-level', '0',
+        '--max-level', '0',
         '-S', 'SELECT level(), isroot, {0}, rpath(sname, sroll) FROM {1} WHERE isroot == 1;'.format(S_col,
                                                                                                     gufi_common.VRSUMMARY),
     ]
@@ -214,8 +214,8 @@ def summarize(args):
         T_col = '{0}.totblocks'
 
     return [
-        '-y', '0',
-        '-z', '0',
+        '--min-level', '0',
+        '--max-level', '0',
         '-T', 'SELECT level(), isroot, {0}, rpath(sname, sroll) FROM {1} LEFT JOIN {2} ON {1}.inode == {2}.inode WHERE {2}.isroot == 1;'.format(T_col.format(gufi_common.TREESUMMARY),
                                                                                                                                                 gufi_common.TREESUMMARY,
                                                                                                                                                 gufi_common.VRSUMMARY),

--- a/scripts/gufi_find
+++ b/scripts/gufi_find
@@ -905,10 +905,10 @@ def run(argv, config_path):
         ]
 
     if args.maxdepth is not None:
-        query_cmd += ['-z', str(args.maxdepth)]
+        query_cmd += ['--max-level', str(args.maxdepth)]
 
     if args.mindepth is not None:
-        query_cmd += ['-y', str(args.mindepth)]
+        query_cmd += ['--min-level', str(args.mindepth)]
 
     if args.skip:
         query_cmd += ['-k', args.skip]

--- a/scripts/gufi_getfattr
+++ b/scripts/gufi_getfattr
@@ -166,8 +166,8 @@ def getfattr(args, indexroot, dirname, nondirname):
 
     # a non directory prevents recursion
     if nondirname:
-        query_args += ['-y', '0',
-                       '-z', '0']
+        query_args += ['--min-level', '0',
+                       '--max-level', '0']
 
     return query_args + [dirname]
 

--- a/scripts/gufi_ls
+++ b/scripts/gufi_ls
@@ -288,8 +288,8 @@ def run(argv, config_path):
         ]
 
         if not args.recursive:
-            query_cmd += ['-y', '0',
-                          '-z', '2']
+            query_cmd += ['--min-level', '0',
+                          '--max-level', '2']
 
         columns = [
             'fullpath', 'name', 'type', 'inode', 'nlink', 'size',

--- a/scripts/gufi_stats
+++ b/scripts/gufi_stats
@@ -136,8 +136,8 @@ def depth(config, args, where):
     ]
 
     if not args.recursive:
-        queries += ['-y', '0',
-                    '-z', '0']
+        queries += ['--min-level', '0',
+                    '--max-level', '0']
 
     return queries
 
@@ -184,8 +184,8 @@ def filesize(config, args, where):
     ]
 
     if not args.recursive:
-        queries += ['-y', '0',
-                    '-z', '0']
+        queries += ['--min-level', '0',
+                    '--max-level', '0']
 
     return queries
 
@@ -208,8 +208,8 @@ def entries_count(config, args, where, type): # pylint: disable=redefined-builti
     ]
 
     if not args.recursive:
-        queries += ['-y', '0',
-                    '-z', '0']
+        queries += ['--min-level', '0',
+                    '--max-level', '0']
 
     return queries
 
@@ -249,7 +249,7 @@ def extensions(_config, args, where):
     ]
 
     if args.recursive is False:
-        queries += ['-z', '0']
+        queries += ['--max-level', '0']
 
     return queries
 
@@ -450,8 +450,8 @@ def dircount(config, args, where):
 
     if not args.recursive:
         queries += [
-            '-y', '0',
-            '-z', '2']
+            '--min-level', '0',
+            '--max-level', '2']
 
     return queries
 
@@ -547,8 +547,8 @@ def leaf_dirs(config, args, where):
     ]
 
     if not args.recursive:
-        queries += ['-y', '1',
-                    '-z', '2']
+        queries += ['--min-level', '1',
+                    '--max-level', '2']
 
     return queries
 
@@ -595,8 +595,8 @@ def leaf_depth(config, args, where):
     ]
 
     if not args.recursive:
-        queries += ['-y', '1',
-                    '-z', '2']
+        queries += ['--min-level', '1',
+                    '--max-level', '2']
 
     return queries
 
@@ -642,8 +642,8 @@ def leaf(config, args, where, type): # pylint: disable=redefined-builtin
     ]
 
     if not args.recursive:
-        queries += ['-y', '1',
-                    '-z', '2']
+        queries += ['--min-level', '1',
+                    '--max-level', '2']
 
     return queries
 
@@ -1050,7 +1050,7 @@ def size_bins(args, base, type): # pylint: disable=redefined-builtin
     ]
 
     if not args.recursive and not args.cumulative:
-        queries += ['-z', '0']
+        queries += ['--max-level', '0']
 
     return queries
 

--- a/src/BottomUp.c
+++ b/src/BottomUp.c
@@ -588,7 +588,7 @@ int parallel_bottomup(char **root_names, const size_t root_count,
                       void *extra_args) {
     if (min_level && subtree_list->data && subtree_list->len) {
         if (root_count > 1) {
-            fprintf(stderr, "Error: Only one root may be provided when a -y and -D are both provided\n");
+            fprintf(stderr, "Error: Only one root may be provided when a --min-level and -D are both provided\n");
             return -1;
         }
     }

--- a/src/bf.c
+++ b/src/bf.c
@@ -183,138 +183,168 @@ static int load_plugin_library(struct input *in, char *plugin_name) {
 }
 
 void print_help(const char* prog_name,
-                const char* getopt_str,
+                const struct option* options,
                 const char* positional_args_help_str) {
    /* Not checking arguments */
 
-   const char* opt = getopt_str;
    printf("usage: %s [options] %s\n", prog_name, positional_args_help_str);
    printf("options:\n");
 
-   int ch;
-   while ((ch = *opt++)) {
-      switch (ch) {
-      case ':': continue;
-      case 'h': printf("  -h                     help"); break;
-      case 'H': printf("  -H                     show assigned input values (debugging)"); break;
-      case 'v': printf("  -v                     version"); break;
-      case 'x': printf("  -x                     index/query xattrs"); break;
-      case 'P': printf("  -P                     print directories as they are encountered"); break;
-      case 'b': printf("  -b                     build GUFI index tree"); break;
-      case 'a': printf("  -a <0|1|2>             0 - if returned row, run next SQL, else stop (continue descent) (default)\n"
-                       "                         1 - skip T, run S and E whether or not a row was returned (old -a)\n"
-                       "                         2 - run T, S, and E whether or not a row was returned"); break;
-      case 'n': printf("  -n <threads>           number of threads"); break;
-      case 'd': printf("  -d <delim>             delimiter (one char)  [use 'x' for 0x%02X]", (uint8_t)fielddelim); break;
-      case 'o': printf("  -o <out_fname>         output file (one-per-thread, with thread-id suffix)"); break;
-      case 'O': printf("  -O <out_DB>            output DB"); break;
-      case 'u': printf("  -u                     prefix row with 1 int column count and each column with 1 octet type and 1 size_t length"); break;
-      case 'I': printf("  -I <SQL_init>          SQL init"); break;
-      case 'T': printf("  -T <SQL_tsum>          SQL for tree-summary table"); break;
-      case 'S': printf("  -S <SQL_sum>           SQL for summary table"); break;
-      case 'E': printf("  -E <SQL_ent>           SQL for entries table"); break;
-      case 'F': printf("  -F <SQL_fin>           SQL cleanup"); break;
-      case 'r': printf("  -r                     insert files and links into db (for bfwreaddirplus2db"); break;
-      case 'R': printf("  -R                     insert dires into db (for bfwreaddirplus2db"); break;
-      case 'Y': printf("  -Y                     default to all directories suspect"); break;
-      case 'Z': printf("  -Z                     default to all files/links suspect"); break;
-      case 'W': printf("  -W <INSUSPECT>         suspect input file"); break;
-      case 'A': printf("  -A <suspectmethod>     suspect method (0 no suspects, 1 suspect file_dfl, 2 suspect stat d and file_fl, 3 suspect stat_dfl"); break;
-      case 'g': printf("  -g <stridesize>        stride size for striping inodes"); break;
-      case 'c': printf("  -c <suspecttime>       time in seconds since epoch for suspect comparision"); break;
-      case 'y': printf("  -y <min level>         minimum level to go down"); break;
-      case 'z': printf("  -z <max level>         maximum level to go down"); break;
-      case 'J': printf("  -J <SQL_interm>        SQL for intermediate results"); break;
-      case 'K': printf("  -K <create aggregate>  SQL to create the final aggregation table"); break;
-      case 'G': printf("  -G <SQL_aggregate>     SQL for aggregated results"); break;
-      case 'm': printf("  -m                     Keep mtime and atime same on the database files"); break;
-      case 'B': printf("  -B <buffer size>       size of each thread's output buffer in bytes"); break;
-      case 'w': printf("  -w                     open the database files in read-write mode instead of read only mode"); break;
-      case 'f': printf("  -f <FORMAT>            use the specified FORMAT instead of the default; output a newline after each use of FORMAT"); break;
-      case 'j': printf("  -j                     print the information in terse form"); break; /* output from stat --help */
-      case 'X': printf("  -X                     Dry run"); break;
-      case 'L': printf("  -L <count>             Highest number of files/links in a directory allowed to be rolled up"); break;
-      case 'k': printf("  -k <filename>          file containing directory names to skip"); break;
-      case 'M': printf("  -M <bytes>             target memory footprint"); break;
-      case 'C': printf("  -C <count>             Number of subdirectories allowed to be enqueued for parallel processing. Any remainders will be processed in-situ"); break;
-      case 'e': printf("  -e                     compress work items"); break;
-      case 'q': printf("  -q                     check that external databases are valid before tracking during indexing"); break;
-      case 'Q': printf("  -Q <basename>\n"
-                       "     <table>\n"
-                       "     <template>.<table>\n"
-                       "     <view>              External database file basename, per-attach table name, template + table name, and the resultant view"); break;
-      case 's': printf("  -s <path>              File name prefix for swap files"); break;
-      case 'p': printf("  -p <path>              Source path prefix"); break;
-      case 'D': printf("  -D <filename>          File containing paths at single level to index (not including starting path). Must also use -y"); break;
-      case 'l': printf("  -l                     if a directory was previously processed, skip descending the subtree"); break;
-      case 'U': printf("  -U <library_name>      plugin library for modifying db entries"); break;
-      case 't': printf("  -t <filter_type>       one or more types to keep ('f', 'd', 'l')"); break;
-      default: printf("print_help(): unrecognized option '%c'", (char)ch);
-      }
-      printf("\n");
+   while (options && options->name != NULL) { 
+          switch (options->val) {
+                case FLAG_HELP_SHORT:                    printf("  -h, --help                        help"); break;
+                case FLAG_DEBUG_SHORT:                   printf("  -H, --debug                       show assigned input values (debugging)"); break;
+                case FLAG_VERSION_SHORT:                 printf("  -v, --version                     version"); break;
+                case FLAG_XATTRS_SHORT:                  printf("  -x, --xattrs                      index/query xattrs"); break;
+                case FLAG_PRINTDIR_SHORT:                printf("  -P                                print directories as they are encountered"); break;
+                case FLAG_BUILDINDEX_SHORT:              printf("  -b                                build GUFI index tree"); break;
+                case FLAG_PROCESS_SQL_SHORT:             printf("  -a <0|1|2>                        0 - if returned row, run next SQL, else stop (continue descent) (default)\n"
+                                                                "                                    1 - skip T, run S and E whether or not a row was returned (old -a)\n"
+                                                                "                                    2 - run T, S, and E whether or not a row was returned"); break;
+                case FLAG_THREADS_SHORT:                 printf("  -n, --threads <threads>           number of threads"); break;
+                case FLAG_DELIM_SHORT:                   printf("  -d, --delim <delim>               delimiter (one char)  [use 'x' for 0x%02X]", (uint8_t)fielddelim); break;
+                case FLAG_OUTPUT_FILE_SHORT:             printf("  -o, --output-file <out_fname>     output file (one-per-thread, with thread-id suffix)"); break;
+                case FLAG_OUTPUT_DB_SHORT:               printf("  -O, --output-db <out_DB>          output DB"); break;
+                case FLAG_PREFIX_SHORT:                  printf("  -u                                prefix row with 1 int column count and each column with 1 octet type and 1 size_t length"); break;
+                case FLAG_SQL_INIT_SHORT:                printf("  -I <SQL_init>                     SQL init"); break;
+                case FLAG_SQL_TSUM_SHORT:                printf("  -T <SQL_tsum>                     SQL for tree-summary table"); break;
+                case FLAG_SQL_SUM_SHORT:                 printf("  -S <SQL_sum>                      SQL for summary table"); break;
+                case FLAG_SQL_ENT_SHORT:                 printf("  -E <SQL_ent>                      SQL for entries table"); break;
+                case FLAG_SQL_FIN_SHORT:                 printf("  -F <SQL_fin>                      SQL cleanup"); break;
+                case FLAG_INSERT_FILE_LINK_SHORT:        printf("  -r                                insert files and links into db (for bfwreaddirplus2db"); break;
+                case FLAG_INSERT_DIR_SHORT:              printf("  -R                                insert dires into db (for bfwreaddirplus2db"); break;
+                case FLAG_SUSPECT_DIR_SHORT:             printf("  -Y                                default to all directories suspect"); break;
+                case FLAG_SUSPECT_FILE_LINK_SHORT:       printf("  -Z                                default to all files/links suspect"); break;
+                case FLAG_INSUSPECT_SHORT:               printf("  -W <INSUSPECT>                    suspect input file"); break;
+                case FLAG_SUSPECT_METHOD_SHORT:          printf("  -A <suspectmethod>                suspect method (0 no suspects, 1 suspect file_dfl, 2 suspect stat d and file_fl, 3 suspect stat_dfl"); break;
+                case FLAG_STRIDE_SHORT:                  printf("  -g <stridesize>                   stride size for striping inodes"); break;
+                case FLAG_SUSPECT_TIME_SHORT:            printf("  -c <suspecttime>                  time in seconds since epoch for suspect comparision"); break;
+                case FLAG_SQL_INTERM_SHORT:              printf("  -J <SQL_interm>                   SQL for intermediate results"); break;
+                case FLAG_SQL_CREATE_AGG_SHORT:          printf("  -K <create aggregate>             SQL to create the final aggregation table"); break;
+                case FLAG_SQL_AGG_SHORT:                 printf("  -G <SQL_aggregate>                SQL for aggregated results"); break;
+                case FLAG_KEEP_MATIME_SHORT:             printf("  -m                                Keep mtime and atime same on the database files"); break;
+                case FLAG_BUFFER_SIZE_SHORT:             printf("  -B, --buffer-size <buffer size>   size of each thread's output buffer in bytes"); break;
+                case FLAG_READ_WRITE_SHORT:              printf("  -w, --read-write                  open the database files in read-write mode instead of read only mode"); break;
+                case FLAG_FORMAT_SHORT:                  printf("  -f, --format <FORMAT>             use the specified FORMAT instead of the default; output a newline after each use of FORMAT"); break;
+                case FLAG_TERSE_FORMAT_SHORT:            printf("  -j, --terse-form                  print the information in terse form"); break; /* output from stat --help */
+                case FLAG_DRY_RUN_SHORT:                 printf("  -X, --dry-run                     Dry run"); break;
+                case FLAG_MAX_IN_DIR_SHORT:              printf("  -L <count>                        Highest number of files/links in a directory allowed to be rolled up"); break;
+                case FLAG_SKIP_SHORT:                    printf("  -k, --skip <filename>             file containing directory names to skip"); break;
+                case FLAG_TARGET_MEMORY_FOOTPRINT_SHORT: printf("  -M <bytes>                        target memory footprint"); break;
+                case FLAG_SUBDIR_LIMIT_SHORT:            printf("  -C <count>                        Number of subdirectories allowed to be enqueued for parallel processing. Any remainders will be processed in-situ"); break;
+                case FLAG_COMPRESS_SHORT:                printf("  -e                                compress work items"); break;
+                case FLAG_CHECK_EXTDB_VALID_SHORT:       printf("  -q                                check that external databases are valid before tracking during indexing"); break;
+                case FLAG_EXTERNAL_ATTACH_SHORT:         printf("  -Q <basename>\n"
+                                                                "     <table>\n"
+                                                                "     <template>.<table>\n"
+                                                                "     <view>                         External database file basename, per-attach table name, template + table name, and the resultant view"); break;
+                case FLAG_SWAP_PREFIX_SHORT:             printf("  -s, --swap-prefix <path>          File name prefix for swap files"); break;
+                case FLAG_PATH_SHORT:                    printf("  -p, --path <path>                 Source path prefix for %%s in SQL"); break;
+                case FLAG_SUBTREE_LIST_SHORT:            printf("  -D <filename>                     File containing paths at single level to index (not including starting path). Must also use --min-level"); break;
+                case FLAG_ALREADY_PROCESSED_SHORT:       printf("  -l                                if a directory was previously processed, skip descending the subtree"); break;
+                case FLAG_PLUGIN_SHORT:                  printf("  -U <library_name>                 plugin library for modifying db entries"); break;
+                case FLAG_FILTER_TYPE_SHORT:             printf("  -t, --filter-type <filter_type>   one or more types to keep ('f', 'd', 'l')"); break;
+                case FLAG_MIN_LEVEL_SHORT:               printf("      --min-level <min level>       minimum level to go down"); break;
+                case FLAG_MAX_LEVEL_SHORT:               printf("      --max-level <max level>       maximum level to go down"); break;
+                default:                                 printf("print_help(): unrecognized option '%c'", (char)options->val); break;
+          }
+          options++;
+          printf("\n");
    }
    printf("\n");
 }
 
 // DEBUGGING
 void show_input(struct input* in, int retval) {
-   printf("in.printed_version          = %d\n",            in->printed_version);
-   printf("in.printdir                 = %d\n",            in->printdir);
-   printf("in.buildindex               = %d\n",            in->buildindex);
-   printf("in.maxthreads               = %zu\n",           in->maxthreads);
-   printf("in.delim                    = '%c'\n",          in->delim);
-   printf("in.process_sql              = %d\n",            (int) in->process_sql);
-   printf("in.types.prefix             = %d\n",            in->types.prefix);
-   printf("in.process_xattrs           = %d\n",            in->process_xattrs);
-   printf("in.nobody.uid               = %" STAT_uid "\n", in->nobody.uid);
-   printf("in.nobody.gid               = %" STAT_gid "\n", in->nobody.gid);
-   printf("in.sql.init                 = '%s'\n",          in->sql.init.data);
-   printf("in.sql.tsum                 = '%s'\n",          in->sql.tsum.data);
-   printf("in.sql.sum                  = '%s'\n",          in->sql.sum.data);
-   printf("in.sql.ent                  = '%s'\n",          in->sql.ent.data);
-   printf("in.sql.fin                  = '%s'\n",          in->sql.fin.data);
-   printf("in.insertdir                = '%d'\n",          in->insertdir);
-   printf("in.insertfl                 = '%d'\n",          in->insertfl);
-   printf("in.suspectd                 = '%d'\n",          in->suspectd);
-   printf("in.suspectfl                = '%d'\n",          in->suspectfl);
-   printf("in.insuspect                = '%s'\n",          in->insuspect.data);
-   printf("in.suspectfile              = '%d'\n",          in->suspectfile);
-   printf("in.suspectmethod            = '%d'\n",          in->suspectmethod);
-   printf("in.suspecttime              = '%d'\n",          in->suspecttime);
-   printf("in.stride                   = '%d'\n",          in->stride);
-   printf("in.min_level                = %zu\n",           in->min_level);
-   printf("in.max_level                = %zu\n",           in->max_level);
-   printf("in.sql.intermediate         = '%s'\n",          in->sql.intermediate.data);
-   printf("in.sql.init_agg             = '%s'\n",          in->sql.init_agg.data);
-   printf("in.sql.agg                  = '%s'\n",          in->sql.agg.data);
-   printf("in.keep_matime              = %d\n",            in->keep_matime);
-   printf("in.output_buffer_size       = %zu\n",           in->output_buffer_size);
-   printf("in.open_flags               = %d\n",            in->open_flags);
-   printf("in.format_set               = %d\n",            in->format_set);
-   printf("in.format                   = '%s'\n",          in->format.data);
-   printf("in.terse                    = %d\n",            in->terse);
-   printf("in.dry_run                  = %d\n",            in->dry_run);
-   printf("in.max_in_dir               = %zu\n",           in->max_in_dir);
-   printf("in.skip_count               = '%zu'\n",         in->skip_count);
-   printf("in.target_memory_footprint  = %" PRIu64 "\n",   in->target_memory_footprint);
-   printf("in.subdir_limit             = %zu\n",           in->subdir_limit);
-   printf("in.compress                 = %d\n",            in->compress);
-   printf("in.check_extdb_valid        = %d\n",            in->check_extdb_valid);
-   size_t i = 0;
-   sll_loop(&in->external_attach, node) {
-       eus_t *eus = (eus_t *) sll_node_data(node);
-       printf("in.external_attach[%zu] = ('%s', '%s', '%s', '%s')\n",
-              i++, eus->basename.data, eus->table.data, eus->template_table.data, eus->view.data);
-   }
-   printf("\n");
-   printf("in.swap_prefix              = '%s'\n",          in->swap_prefix.data);
-   printf("in.source_prefix            = '%s'\n",          in->source_prefix.data);
-   printf("in.subtree_list             = '%s'\n",          in->subtree_list.data);
-   printf("in.check_already_processed  = %d\n",            in->check_already_processed);
-   printf("in.filter_types             = %d\n",            in->filter_types);
+    printf("in.printed_version          = %d\n",            in->printed_version);
+    printf("in.printdir                 = %d\n",            in->printdir);
+    printf("in.buildindex               = %d\n",            in->buildindex);
+    printf("in.maxthreads               = %zu\n",           in->maxthreads);
+    printf("in.delim                    = '%c'\n",          in->delim);
+    printf("in.process_sql              = %d\n",            (int) in->process_sql);
+    printf("in.types.prefix             = %d\n",            in->types.prefix);
+    printf("in.process_xattrs           = %d\n",            in->process_xattrs);
+    printf("in.nobody.uid               = %" STAT_uid "\n", in->nobody.uid);
+    printf("in.nobody.gid               = %" STAT_gid "\n", in->nobody.gid);
+    printf("in.sql.init                 = '%s'\n",          in->sql.init.data);
+    printf("in.sql.tsum                 = '%s'\n",          in->sql.tsum.data);
+    printf("in.sql.sum                  = '%s'\n",          in->sql.sum.data);
+    printf("in.sql.ent                  = '%s'\n",          in->sql.ent.data);
+    printf("in.sql.fin                  = '%s'\n",          in->sql.fin.data);
+    printf("in.insertdir                = '%d'\n",          in->insertdir);
+    printf("in.insertfl                 = '%d'\n",          in->insertfl);
+    printf("in.suspectd                 = '%d'\n",          in->suspectd);
+    printf("in.suspectfl                = '%d'\n",          in->suspectfl);
+    printf("in.insuspect                = '%s'\n",          in->insuspect.data);
+    printf("in.suspectfile              = '%d'\n",          in->suspectfile);
+    printf("in.suspectmethod            = '%d'\n",          in->suspectmethod);
+    printf("in.suspecttime              = '%d'\n",          in->suspecttime);
+    printf("in.stride                   = '%d'\n",          in->stride);
+    printf("in.min_level                = %zu\n",           in->min_level);
+    printf("in.max_level                = %zu\n",           in->max_level);
+    printf("in.sql.intermediate         = '%s'\n",          in->sql.intermediate.data);
+    printf("in.sql.init_agg             = '%s'\n",          in->sql.init_agg.data);
+    printf("in.sql.agg                  = '%s'\n",          in->sql.agg.data);
+    printf("in.keep_matime              = %d\n",            in->keep_matime);
+    printf("in.output_buffer_size       = %zu\n",           in->output_buffer_size);
+    printf("in.open_flags               = %d\n",            in->open_flags);
+    printf("in.format_set               = %d\n",            in->format_set);
+    printf("in.format                   = '%s'\n",          in->format.data);
+    printf("in.terse                    = %d\n",            in->terse);
+    printf("in.dry_run                  = %d\n",            in->dry_run);
+    printf("in.max_in_dir               = %zu\n",           in->max_in_dir);
+    printf("in.skip_count               = '%zu'\n",         in->skip_count);
+    printf("in.target_memory_footprint  = %" PRIu64 "\n",   in->target_memory_footprint);
+    printf("in.subdir_limit             = %zu\n",           in->subdir_limit);
+    printf("in.compress                 = %d\n",            in->compress);
+    printf("in.check_extdb_valid        = %d\n",            in->check_extdb_valid);
+    size_t i = 0;
+    sll_loop(&in->external_attach, node) {
+        eus_t *eus = (eus_t *) sll_node_data(node);
+        printf("in.external_attach[%zu] = ('%s', '%s', '%s', '%s')\n",
+               i++, eus->basename.data, eus->table.data, eus->template_table.data, eus->view.data);
+    }
+    printf("\n");
+    printf("in.swap_prefix              = '%s'\n",          in->swap_prefix.data);
+    printf("in.source_prefix            = '%s'\n",          in->source_prefix.data);
+    printf("in.subtree_list             = '%s'\n",          in->subtree_list.data);
+    printf("in.check_already_processed  = %d\n",            in->check_already_processed);
+    printf("in.filter_types             = %d\n",            in->filter_types);
 
-   printf("retval                      = %d\n",            retval);
-   printf("\n");
+    printf("retval                      = %d\n",            retval);
+    printf("\n");
+}
+
+char *build_getopt_str(const struct option *options) {
+    size_t len = 1; /* null terminator */
+
+    for (const struct option *opt = options; opt->name != NULL; opt++) {
+        if (opt->val >= '0' && opt->val <= 'z') {
+            len++;
+            if (opt->has_arg == required_argument) {
+                len++;
+            } else if (opt->has_arg == optional_argument) {
+                len += 2;
+            }
+        }
+    }
+
+    char *getopt_str = calloc(len, sizeof(char));
+
+    char *ptr = getopt_str;
+    for (const struct option *opt = options; opt->name != NULL; opt++) {
+        if (opt->val >= '0' && opt->val <= 'z') {
+            *ptr++ = (char) opt->val;
+            if (opt->has_arg == required_argument) {
+                *ptr++ = ':';
+            } else if (opt->has_arg == optional_argument) {
+                *ptr++ = ':';
+                *ptr++ = ':';
+            }
+        }
+    }
+    *ptr = '\0';
+    return getopt_str;
 }
 
 // process command-line options
@@ -331,332 +361,334 @@ void show_input(struct input* in, int retval) {
 //    positional argument in <argv>.  This allows the caller to do a custom
 //    parse of the remaining arguments as required (positional) args.
 //
-int parse_cmd_line(int         argc,
-                   char*       argv[],
-                   const char* getopt_str,
-                   int         n_positional,
-                   const char* positional_args_help_str,
-                   struct input *in) {
-
-   input_init(in);
-
-   int show                    = 0;
-   int retval                  = 0;
-   int bad_skipfile            = 0;
-   int ch;
-   optind = 1; // reset to 1, not 0 (man 3 getopt)
-   while ( (ch = getopt(argc, argv, getopt_str)) != -1) {
-      switch (ch) {
-
-      case 'h':               // help
-         print_help(argv[0], getopt_str, positional_args_help_str);
-         in->helped = 1;
-         retval = -1;
-         break;
-
-      case 'H':               // show parsed inputs
-         show = 1;
-         retval = -1;
-         break;
-
-      case 'v':
-          printf(STR(GUFI_VERSION) "\n");
-          in->printed_version = 1;
-          break;
-
-      case 'x':               // enable xattr processing
-         in->process_xattrs = 1;
-         break;
-
-      case 'P':               // print dirs?
-         in->printdir = 1;
-         break;
-
-      case 'b':               // build index?
-         in->buildindex = 1;
-         break;
-
-      case 'a':
-         {
-             int a = -1;
-             INSTALL_INT(&a, optarg, 0, 2, "-a", &retval);
-             in->process_sql = a;
-         }
-         break;
-
-      case 'n':
-          INSTALL_SIZE(&in->maxthreads, optarg, 1, (size_t) -1, "-n", &retval);
-         break;
-
-      case 'd':
-         if (optarg[0] == 'x') {
-             in->delim = fielddelim;
-         }
-         else {
-             in->delim = optarg[0];
-         }
-         break;
-
-      case 'o':
-         in->output = OUTFILE;
-         INSTALL_STR(&in->outname, optarg);
-         break;
-
-      case 'O':
-         in->output = OUTDB;
-         INSTALL_STR(&in->outname, optarg);
-         break;
-
-      case 'u':
-         in->types.prefix = 1;
-         break;
-
-      case 'I':               // SQL initializations
-         INSTALL_STR(&in->sql.init, optarg);
-         break;
-
-      case 'T':               // SQL for tree-summary
-         INSTALL_STR(&in->sql.tsum, optarg);
-         break;
-
-      case 'S':               // SQL for summary
-         INSTALL_STR(&in->sql.sum, optarg);
-         break;
-
-      case 'E':               // SQL for entries
-         INSTALL_STR(&in->sql.ent, optarg);
-         break;
-
-      case 'F':               // SQL clean-up
-         INSTALL_STR(&in->sql.fin, optarg);
-         break;
-
-      case 'r':               // insert files and links into db for bfwreaddirplus2db
-         in->insertfl = 1;
-         break;
-
-      case 'R':               // insert dirs into db for bfwreaddirplus2db
-         in->insertdir = 1;
-         break;
-
-      case 'Y':               // default is 0
-         in->suspectd = 1;
-         break;
-
-      case 'Z':               // default is 0
-         in->suspectfl = 1;
-         break;
-
-      case 'W':               // SQL clean-up
-         INSTALL_STR(&in->insuspect, optarg);
-         in->suspectfile = 1;
-         break;
-
-      case 'A':
-         INSTALL_INT(&in->suspectmethod, optarg, 0, 3, "-A", &retval);
-         break;
-
-      case 'g':
-         INSTALL_INT(&in->stride, optarg, 1, MAXSTRIDE, "-g", &retval);
-         break;
-
-      case 'c':
-         INSTALL_INT(&in->suspecttime, optarg, 1, 2147483646, "-c", &retval);
-         break;
-
-      case 'y':
-         INSTALL_SIZE(&in->min_level, optarg, (size_t) 0, (size_t) -1, "-y", &retval);
-         break;
-
-      case 'z':
-         INSTALL_SIZE(&in->max_level, optarg, (size_t) 0, (size_t) -1, "-z", &retval);
-         break;
-
-      case 'J':
-         INSTALL_STR(&in->sql.intermediate, optarg);
-         break;
-
-      case 'K':
-         INSTALL_STR(&in->sql.init_agg, optarg);
-         break;
-
-      case 'G':
-         INSTALL_STR(&in->sql.agg, optarg);
-         break;
-
-      case 'm':
-         in->keep_matime = 1;
-         break;
-
-      case 'B':
-         INSTALL_SIZE(&in->output_buffer_size, optarg, (size_t) 0, (size_t) -1, "-z", &retval);
-         break;
-
-      case 'w':
-         in->open_flags = SQLITE_OPEN_READWRITE;
-         break;
-
-      case 'f':
-          INSTALL_STR(&in->format, optarg);
-          in->format_set = 1;
-          break;
-
-      case 'j':
-          in->terse = 1;
-          break;
-
-      case 'X':
-          in->dry_run = 1;
-          break;
-
-      case 'L':
-          INSTALL_SIZE(&in->max_in_dir, optarg, (size_t) 0, (size_t) -1, "-L", &retval);
-          break;
-
-      case 'k':
-          {
-              refstr_t skipfile = {
-                  .data = NULL,
-                  .len = 0,
-              };
-              INSTALL_STR(&skipfile, optarg);
-              const ssize_t added = setup_directory_skip(in->skip, skipfile.data);
-              if (added < 0) {
-                  retval = -1;
-                  bad_skipfile = 1;
-                  /* cannot return here - expected behavior is to parse remaining options first */
-              }
-              else {
-                  in->skip_count += added;
-              }
-          }
-          break;
-
-      case 'M':
-          INSTALL_UINT64(&in->target_memory_footprint, optarg, (uint64_t) 0, (uint64_t) -1, "-M", &retval);
-          break;
-
-      case 'C':
-          INSTALL_SIZE(&in->subdir_limit, optarg, (size_t) 0, (size_t) -1, "-C", &retval);
-          break;
-
-      case 'e':
-          in->compress = 1;
-          break;
-
-      case 'q':
-          in->check_extdb_valid = 1;
-          break;
-
-      case 'Q':
-          {
-              eus_t *user = calloc(1, sizeof(*user));
-
-              INSTALL_STR(&user->basename, optarg);
-
-              optarg = argv[optind];
-              INSTALL_STR(&user->table, optarg);
-
-              optarg = argv[++optind];
-              INSTALL_STR(&user->template_table, optarg);
-
-              optarg = argv[++optind];
-              INSTALL_STR(&user->view, optarg);
-
-              optarg = argv[++optind];
-
-              sll_push(&in->external_attach, user);
-          }
-          break;
-
-      case 's':
-          INSTALL_STR(&in->swap_prefix, optarg);
-          break;
-
-      case 'p':
-          INSTALL_STR(&in->source_prefix, optarg);
-          break;
-
-      case 'D':
-          INSTALL_STR(&in->subtree_list, optarg);
-          break;
-
-      case 'l':
-          in->check_already_processed = 1;
-          break;
-
-      case 'U':
-          if (load_plugin_library(in, optarg)) {
-              retval = -1;
-          }
-          break;
-
-      case 't':
-          while (*optarg) {
-              switch (*optarg) {
-                  case 'f':
-                      in->filter_types |= FILTER_TYPE_FILE;
-                      break;
-                  case 'd':
-                      in->filter_types |= FILTER_TYPE_DIR;
-                      break;
-                  case 'l':
-                      in->filter_types |= FILTER_TYPE_LINK;
-                      break;
-                  default:
-                      fprintf(stderr, "%c is not a valid option\n", *optarg);
-                      retval = -1;
-                      break;
-              }
-              ++optarg;
-          }
-          break;
-
-      case '?':
-         // getopt returns '?' when there is a problem.  In this case it
-         // also prints, e.g. "getopt_test: illegal option -- z"
-         fprintf(stderr, "unrecognized option '%s'\n", argv[optind -1]);
-         retval = -1;
-         break;
-
-      default:
-         retval = -1;
-         fprintf(stderr, "?? getopt returned character code 0%o ??\n", ch);
-      };
-   }
-
-   // if there were no other errors,
-   // make sure min_level <= max_level
-   if (retval == 0) {
-       retval = -(in->min_level > in->max_level);
-   }
-
-   if (in->printed_version) {
-       return -1;
-   }
-
-   if (in->filter_types == 0) {
-      in->filter_types = FILTER_TYPE_FILE | FILTER_TYPE_DIR | FILTER_TYPE_LINK;
-   }
-
-   // caller requires given number of positional args, after the options.
-   // <optind> is the number of argv[] values that were recognized as options.
-   // NOTE: caller may have custom options ovf their own, so returning a
-   //       value > n_positional is okay (?)
-   if (retval
-       || ((argc - optind) < n_positional)) {
-      if (!in->helped && !bad_skipfile) {
-         print_help(argv[0], getopt_str, positional_args_help_str);
-         in->helped = 1;
-      }
-      retval = -1;
-   }
-
-   // DEBUGGING:
-   if (show)
-      show_input(in, retval);
-
-   return (retval ? retval : optind);
+int parse_cmd_line(int                  argc,
+                   char*                argv[],
+                   const struct option* options,
+                   int                  n_positional,
+                   const char*          positional_args_help_str,
+                   struct input*        in) {
+    input_init(in);
+    char *getopt_str = build_getopt_str(options);
+
+    int show                    = 0;
+    int retval                  = 0;
+    int bad_skipfile            = 0;
+    int ch;
+    setenv("POSIXLY_CORRECT", "1", 1); /* don't check errors? */
+    optind = 0;                        /* man 3 getopt_long */
+    while ( (ch = getopt_long(argc, argv, getopt_str, options, NULL)) != -1) {
+        switch (ch) {
+
+            case FLAG_HELP_SHORT:               // help
+                print_help(argv[0], options, positional_args_help_str);
+                in->helped = 1;
+                retval = -1;
+                break;
+
+            case FLAG_DEBUG_SHORT:               // show parsed inputs
+                show = 1;
+                retval = -1;
+                break;
+
+            case FLAG_VERSION_SHORT:
+                printf(STR(GUFI_VERSION) "\n");
+                in->printed_version = 1;
+                break;
+
+            case FLAG_XATTRS_SHORT:               // enable xattr processing
+                in->process_xattrs = 1;
+                break;
+
+            case FLAG_PRINTDIR_SHORT:               // print dirs?
+                in->printdir = 1;
+                break;
+
+            case FLAG_BUILDINDEX_SHORT:               // build index?
+                in->buildindex = 1;
+                break;
+
+            case FLAG_PROCESS_SQL_SHORT:
+                {
+                    int a = -1;
+                    INSTALL_INT(&a, optarg, 0, 2, "-a", &retval);
+                    in->process_sql = a;
+                }
+                break;
+
+            case FLAG_THREADS_SHORT:
+                INSTALL_SIZE(&in->maxthreads, optarg, 1, (size_t) -1, "-n", &retval);
+                break;
+
+            case FLAG_DELIM_SHORT:
+                if (optarg[0] == 'x') {
+                    in->delim = fielddelim;
+                }
+                else {
+                    in->delim = optarg[0];
+                }
+                break;
+
+            case FLAG_OUTPUT_FILE_SHORT:
+                in->output = OUTFILE;
+                INSTALL_STR(&in->outname, optarg);
+                break;
+
+            case FLAG_OUTPUT_DB_SHORT:
+                in->output = OUTDB;
+                INSTALL_STR(&in->outname, optarg);
+                break;
+
+            case FLAG_PREFIX_SHORT:
+                in->types.prefix = 1;
+                break;
+
+            case FLAG_SQL_INIT_SHORT:               // SQL initializations
+                INSTALL_STR(&in->sql.init, optarg);
+                break;
+
+            case FLAG_SQL_TSUM_SHORT:               // SQL for tree-summary
+                INSTALL_STR(&in->sql.tsum, optarg);
+                break;
+
+            case FLAG_SQL_SUM_SHORT:               // SQL for summary
+                INSTALL_STR(&in->sql.sum, optarg);
+                break;
+
+            case FLAG_SQL_ENT_SHORT:               // SQL for entries
+                INSTALL_STR(&in->sql.ent, optarg);
+                break;
+
+            case FLAG_SQL_FIN_SHORT:               // SQL clean-up
+                INSTALL_STR(&in->sql.fin, optarg);
+                break;
+
+            case FLAG_INSERT_FILE_LINK_SHORT:     // insert files and links into db for bfwreaddirplus2db
+                in->insertfl = 1;
+                break;
+
+            case FLAG_INSERT_DIR_SHORT:          // insert dirs into db for bfwreaddirplus2db
+                in->insertdir = 1;
+                break;
+
+            case FLAG_SUSPECT_DIR_SHORT:         // default is 0
+                in->suspectd = 1;
+                break;
+
+            case FLAG_SUSPECT_FILE_LINK_SHORT:               // default is 0
+                in->suspectfl = 1;
+                break;
+
+            case FLAG_INSUSPECT_SHORT:               // SQL clean-up
+                INSTALL_STR(&in->insuspect, optarg);
+                in->suspectfile = 1;
+                break;
+
+            case FLAG_SUSPECT_METHOD_SHORT:
+                INSTALL_INT(&in->suspectmethod, optarg, 0, 3, "-A", &retval);
+                break;
+
+            case FLAG_STRIDE_SHORT:
+                INSTALL_INT(&in->stride, optarg, 1, MAXSTRIDE, "-g", &retval);
+                break;
+
+            case FLAG_SUSPECT_TIME_SHORT:
+                INSTALL_INT(&in->suspecttime, optarg, 1, 2147483646, "-c", &retval);
+                break;
+
+            case FLAG_MIN_LEVEL_SHORT: /* min-level */
+                INSTALL_SIZE(&in->min_level, optarg, (size_t) 0, (size_t) -1, "--min-level", &retval);
+                break;
+
+            case FLAG_MAX_LEVEL_SHORT: /* max-level */
+                INSTALL_SIZE(&in->max_level, optarg, (size_t) 0, (size_t) -1, "--max-level", &retval);
+                break;
+
+            case FLAG_SQL_INTERM_SHORT:
+                INSTALL_STR(&in->sql.intermediate, optarg);
+                break;
+
+            case FLAG_SQL_CREATE_AGG_SHORT:
+                INSTALL_STR(&in->sql.init_agg, optarg);
+                break;
+
+            case FLAG_SQL_AGG_SHORT:
+                INSTALL_STR(&in->sql.agg, optarg);
+                break;
+
+            case FLAG_KEEP_MATIME_SHORT:
+                in->keep_matime = 1;
+                break;
+
+            case FLAG_BUFFER_SIZE_SHORT:
+                INSTALL_SIZE(&in->output_buffer_size, optarg, (size_t) 0, (size_t) -1, "-B", &retval);
+                break;
+
+            case FLAG_READ_WRITE_SHORT:
+                in->open_flags = SQLITE_OPEN_READWRITE;
+                break;
+
+            case FLAG_FORMAT_SHORT:
+                INSTALL_STR(&in->format, optarg);
+                in->format_set = 1;
+                break;
+
+            case FLAG_TERSE_FORMAT_SHORT:
+                in->terse = 1;
+                break;
+
+            case FLAG_DRY_RUN_SHORT:
+                in->dry_run = 1;
+                break;
+
+            case FLAG_MAX_IN_DIR_SHORT:
+                INSTALL_SIZE(&in->max_in_dir, optarg, (size_t) 0, (size_t) -1, "-L", &retval);
+                break;
+
+            case FLAG_SKIP_SHORT:
+                {
+                    refstr_t skipfile = {
+                        .data = NULL,
+                        .len = 0,
+                    };
+                    INSTALL_STR(&skipfile, optarg);
+                    const ssize_t added = setup_directory_skip(in->skip, skipfile.data);
+                    if (added < 0) {
+                        retval = -1;
+                        bad_skipfile = 1;
+                        /* cannot return here - expected behavior is to parse remaining options first */
+                    }
+                    else {
+                        in->skip_count += added;
+                    }
+                }
+                break;
+
+            case FLAG_TARGET_MEMORY_FOOTPRINT_SHORT:
+                INSTALL_UINT64(&in->target_memory_footprint, optarg, (uint64_t) 0, (uint64_t) -1, "-M", &retval);
+                break;
+
+            case FLAG_SUBDIR_LIMIT_SHORT:
+                INSTALL_SIZE(&in->subdir_limit, optarg, (size_t) 0, (size_t) -1, "-C", &retval);
+                break;
+
+            case FLAG_COMPRESS_SHORT:
+                in->compress = 1;
+                break;
+
+            case FLAG_CHECK_EXTDB_VALID_SHORT:
+                in->check_extdb_valid = 1;
+                break;
+
+            case FLAG_EXTERNAL_ATTACH_SHORT:
+                {
+                    eus_t *user = calloc(1, sizeof(*user));
+
+                    INSTALL_STR(&user->basename, optarg);
+
+                    optarg = argv[optind];
+                    INSTALL_STR(&user->table, optarg);
+
+                    optarg = argv[++optind];
+                    INSTALL_STR(&user->template_table, optarg);
+
+                    optarg = argv[++optind];
+                    INSTALL_STR(&user->view, optarg);
+
+                    optarg = argv[++optind];
+
+                    sll_push(&in->external_attach, user);
+                }
+                break;
+
+            case FLAG_SWAP_PREFIX_SHORT:
+                INSTALL_STR(&in->swap_prefix, optarg);
+                break;
+
+            case FLAG_PATH_SHORT:
+                INSTALL_STR(&in->source_prefix, optarg);
+                break;
+
+            case FLAG_SUBTREE_LIST_SHORT:
+                INSTALL_STR(&in->subtree_list, optarg);
+                break;
+
+            case FLAG_ALREADY_PROCESSED_SHORT:
+                in->check_already_processed = 1;
+                break;
+
+            case FLAG_PLUGIN_SHORT:
+                if (load_plugin_library(in, optarg)) {
+                    retval = -1;
+                }
+                break;
+
+            case FLAG_FILTER_TYPE_SHORT:
+                while (*optarg) {
+                    switch (*optarg) {
+                        case 'f':
+                            in->filter_types |= FILTER_TYPE_FILE;
+                            break;
+                        case 'd':
+                            in->filter_types |= FILTER_TYPE_DIR;
+                            break;
+                        case 'l':
+                            in->filter_types |= FILTER_TYPE_LINK;
+                            break;
+                        default:
+                            fprintf(stderr, "%c is not a valid option\n", *optarg);
+                            retval = -1;
+                            break;
+                    }
+                    ++optarg; 
+                }
+                break;
+
+            case '?':
+                // getopt returns '?' when there is a problem.  In this case it
+                // also prints, e.g. "getopt_test: illegal option -- z"
+                fprintf(stderr, "unrecognized option '%s'\n", argv[optind -1]);
+                retval = -1;
+                break;
+
+            default:
+                retval = -1;
+                fprintf(stderr, "?? getopt returned character code 0%o ??\n", ch);
+        };
+    }
+    free(getopt_str);
+
+    // if there were no other errors,
+    // make sure min_level <= max_level
+    if (retval == 0) {
+        retval = -(in->min_level > in->max_level);
+    }
+
+    if (in->printed_version) {
+        return -1;
+    }
+
+    if (in->filter_types == 0) {
+        in->filter_types = FILTER_TYPE_FILE | FILTER_TYPE_DIR | FILTER_TYPE_LINK;
+    }
+
+    // caller requires given number of positional args, after the options.
+    // <optind> is the number of argv[] values that were recognized as options.
+    // NOTE: caller may have custom options ovf their own, so returning a
+    //       value > n_positional is okay (?)
+    if (retval
+        || ((argc - optind) < n_positional)) {
+        if (!in->helped && !bad_skipfile) {
+            print_help(argv[0], options, positional_args_help_str);
+            in->helped = 1;
+        }
+        retval = -1;
+    }
+
+    // DEBUGGING:
+    if (show)
+        show_input(in, retval);
+
+    return (retval ? retval : optind);
 }
 
 int INSTALL_STR(refstr_t *VAR, const char *SOURCE) {

--- a/src/bfwreaddirplus2db.c
+++ b/src/bfwreaddirplus2db.c
@@ -661,9 +661,16 @@ int main(int argc, char *argv[]) {
     /* but allow different fields to be filled at the command-line. */
     /* Callers provide the options-string for get_opt(), which will */
     /* control which options are parsed for each program. */
+    const struct option options[] = {
+        FLAG_HELP, FLAG_DEBUG, FLAG_VERSION, FLAG_THREADS,
+        FLAG_OUTPUT_DB, FLAG_OUTPUT_FILE, FLAG_DELIM, FLAG_INSERT_FILE_LINK,
+        FLAG_INSERT_DIR, FLAG_SUSPECT_DIR, FLAG_SUSPECT_FILE_LINK, FLAG_INSUSPECT,
+        FLAG_STRIDE, FLAG_SUSPECT_METHOD, FLAG_SUSPECT_TIME, FLAG_XATTRS,
+        FLAG_BUILDINDEX, FLAG_END
+    };
     struct PoolArgs pa;
     memset(&pa, 0, sizeof(pa));
-    int idx = parse_cmd_line(argc, argv, "hHvn:O:o:d:rRYZW:g:A:c:xb", 1, "input_dir [index]", &pa.in);
+    int idx = parse_cmd_line(argc, argv, options, 1, "input_dir [index]", &pa.in);
     if (pa.in.helped)
         sub_help();
 

--- a/src/gpfs-scan-tool.c
+++ b/src/gpfs-scan-tool.c
@@ -359,8 +359,12 @@ int main(int argc, char *argv[]) {
      // but allow different fields to be filled at the command-line.
      // Callers provide the options-string for get_opt(), which will
      // control which options are parsed for each program.
+  const struct option options[] = {
+    FLAG_HELP, FLAG_DEBUG, FLAG_THREADS, FLAG_DELIM, FLAG_STRIDE, FLAG_END
+  };
   struct input in;
-  int idx = parse_cmd_line(argc, argv, "hHn:d:g:", 1, "input_dir", &in);
+  int idx = parse_cmd_line(argc, argv, options, 1, "input_dir", &in);
+
   lastrun = fopen(".lastrun", "r");
   if (lastrun == NULL) {
     intime=atoll(pastsec);

--- a/src/gufi_dir2index.c
+++ b/src/gufi_dir2index.c
@@ -482,8 +482,16 @@ static void sub_help(void) {
 }
 
 int main(int argc, char *argv[]) {
+    const struct option options[] = {
+        FLAG_HELP, FLAG_DEBUG, FLAG_VERSION, FLAG_THREADS, FLAG_XATTRS, FLAG_MIN_LEVEL, FLAG_MAX_LEVEL,
+        FLAG_SKIP, FLAG_TARGET_MEMORY_FOOTPRINT, FLAG_SWAP_PREFIX, FLAG_SUBDIR_LIMIT, FLAG_PLUGIN,
+        #ifdef HAVE_ZLIB
+        FLAG_COMPRESS,
+        #endif
+        FLAG_CHECK_EXTDB_VALID, FLAG_SUBTREE_LIST, FLAG_END
+    };
     struct PoolArgs pa;
-    process_args_and_maybe_exit("hHvn:xy:z:k:M:s:C:U:" COMPRESS_OPT "qD:", 2, "input_dir... output_dir", &pa.in);
+    process_args_and_maybe_exit(options, 2, "input_dir... output_dir", &pa.in);
 
     /* parse positional args, following the options */
     /* does not have to be canonicalized */

--- a/src/gufi_dir2trace.c
+++ b/src/gufi_dir2trace.c
@@ -218,8 +218,16 @@ static void sub_help(void) {
 }
 
 int main(int argc, char *argv[]) {
+    const struct option options[] = {
+        FLAG_HELP, FLAG_DEBUG, FLAG_VERSION, FLAG_THREADS, FLAG_XATTRS, FLAG_MIN_LEVEL, FLAG_MAX_LEVEL,
+        FLAG_DELIM, FLAG_SKIP, FLAG_TARGET_MEMORY_FOOTPRINT, FLAG_SWAP_PREFIX, FLAG_SUBDIR_LIMIT,
+        #ifdef HAVE_ZLIB
+        FLAG_COMPRESS,
+        #endif
+        FLAG_CHECK_EXTDB_VALID, FLAG_SUBTREE_LIST, FLAG_END
+    };
     struct PoolArgs pa;
-    process_args_and_maybe_exit("hHvn:xy:z:d:k:M:s:C:" COMPRESS_OPT "qD:", 2, "input_dir... output_prefix", &pa.in);
+    process_args_and_maybe_exit(options, 2, "input_dir... output_prefix", &pa.in);
 
     /* parse positional args, following the options */
     INSTALL_STR(&pa.in.nameto, argv[argc - 1]);

--- a/src/gufi_find_outliers/main.c
+++ b/src/gufi_find_outliers/main.c
@@ -91,8 +91,11 @@ static void sub_help(void) {
 }
 
 int main(int argc, char *argv[]) {
+    const struct option flags[] = {
+        FLAG_HELP, FLAG_DEBUG, FLAG_VERSION, FLAG_THREADS, FLAG_DELIM, FLAG_OUTPUT_DB, FLAG_END
+    };
     struct PoolArgs pa;
-    process_args_and_maybe_exit("hHvn:d:O:", 2, "input_dir data ...", &pa.in);
+    process_args_and_maybe_exit(flags, 2, "input_dir data ...", &pa.in);
 
     int rc = EXIT_SUCCESS;
 

--- a/src/gufi_index2dir.c
+++ b/src/gufi_index2dir.c
@@ -425,8 +425,11 @@ void sub_help(void) {
 }
 
 int main(int argc, char * argv[]) {
+    const struct option options[] = {
+        FLAG_HELP, FLAG_DEBUG, FLAG_VERSION, FLAG_THREADS, FLAG_XATTRS, FLAG_END
+    };
     struct PoolArgs pa;
-    process_args_and_maybe_exit("hHvn:x", 2, "input_dir output_dir", &pa.in);
+    process_args_and_maybe_exit(options, 2, "input_dir output_dir", &pa.in);
 
     INSTALL_STR(&pa.in.name,   argv[idx++]);
     INSTALL_STR(&pa.in.nameto, argv[idx++]);

--- a/src/gufi_query/main.c
+++ b/src/gufi_query/main.c
@@ -83,7 +83,7 @@ OF SUCH DAMAGE.
 
 /*
  * attach directory paths directly to the root path and
- * run starting at -y instead of walking to -y first
+ * run starting at --min-level instead of walking to --min-level first
  */
 int gqw_process_subtree_list(struct input *in, gqw_t *root, QPTPool_t *ctx) {
     FILE *file = fopen(in->subtree_list.data, "r");
@@ -133,7 +133,7 @@ int gqw_process_subtree_list(struct input *in, gqw_t *root, QPTPool_t *ctx) {
 
         subtree_root->work.root_basename_len = root->work.basename_len;
 
-        /* go directly to -y */
+        /* go directly to --min-level */
         subtree_root->work.level = in->min_level;
 
         QPTPool_enqueue(ctx, 0, processdir, subtree_root);
@@ -157,8 +157,20 @@ int main(int argc, char *argv[])
     /* but allow different fields to be filled at the command-line. */
     /* Callers provide the options-string for get_opt(), which will */
     /* control which options are parsed for each program. */
+    const struct option options[] = {
+        FLAG_HELP, FLAG_DEBUG, FLAG_VERSION, FLAG_SQL_TSUM, FLAG_SQL_SUM, FLAG_SQL_ENT,
+        FLAG_PROCESS_SQL, FLAG_THREADS, FLAG_TERSE_FORMAT, FLAG_OUTPUT_FILE, FLAG_DELIM,
+        FLAG_OUTPUT_DB, FLAG_PREFIX, FLAG_SQL_INIT, FLAG_SQL_FIN, FLAG_MIN_LEVEL,
+        FLAG_MAX_LEVEL, FLAG_SQL_INTERM, FLAG_SQL_CREATE_AGG, FLAG_SQL_AGG, FLAG_KEEP_MATIME,
+        FLAG_BUFFER_SIZE, FLAG_READ_WRITE, FLAG_XATTRS, FLAG_SKIP, FLAG_TARGET_MEMORY_FOOTPRINT,
+        FLAG_SWAP_PREFIX, FLAG_PATH,
+        #ifdef HAVE_ZLIB
+        FLAG_COMPRESS,
+        #endif
+        FLAG_EXTERNAL_ATTACH, FLAG_SUBTREE_LIST, FLAG_END
+    };
     struct input in;
-    process_args_and_maybe_exit("hHvT:S:E:a:n:jo:d:O:uI:F:y:z:J:K:G:mB:wxk:M:s:p:" COMPRESS_OPT "Q:D:", 1, "GUFI_tree ...", &in);
+    process_args_and_maybe_exit(options, 1, "GUFI_tree ...", &in);
 
     if (handle_sql(&in) != 0) {
         input_fini(&in);

--- a/src/gufi_rollup.c
+++ b/src/gufi_rollup.c
@@ -926,8 +926,13 @@ int main(int argc, char *argv[]) {
     struct start_end runtime;
     clock_gettime(CLOCK_MONOTONIC, &runtime.start);
 
+    const struct option options[] = {
+        FLAG_HELP, FLAG_DEBUG, FLAG_VERSION, FLAG_THREADS, FLAG_MAX_IN_DIR,
+        FLAG_DRY_RUN, FLAG_MIN_LEVEL, FLAG_MAX_LEVEL,FLAG_SUBTREE_LIST,
+        FLAG_ALREADY_PROCESSED, FLAG_END
+    };
     struct PoolArgs pa;
-    process_args_and_maybe_exit("hHvn:L:Xy:z:D:l", 1, "GUFI_tree ...", &pa.in);
+    process_args_and_maybe_exit(options, 1, "GUFI_tree ...", &pa.in);
 
     init_template_db(&pa.xattr_template);
     if (create_xattrs_template(&pa.xattr_template) != 0) {

--- a/src/gufi_sqlite3.c
+++ b/src/gufi_sqlite3.c
@@ -84,8 +84,11 @@ static void sub_help(void) {
 }
 
 int main(int argc, char *argv[]) {
+    const struct option options[] = {
+        FLAG_HELP, FLAG_VERSION, FLAG_DELIM, FLAG_END
+    };
     struct input in;
-    process_args_and_maybe_exit("hvd:", 0, "[db [SQL]...]", &in);
+    process_args_and_maybe_exit(options, 0, "[db [SQL]...]", &in);
 
     const int args_left = argc - idx;
     const char *dbname = (args_left == 0)?SQLITE_MEMORY:argv[idx++];

--- a/src/gufi_stat.c
+++ b/src/gufi_stat.c
@@ -498,8 +498,11 @@ int main(int argc, char *argv[])
     /* but allow different fields to be filled at the command-line. */
     /* Callers provide the options-string for get_opt(), which will */
     /* control which options are parsed for each program. */
+    const struct option options[] = {
+        FLAG_HELP, FLAG_DEBUG, FLAG_VERSION, FLAG_FORMAT, FLAG_TERSE_FORMAT, FLAG_END
+    };
     struct input in;
-    process_args_and_maybe_exit("hHvf:j", 1, "path ...", &in);
+    process_args_and_maybe_exit(options, 1, "path ...", &in);
 
     const char *format = DEFAULT_FORMAT;
 

--- a/src/gufi_trace2dir.c
+++ b/src/gufi_trace2dir.c
@@ -201,8 +201,11 @@ void sub_help(void) {
 }
 
 int main(int argc, char * argv[]) {
+    const struct option options[] = {
+        FLAG_HELP, FLAG_DEBUG, FLAG_VERSION, FLAG_THREADS, FLAG_DELIM, FLAG_XATTRS, FLAG_END
+    };
     struct PoolArgs pa;
-    process_args_and_maybe_exit("hHvn:d:x", 2, "trace_file... output_dir", &pa.in);
+    process_args_and_maybe_exit(options, 2, "trace_file... output_dir", &pa.in);
 
     // parse positional args, following the options
     INSTALL_STR(&pa.in.nameto, argv[argc - 1]);

--- a/src/gufi_trace2index.c
+++ b/src/gufi_trace2index.c
@@ -236,8 +236,12 @@ int main(int argc, char *argv[]) {
     clock_gettime(CLOCK_MONOTONIC, &main_func.start);
     epoch = since_epoch(&main_func.start);
 
+    const struct option options[] = {
+        FLAG_HELP, FLAG_DEBUG, FLAG_VERSION, FLAG_THREADS,
+        FLAG_DELIM, FLAG_TARGET_MEMORY_FOOTPRINT, FLAG_SWAP_PREFIX, FLAG_END
+    };
     struct PoolArgs pa;
-    process_args_and_maybe_exit("hHvn:d:M:s:", 2, "trace_file... output_dir", &pa.in);
+    process_args_and_maybe_exit(options, 2, "trace_file... output_dir", &pa.in);
 
     /* parse positional args, following the options */
     INSTALL_STR(&pa.in.nameto, argv[argc - 1]);

--- a/src/gufi_treesummary.c
+++ b/src/gufi_treesummary.c
@@ -306,8 +306,12 @@ int main(int argc, char *argv[]) {
      * Callers provide the options-string for get_opt(), which will
      * control which options are parsed for each program.
      */
+    const struct option options[] = {
+        FLAG_HELP, FLAG_DEBUG, FLAG_VERSION, FLAG_PRINTDIR,
+        FLAG_THREADS, FLAG_DELIM, FLAG_DRY_RUN, FLAG_END
+    };
     struct PoolArgs pa;
-    process_args_and_maybe_exit("hHvPn:d:X", 1, "GUFI_tree", &pa.in);
+    process_args_and_maybe_exit(options, 1, "GUFI_tree", &pa.in);
 
     INSTALL_STR(&pa.in.name, argv[idx++]);
 

--- a/src/gufi_treesummary_all.c
+++ b/src/gufi_treesummary_all.c
@@ -140,8 +140,12 @@ int main(int argc, char *argv[]) {
      * Callers provide the options-string for get_opt(), which will
      * control which options are parsed for each program.
      */
+    const struct option options[] = {
+        FLAG_HELP, FLAG_DEBUG, FLAG_VERSION, FLAG_THREADS, FLAG_MIN_LEVEL,
+        FLAG_MAX_LEVEL, FLAG_SUBTREE_LIST, FLAG_ALREADY_PROCESSED, FLAG_END
+    };
     struct input in;
-    process_args_and_maybe_exit("hHvn:y:z:D:l", 1, "GUFI_tree", &in);
+    process_args_and_maybe_exit(options, 1, "GUFI_tree", &in);
 
     BU_descend_f desc = in.check_already_processed?treesummary_descend:NULL;
 

--- a/src/gufi_unrollup.c
+++ b/src/gufi_unrollup.c
@@ -276,8 +276,12 @@ static void sub_help(void) {
 }
 
 int main(int argc, char *argv[]) {
+    const struct option options[] = {
+        FLAG_HELP, FLAG_DEBUG, FLAG_VERSION, FLAG_THREADS, FLAG_MIN_LEVEL,
+        FLAG_MAX_LEVEL, FLAG_SUBTREE_LIST, FLAG_END
+    };
     struct input in;
-    process_args_and_maybe_exit("hHvn:y:z:D:", 1, "GUFI_tree ...", &in);
+    process_args_and_maybe_exit(options, 1, "GUFI_tree ...", &in);
 
     const int root_count = argc - idx;
 

--- a/src/parallel_cpr.c
+++ b/src/parallel_cpr.c
@@ -294,8 +294,11 @@ static void sub_help(void) {
 }
 
 int main(int argc, char * argv[]) {
+    const struct option options[] = {
+        FLAG_HELP, FLAG_DEBUG, FLAG_VERSION, FLAG_THREADS, FLAG_XATTRS, FLAG_END
+    };
     struct input in;
-    process_args_and_maybe_exit("hHvn:x", 2, "src... dst", &in);
+    process_args_and_maybe_exit(options, 2, "src... dst", &in);
 
     /* parse positional args, following the options */
     /* does not have to be canonicalized */

--- a/src/parallel_find.c
+++ b/src/parallel_find.c
@@ -176,7 +176,7 @@ static int process_output(struct work *work, struct entry_data *ed, void *nondir
     ├── dir1/ --- level 1
     │   └── file1.txt --- level 1
 
-    parallel_find -n -y 1 -z 1
+    parallel_find -n --min-level 1 --max-level 1
     The expected output is:
     root_dir/dir1
     root_dir/dir1/file1.txt
@@ -267,8 +267,12 @@ static FILE **stdout_init(struct input *in) {
 }
 
 int main(int argc, char *argv[]) {
+    const struct option options[] = {
+        FLAG_HELP, FLAG_DEBUG, FLAG_VERSION, FLAG_THREADS, FLAG_FORMAT, FLAG_MIN_LEVEL,
+        FLAG_MAX_LEVEL, FLAG_FILTER_TYPE, FLAG_OUTPUT_FILE, FLAG_BUFFER_SIZE, FLAG_END
+    };
     struct PoolArgs pa;
-    process_args_and_maybe_exit("hHvn:f:y:z:t:o:B:", 1, "input_dir...", &pa.in);
+    process_args_and_maybe_exit(options, 1, "input_dir...", &pa.in);
     int rc = 0;
 
     pa.outfiles = (pa.in.output == OUTFILE)?outfiles_init(&pa.in.outname, pa.in.maxthreads):stdout_init(&pa.in);

--- a/src/parallel_rmr.c
+++ b/src/parallel_rmr.c
@@ -117,8 +117,11 @@ static void sub_help(void) {
 }
 
 int main(int argc, char * argv[]) {
+    const struct option options[] = {
+        FLAG_HELP, FLAG_DEBUG, FLAG_VERSION, FLAG_THREADS, FLAG_END
+    };
     struct input in;
-    process_args_and_maybe_exit("hHvn:", 1, "directory ...", &in);
+    process_args_and_maybe_exit(options, 1, "directory ...", &in);
 
     const int rc = parallel_bottomup(argv + idx, argc - idx,
                                      0, (size_t) -1,

--- a/src/utils.c
+++ b/src/utils.c
@@ -968,7 +968,7 @@ int doing_partial_walk(struct input *in, const size_t root_count) {
 
 /*
  * attach directory paths directly to the root path and
- * run starting at -y instead of walking to -y first
+ * run starting at --min-level instead of walking to --min-level first
  */
 ssize_t process_subtree_list(struct input *in, struct work *root,
                              QPTPool_t *ctx, QPTPool_f func) {
@@ -1018,7 +1018,7 @@ ssize_t process_subtree_list(struct input *in, struct work *root,
         /* remove trailing slashes (+ 1 to keep at least 1 character) */
         subtree_root->basename_len = subtree_root->name_len - (trailing_match_index(subtree_root->name + 1, subtree_root->name_len - 1, "/", 1) + 1);
 
-        /* go directly to -y */
+        /* go directly to --min-level */
         subtree_root->level = in->min_level;
 
         QPTPool_enqueue(ctx, 0, func, subtree_root);

--- a/test/regression/gufi_dir2index.expected
+++ b/test/regression/gufi_dir2index.expected
@@ -2,21 +2,21 @@
 $ gufi_dir2index
 usage: gufi_dir2index [options] input_dir... output_dir
 options:
-  -h                     help
-  -H                     show assigned input values (debugging)
-  -v                     version
-  -n <threads>           number of threads
-  -x                     index/query xattrs
-  -y <min level>         minimum level to go down
-  -z <max level>         maximum level to go down
-  -k <filename>          file containing directory names to skip
-  -M <bytes>             target memory footprint
-  -s <path>              File name prefix for swap files
-  -C <count>             Number of subdirectories allowed to be enqueued for parallel processing. Any remainders will be processed in-situ
-  -U <library_name>      plugin library for modifying db entries
-  -e                     compress work items
-  -q                     check that external databases are valid before tracking during indexing
-  -D <filename>          File containing paths at single level to index (not including starting path). Must also use -y
+  -h, --help                        help
+  -H, --debug                       show assigned input values (debugging)
+  -v, --version                     version
+  -n, --threads <threads>           number of threads
+  -x, --xattrs                      index/query xattrs
+      --min-level <min level>       minimum level to go down
+      --max-level <max level>       maximum level to go down
+  -k, --skip <filename>             file containing directory names to skip
+  -M <bytes>                        target memory footprint
+  -s, --swap-prefix <path>          File name prefix for swap files
+  -C <count>                        Number of subdirectories allowed to be enqueued for parallel processing. Any remainders will be processed in-situ
+  -U <library_name>                 plugin library for modifying db entries
+  -e                                compress work items
+  -q                                check that external databases are valid before tracking during indexing
+  -D <filename>                     File containing paths at single level to index (not including starting path). Must also use --min-level
 
 input_dir...      walk one or more trees to produce GUFI tree
 output_dir        build GUFI tree here
@@ -215,18 +215,18 @@ Index up to level 3:
         prefix/unusual#? directory ,/unusual, name?#             prefix/unusual#? directory ,/unusual, name?#
 
 # build index in pieces
-$ gufi_dir2index -y 2      -x prefix search
+$ gufi_dir2index --min-level 2               -x prefix search
 Creating GUFI Index search with 1 threads
 Total Dirs:          1
 Total Non-Dirs:      2
 
-$ gufi_dir2index -y 1 -z 2 -x prefix search
+$ gufi_dir2index --min-level 1 --max-level 2 -x prefix search
 "search" Already exists!
 Creating GUFI Index search with 1 threads
 Total Dirs:          5
 Total Non-Dirs:      8
 
-$ gufi_dir2index -y 0 -z 1 -x prefix search
+$ gufi_dir2index --min-level 0 --max-level 1 -x prefix search
 "search" Already exists!
 Creating GUFI Index search with 1 threads
 Total Dirs:          5
@@ -272,7 +272,7 @@ $ cat "distributed.0"
 directory
 empty_directory
 
-$ gufi_dir2index -n 2 -D "distributed.0" -y 1 "prefix" "search"
+$ gufi_dir2index -n 2 -D "distributed.0" --min-level 1 "prefix" "search"
 Creating GUFI Index search with 2 threads
 Total Dirs:          3
 Total Non-Dirs:      5
@@ -298,7 +298,7 @@ $ cat "distributed.1"
 leaf_directory
 unusual#? directory ,
 
-$ gufi_dir2index -n 2 -D "distributed.1" -y 1 "prefix" "search"
+$ gufi_dir2index -n 2 -D "distributed.1" --min-level 1 "prefix" "search"
 Creating GUFI Index search with 2 threads
 Total Dirs:          2
 Total Non-Dirs:      3
@@ -317,18 +317,18 @@ prefix/unusual#? directory ,/unusual, name?#
 # combine partial indexing
 $ rm -r "search"
 
-$ gufi_dir2index -n 2 -D "distributed.0" -y 1 "prefix" "search"
+$ gufi_dir2index -n 2 -D "distributed.0" --min-level 1 "prefix" "search"
 Creating GUFI Index search with 2 threads
 Total Dirs:          3
 Total Non-Dirs:      5
 
-$ gufi_dir2index -n 2 -D "distributed.1" -y 1 "prefix" "search"
+$ gufi_dir2index -n 2 -D "distributed.1" --min-level 1 "prefix" "search"
 "search" Already exists!
 Creating GUFI Index search with 2 threads
 Total Dirs:          2
 Total Non-Dirs:      3
 
-$ gufi_dir2index -n 2 -z 0 "prefix" "search"
+$ gufi_dir2index -n 2 --max-level 0 "prefix" "search"
 "search" Already exists!
 Creating GUFI Index search with 2 threads
 Total Dirs:          1
@@ -409,6 +409,6 @@ $ gufi_dir2index -n 18446744073709551615 "prefix" "search"
 Error: Failed to start thread pool
 
 # multiple input directories are not allowed for partial indexing
-$ gufi_dir2index -n 2 -D "distributed.1" -y 1 "prefix" "prefix" "search"
+$ gufi_dir2index -n 2 -D "distributed.1" --min-level 1 "prefix" "prefix" "search"
 Error: When -D is passed in, only one source directory may be specified
 

--- a/test/regression/gufi_dir2index.sh.in
+++ b/test/regression/gufi_dir2index.sh.in
@@ -106,7 +106,7 @@ do
 
     # generate the index
     # shellcheck disable=SC2016
-    out=$("${GUFI_DIR2INDEX}" -y ${level} -x "${SRCDIR}" "${SEARCH}" 2>&1 | @AWK@ '{ print "    " $0 }')
+    out=$("${GUFI_DIR2INDEX}" --min-level ${level} -x "${SRCDIR}" "${SEARCH}" 2>&1 | @AWK@ '{ print "    " $0 }')
 
     # find and GUFI levels are slightly different
     src=$( (find "${SRCDIR}" -mindepth ${level} -type d; find "${SRCDIR}" -mindepth $((level + 1)) ! -type d) | sort)
@@ -137,7 +137,7 @@ do
 
     # generate the index
     # shellcheck disable=SC2016
-    out=$("${GUFI_DIR2INDEX}" -z ${level} -x "${SRCDIR}" "${SEARCH}" 2>&1 | @AWK@ '{ print "    " $0 }')
+    out=$("${GUFI_DIR2INDEX}" --max-level ${level} -x "${SRCDIR}" "${SEARCH}" 2>&1 | @AWK@ '{ print "    " $0 }')
 
     src=$( (find "${SRCDIR}" -maxdepth ${level} -type d; find "${SRCDIR}" -maxdepth $((level + 1)) ! -type d) | sort)
     # src=$(find "${SRCDIR}" -maxdepth ${level} | sort)
@@ -162,9 +162,9 @@ done
 
 echo "# build index in pieces"
 rm -r "${SEARCH}"
-run_no_sort "${GUFI_DIR2INDEX} -y 2      -x ${SRCDIR} ${SEARCH}"
-run_no_sort "${GUFI_DIR2INDEX} -y 1 -z 2 -x ${SRCDIR} ${SEARCH}"
-run_no_sort "${GUFI_DIR2INDEX} -y 0 -z 1 -x ${SRCDIR} ${SEARCH}"
+run_no_sort "${GUFI_DIR2INDEX} --min-level 2               -x ${SRCDIR} ${SEARCH}"
+run_no_sort "${GUFI_DIR2INDEX} --min-level 1 --max-level 2 -x ${SRCDIR} ${SEARCH}"
+run_no_sort "${GUFI_DIR2INDEX} --min-level 0 --max-level 1 -x ${SRCDIR} ${SEARCH}"
 index=$("${GUFI_QUERY}" -d " " -S "SELECT rpath(sname, sroll) FROM vrsummary;" -E "SELECT rpath(sname, sroll) || '/' || name FROM vrpentries;" "${INDEXROOT}" | sort)
 
 paste \
@@ -184,7 +184,7 @@ echo "# ######################################"
 echo "# partial indexing (first half)"
 run_no_sort "rm -r \"${SEARCH}\""
 run_no_sort "cat \"${DISTRIBUTED_0}\""
-run_no_sort "${GUFI_DIR2INDEX} -n ${THREADS} -D \"${DISTRIBUTED_0}\" -y ${DISTRIBUTED_LEVEL} \"${SRCDIR}\" \"${SEARCH}\""
+run_no_sort "${GUFI_DIR2INDEX} -n ${THREADS} -D \"${DISTRIBUTED_0}\" --min-level ${DISTRIBUTED_LEVEL} \"${SRCDIR}\" \"${SEARCH}\""
 run_sort "${GUFI_QUERY} -d \" \" -S \"SELECT rpath(sname, sroll) FROM vrsummary;\" -E \"SELECT rpath(sname, sroll) || '/' || name FROM vrpentries;\" \"${INDEXROOT}\""
 echo "# ######################################"
 echo
@@ -192,16 +192,16 @@ echo "# ######################################"
 echo "# partial indexing (second half)"
 run_no_sort "rm -r \"${SEARCH}\""
 run_no_sort "cat \"${DISTRIBUTED_1}\""
-run_no_sort "${GUFI_DIR2INDEX} -n ${THREADS} -D \"${DISTRIBUTED_1}\" -y ${DISTRIBUTED_LEVEL} \"${SRCDIR}\" \"${SEARCH}\""
+run_no_sort "${GUFI_DIR2INDEX} -n ${THREADS} -D \"${DISTRIBUTED_1}\" --min-level ${DISTRIBUTED_LEVEL} \"${SRCDIR}\" \"${SEARCH}\""
 run_sort "${GUFI_QUERY} -d \" \" -S \"SELECT rpath(sname, sroll) FROM vrsummary;\" -E \"SELECT rpath(sname, sroll) || '/' || name FROM vrpentries;\" \"${INDEXROOT}\""
 echo "# ######################################"
 echo
 echo "# ######################################"
 echo "# combine partial indexing"
 run_no_sort "rm -r \"${SEARCH}\""
-run_no_sort "${GUFI_DIR2INDEX} -n ${THREADS} -D \"${DISTRIBUTED_0}\" -y ${DISTRIBUTED_LEVEL} \"${SRCDIR}\" \"${SEARCH}\""
-run_no_sort "${GUFI_DIR2INDEX} -n ${THREADS} -D \"${DISTRIBUTED_1}\" -y ${DISTRIBUTED_LEVEL} \"${SRCDIR}\" \"${SEARCH}\""
-run_no_sort "${GUFI_DIR2INDEX} -n ${THREADS} -z 0 \"${SRCDIR}\" \"${SEARCH}\""
+run_no_sort "${GUFI_DIR2INDEX} -n ${THREADS} -D \"${DISTRIBUTED_0}\" --min-level ${DISTRIBUTED_LEVEL} \"${SRCDIR}\" \"${SEARCH}\""
+run_no_sort "${GUFI_DIR2INDEX} -n ${THREADS} -D \"${DISTRIBUTED_1}\" --min-level ${DISTRIBUTED_LEVEL} \"${SRCDIR}\" \"${SEARCH}\""
+run_no_sort "${GUFI_DIR2INDEX} -n ${THREADS} --max-level 0 \"${SRCDIR}\" \"${SEARCH}\""
 run_sort "${GUFI_QUERY} -d \" \" -S \"SELECT rpath(sname, sroll) FROM vrsummary;\" -E \"SELECT rpath(sname, sroll) || '/' || name FROM vrpentries;\" \"${INDEXROOT}\""
 echo "# ######################################"
 echo
@@ -231,7 +231,7 @@ echo "# bad thread count"
 run_no_sort "${GUFI_DIR2INDEX} -n 18446744073709551615 \"${SRCDIR}\" \"${SEARCH}\""
 
 echo "# multiple input directories are not allowed for partial indexing"
-run_no_sort "${GUFI_DIR2INDEX} -n ${THREADS} -D \"${DISTRIBUTED_1}\" -y ${DISTRIBUTED_LEVEL} \"${SRCDIR}\" \"${SRCDIR}\" \"${SEARCH}\""
+run_no_sort "${GUFI_DIR2INDEX} -n ${THREADS} -D \"${DISTRIBUTED_1}\" --min-level ${DISTRIBUTED_LEVEL} \"${SRCDIR}\" \"${SRCDIR}\" \"${SEARCH}\""
 ) | remove_indexing_time | replace | tee "${OUTPUT}"
 
 @DIFF@ @CMAKE_CURRENT_BINARY_DIR@/gufi_dir2index.expected "${OUTPUT}"

--- a/test/regression/gufi_dir2trace.expected
+++ b/test/regression/gufi_dir2trace.expected
@@ -2,21 +2,21 @@
 $ gufi_dir2trace
 usage: gufi_dir2trace [options] input_dir... output_prefix
 options:
-  -h                     help
-  -H                     show assigned input values (debugging)
-  -v                     version
-  -n <threads>           number of threads
-  -x                     index/query xattrs
-  -y <min level>         minimum level to go down
-  -z <max level>         maximum level to go down
-  -d <delim>             delimiter (one char)  [use 'x' for 0x1E]
-  -k <filename>          file containing directory names to skip
-  -M <bytes>             target memory footprint
-  -s <path>              File name prefix for swap files
-  -C <count>             Number of subdirectories allowed to be enqueued for parallel processing. Any remainders will be processed in-situ
-  -e                     compress work items
-  -q                     check that external databases are valid before tracking during indexing
-  -D <filename>          File containing paths at single level to index (not including starting path). Must also use -y
+  -h, --help                        help
+  -H, --debug                       show assigned input values (debugging)
+  -v, --version                     version
+  -n, --threads <threads>           number of threads
+  -x, --xattrs                      index/query xattrs
+      --min-level <min level>       minimum level to go down
+      --max-level <max level>       maximum level to go down
+  -d, --delim <delim>               delimiter (one char)  [use 'x' for 0x1E]
+  -k, --skip <filename>             file containing directory names to skip
+  -M <bytes>                        target memory footprint
+  -s, --swap-prefix <path>          File name prefix for swap files
+  -C <count>                        Number of subdirectories allowed to be enqueued for parallel processing. Any remainders will be processed in-situ
+  -e                                compress work items
+  -q                                check that external databases are valid before tracking during indexing
+  -D <filename>                     File containing paths at single level to index (not including starting path). Must also use --min-level
 
 input_dir...         walk one or more trees to produce trace file
 output_prefix        prefix of output files (<prefix>.<tid>)
@@ -100,7 +100,7 @@ $ cat "distributed.0"
 directory
 empty_directory
 
-$ gufi_dir2trace -d "|" -n 2 -D "distributed.0" -y 1 "prefix" "trace"
+$ gufi_dir2trace -d "|" -n 2 -D "distributed.0" --min-level 1 "prefix" "trace"
 "trace.0" Already exists!
 "trace.1" Already exists!
 Creating GUFI Traces trace with 2 threads
@@ -125,7 +125,7 @@ $ cat "distributed.1"
 leaf_directory
 unusual#? directory ,
 
-$ gufi_dir2trace -d "|" -n 2 -D "distributed.1" -y 1 "prefix" "trace"
+$ gufi_dir2trace -d "|" -n 2 -D "distributed.1" --min-level 1 "prefix" "trace"
 "trace.0" Already exists!
 "trace.1" Already exists!
 Creating GUFI Traces trace with 2 threads
@@ -143,17 +143,17 @@ prefix/unusual#? directory ,/unusual, name?#
 
 # ######################################
 # combine partial indexing
-$ gufi_dir2trace -d "|" -n 2 -D "distributed.0" -y 1 "prefix" "first"
+$ gufi_dir2trace -d "|" -n 2 -D "distributed.0" --min-level 1 "prefix" "first"
 Creating GUFI Traces first with 2 threads
 Total Dirs:          3
 Total Files:         5
 
-$ gufi_dir2trace -d "|" -n 2 -D "distributed.1" -y 1 "prefix" "second"
+$ gufi_dir2trace -d "|" -n 2 -D "distributed.1" --min-level 1 "prefix" "second"
 Creating GUFI Traces second with 2 threads
 Total Dirs:          2
 Total Files:         3
 
-$ gufi_dir2trace -d "|" -n 2 -z 0 "prefix" "trace"
+$ gufi_dir2trace -d "|" -n 2 --max-level 0 "prefix" "trace"
 "trace.0" Already exists!
 "trace.1" Already exists!
 Creating GUFI Traces trace with 2 threads
@@ -264,7 +264,7 @@ $ gufi_dir2trace -n 18446744073709551615 "prefix" "trace"
 Could not allocate space for 18446744073709551615 files
 
 # multiple input directories are not allowed for partial indexing
-$ gufi_dir2trace -n 2 -D "distributed.1" -y 1 "prefix" "prefix" "trace"
+$ gufi_dir2trace -n 2 -D "distributed.1" --min-level 1 "prefix" "prefix" "trace"
 Error: When -D is passed in, only one source directory may be specified
 
 write to stdout with more than 1 thread is not allowed

--- a/test/regression/gufi_dir2trace.sh.in
+++ b/test/regression/gufi_dir2trace.sh.in
@@ -139,7 +139,7 @@ partial_indexing_setup
 echo "# ######################################"
 echo "# partial indexing (first half)"
 run_no_sort "cat \"${DISTRIBUTED_0}\""
-run_no_sort "${GUFI_DIR2TRACE} -d \"|\" -n ${THREADS} -D \"${DISTRIBUTED_0}\" -y ${DISTRIBUTED_LEVEL} \"${SRCDIR}\" \"${TRACE}\""
+run_no_sort "${GUFI_DIR2TRACE} -d \"|\" -n ${THREADS} -D \"${DISTRIBUTED_0}\" --min-level ${DISTRIBUTED_LEVEL} \"${SRCDIR}\" \"${TRACE}\""
 # shellcheck disable=SC2145
 run_sort "cat ${TRACES[@]} | @AWK@ -F '|' '{ print \$1 }' | sort"
 echo "# ######################################"
@@ -147,16 +147,16 @@ echo
 echo "# ######################################"
 echo "# partial indexing (second half)"
 run_no_sort "cat \"${DISTRIBUTED_1}\""
-run_no_sort "${GUFI_DIR2TRACE} -d \"|\" -n ${THREADS} -D \"${DISTRIBUTED_1}\" -y ${DISTRIBUTED_LEVEL} \"${SRCDIR}\" \"${TRACE}\""
+run_no_sort "${GUFI_DIR2TRACE} -d \"|\" -n ${THREADS} -D \"${DISTRIBUTED_1}\" --min-level ${DISTRIBUTED_LEVEL} \"${SRCDIR}\" \"${TRACE}\""
 # shellcheck disable=SC2145
 run_sort "cat ${TRACES[@]} | @AWK@ -F '|' '{ print \$1 }' | sort"
 echo "# ######################################"
 echo
 echo "# ######################################"
 echo "# combine partial indexing"
-run_no_sort "${GUFI_DIR2TRACE} -d \"|\" -n ${THREADS} -D \"${DISTRIBUTED_0}\" -y ${DISTRIBUTED_LEVEL} \"${SRCDIR}\" \"${FIRST}\""
-run_no_sort "${GUFI_DIR2TRACE} -d \"|\" -n ${THREADS} -D \"${DISTRIBUTED_1}\" -y ${DISTRIBUTED_LEVEL} \"${SRCDIR}\" \"${SECOND}\""
-run_no_sort "${GUFI_DIR2TRACE} -d \"|\" -n ${THREADS} -z 0 \"${SRCDIR}\" \"${TRACE}\""
+run_no_sort "${GUFI_DIR2TRACE} -d \"|\" -n ${THREADS} -D \"${DISTRIBUTED_0}\" --min-level ${DISTRIBUTED_LEVEL} \"${SRCDIR}\" \"${FIRST}\""
+run_no_sort "${GUFI_DIR2TRACE} -d \"|\" -n ${THREADS} -D \"${DISTRIBUTED_1}\" --min-level ${DISTRIBUTED_LEVEL} \"${SRCDIR}\" \"${SECOND}\""
+run_no_sort "${GUFI_DIR2TRACE} -d \"|\" -n ${THREADS} --max-level 0 \"${SRCDIR}\" \"${TRACE}\""
 # shellcheck disable=SC2145
 run_no_sort "cat ${TRACES[@]} ${FIRST}.* ${SECOND}.* | @AWK@ -F '|' '{ print \$1 }' | sort"
 echo "# ######################################"
@@ -190,7 +190,7 @@ echo "# bad thread count"
 run_no_sort "${GUFI_DIR2TRACE} -n 18446744073709551615 \"${SRCDIR}\" \"${TRACE}\""
 
 echo "# multiple input directories are not allowed for partial indexing"
-run_no_sort "${GUFI_DIR2TRACE} -n ${THREADS} -D \"${DISTRIBUTED_1}\" -y ${DISTRIBUTED_LEVEL} \"${SRCDIR}\" \"${SRCDIR}\" \"${TRACE}\""
+run_no_sort "${GUFI_DIR2TRACE} -n ${THREADS} -D \"${DISTRIBUTED_1}\" --min-level ${DISTRIBUTED_LEVEL} \"${SRCDIR}\" \"${SRCDIR}\" \"${TRACE}\""
 
 echo "write to stdout with more than 1 thread is not allowed"
 run_no_sort "${GUFI_DIR2TRACE} -d \"${DELIM}\" -n ${THREADS} -x \"${SRCDIR}\" \"-\""

--- a/test/regression/gufi_du.expected
+++ b/test/regression/gufi_du.expected
@@ -474,8 +474,8 @@ GUFI query is
    gufi_query \
     -d ' ' \
     -n 1 \
-    -y 0 \
-    -z 0 \
+    --min-level 0 \
+    --max-level 0 \
     -E 'SELECT level(), 1, size, rpath(sname, sroll) || '"'"'/'"'"' || name FROM vrpentries WHERE name == '"'"'1MB'"'"';' \
     prefix
 1048576 prefix/1MB
@@ -483,8 +483,8 @@ GUFI query is
    gufi_query \
     -d ' ' \
     -n 1 \
-    -y 0 \
-    -z 0 \
+    --min-level 0 \
+    --max-level 0 \
     -E 'SELECT level(), 1, size, rpath(sname, sroll) || '"'"'/'"'"' || name FROM vrpentries WHERE name == '"'"'1KB'"'"';' \
     prefix
 1024 prefix/1KB

--- a/test/regression/gufi_find_outliers.expected
+++ b/test/regression/gufi_find_outliers.expected
@@ -1,12 +1,12 @@
 $ gufi_find_outliers -h
 usage: gufi_find_outliers [options] input_dir data ...
 options:
-  -h                     help
-  -H                     show assigned input values (debugging)
-  -v                     version
-  -n <threads>           number of threads
-  -d <delim>             delimiter (one char)  [use 'x' for 0x1E]
-  -O <out_DB>            output DB
+  -h, --help                        help
+  -H, --debug                       show assigned input values (debugging)
+  -v, --version                     version
+  -n, --threads <threads>           number of threads
+  -d, --delim <delim>               delimiter (one char)  [use 'x' for 0x1E]
+  -O, --output-db <out_DB>          output DB
 
 input_dir         walk this tree to find directories with outliers
 data              column or group (T_ONLY, MINS, MAXS, MINMAXS, TOTS, TIMES, ALL) to look at

--- a/test/regression/gufi_index2dir.expected
+++ b/test/regression/gufi_index2dir.expected
@@ -2,11 +2,11 @@
 $ gufi_index2dir
 usage: gufi_index2dir [options] input_dir output_dir
 options:
-  -h                     help
-  -H                     show assigned input values (debugging)
-  -v                     version
-  -n <threads>           number of threads
-  -x                     index/query xattrs
+  -h, --help                        help
+  -H, --debug                       show assigned input values (debugging)
+  -v, --version                     version
+  -n, --threads <threads>           number of threads
+  -x, --xattrs                      index/query xattrs
 
 input_dir         walk this GUFI index to produce a tree
 output_dir        reconstruct the tree under here

--- a/test/regression/gufi_ls.expected
+++ b/test/regression/gufi_ls.expected
@@ -5,8 +5,8 @@ $ gufi_ls --verbose
 GUFI query is
    gufi_query \
     -n 1 \
-    -y 0 \
-    -z 2 \
+    --min-level 0 \
+    --max-level 2 \
     -I 'CREATE TABLE out (fullpath TEXT, name TEXT, type TEXT, inode INT64, nlink INT64, size INT64, mode INT64, uid INT64, gid INT64, blksize INT64, blocks INT64, mtime INT64, atime INT64, ctime INT64, linkname TEXT, xattr_names TEXT, pinode INT64);' \
     -S 'INSERT INTO out SELECT rpath(sname, sroll), basename(name), type, inode, nlink, size, mode, uid, gid, blksize, blocks, mtime, atime, ctime, linkname, xattr_names, pinode FROM vrsummary WHERE (name REGEXP '"'"'^(?![\.]).*$'"'"') AND (
     CASE level()

--- a/test/regression/gufi_query.expected
+++ b/test/regression/gufi_query.expected
@@ -2,42 +2,42 @@
 $ gufi_query
 usage: gufi_query [options] GUFI_tree ...
 options:
-  -h                     help
-  -H                     show assigned input values (debugging)
-  -v                     version
-  -T <SQL_tsum>          SQL for tree-summary table
-  -S <SQL_sum>           SQL for summary table
-  -E <SQL_ent>           SQL for entries table
-  -a <0|1|2>             0 - if returned row, run next SQL, else stop (continue descent) (default)
-                         1 - skip T, run S and E whether or not a row was returned (old -a)
-                         2 - run T, S, and E whether or not a row was returned
-  -n <threads>           number of threads
-  -j                     print the information in terse form
-  -o <out_fname>         output file (one-per-thread, with thread-id suffix)
-  -d <delim>             delimiter (one char)  [use 'x' for 0x1E]
-  -O <out_DB>            output DB
-  -u                     prefix row with 1 int column count and each column with 1 octet type and 1 size_t length
-  -I <SQL_init>          SQL init
-  -F <SQL_fin>           SQL cleanup
-  -y <min level>         minimum level to go down
-  -z <max level>         maximum level to go down
-  -J <SQL_interm>        SQL for intermediate results
-  -K <create aggregate>  SQL to create the final aggregation table
-  -G <SQL_aggregate>     SQL for aggregated results
-  -m                     Keep mtime and atime same on the database files
-  -B <buffer size>       size of each thread's output buffer in bytes
-  -w                     open the database files in read-write mode instead of read only mode
-  -x                     index/query xattrs
-  -k <filename>          file containing directory names to skip
-  -M <bytes>             target memory footprint
-  -s <path>              File name prefix for swap files
-  -p <path>              Source path prefix
-  -e                     compress work items
+  -h, --help                        help
+  -H, --debug                       show assigned input values (debugging)
+  -v, --version                     version
+  -T <SQL_tsum>                     SQL for tree-summary table
+  -S <SQL_sum>                      SQL for summary table
+  -E <SQL_ent>                      SQL for entries table
+  -a <0|1|2>                        0 - if returned row, run next SQL, else stop (continue descent) (default)
+                                    1 - skip T, run S and E whether or not a row was returned (old -a)
+                                    2 - run T, S, and E whether or not a row was returned
+  -n, --threads <threads>           number of threads
+  -j, --terse-form                  print the information in terse form
+  -o, --output-file <out_fname>     output file (one-per-thread, with thread-id suffix)
+  -d, --delim <delim>               delimiter (one char)  [use 'x' for 0x1E]
+  -O, --output-db <out_DB>          output DB
+  -u                                prefix row with 1 int column count and each column with 1 octet type and 1 size_t length
+  -I <SQL_init>                     SQL init
+  -F <SQL_fin>                      SQL cleanup
+      --min-level <min level>       minimum level to go down
+      --max-level <max level>       maximum level to go down
+  -J <SQL_interm>                   SQL for intermediate results
+  -K <create aggregate>             SQL to create the final aggregation table
+  -G <SQL_aggregate>                SQL for aggregated results
+  -m                                Keep mtime and atime same on the database files
+  -B, --buffer-size <buffer size>   size of each thread's output buffer in bytes
+  -w, --read-write                  open the database files in read-write mode instead of read only mode
+  -x, --xattrs                      index/query xattrs
+  -k, --skip <filename>             file containing directory names to skip
+  -M <bytes>                        target memory footprint
+  -s, --swap-prefix <path>          File name prefix for swap files
+  -p, --path <path>                 Source path prefix for %s in SQL
+  -e                                compress work items
   -Q <basename>
      <table>
      <template>.<table>
-     <view>              External database file basename, per-attach table name, template + table name, and the resultant view
-  -D <filename>          File containing paths at single level to index (not including starting path). Must also use -y
+     <view>                         External database file basename, per-attach table name, template + table name, and the resultant view
+  -D <filename>                     File containing paths at single level to index (not including starting path). Must also use --min-level
 
 GUFI_tree        find GUFI tree here
 
@@ -242,7 +242,7 @@ prefix/unusual#? directory ,
 prefix/unusual#? directory ,/unusual, name?#
 
 # limit tree traversal to directories at level 1 (missing prefix/ and prefix/directory/subdirectory/)
-$ gufi_query -d " " -n 2 -y 1 -z 1 -S "SELECT rpath(sname, sroll) FROM vrsummary;" -E "SELECT rpath(sname, sroll) || '/' || name FROM vrpentries;" "prefix"
+$ gufi_query -d " " -n 2 --min-level 1 --max-level 1 -S "SELECT rpath(sname, sroll) FROM vrsummary;" -E "SELECT rpath(sname, sroll) || '/' || name FROM vrpentries;" "prefix"
 prefix/directory
 prefix/directory/executable
 prefix/directory/readonly
@@ -269,7 +269,7 @@ directory
 empty_directory
 
 # limit tree traversal to some directories under at level 1 (only prefix/directory and prefix/empty_directory)
-$ gufi_query -d " " -n 2 -y 1 -D "distributed.0" -S "SELECT rpath(sname, sroll) FROM vrsummary;" -E "SELECT rpath(sname, sroll) || '/' || name FROM vrpentries;" "prefix"
+$ gufi_query -d " " -n 2 --min-level 1 -D "distributed.0" -S "SELECT rpath(sname, sroll) FROM vrsummary;" -E "SELECT rpath(sname, sroll) || '/' || name FROM vrpentries;" "prefix"
 prefix/directory
 prefix/directory/executable
 prefix/directory/readonly
@@ -392,7 +392,7 @@ $ gufi_query -n 18446744073709551615 "prefix"
 Error: Could not allocate 18446744073709551615 thread structures
 
 # Bad user data key
-$ gufi_query -d " " -z 0 -E "SELECT {abc}, {def;" "prefix"
+$ gufi_query -d " " --max-level 0 -E "SELECT {abc}, {def;" "prefix"
 Error: Failed to do string replacements for -E
 Error: replacement key not found: abc
 Warning: Could not find stop character for user string key starting at index 14 of "SELECT {abc}, {def;"
@@ -536,6 +536,6 @@ $ gufi_query -d " " -m -S "SELECT name FROM vrsummary;" -E "SELECT name FROM vrp
 Could not database file's timestamps "prefix/db.db": No such file or directory (2)
 
 # multiple input directories are not allowed for partial querying
-$ gufi_query -n 2 -D "distributed.0" -y 1 "search" "search"
+$ gufi_query -n 2 -D "distributed.0" --min-level 1 "search" "search"
 Error: When -D is passed in, only one root directory may be specified
 

--- a/test/regression/gufi_query.py.expected
+++ b/test/regression/gufi_query.py.expected
@@ -2,42 +2,42 @@
 $ gufi_query.py -h
 usage: gufi_query [options] GUFI_tree ...
 options:
-  -h                     help
-  -H                     show assigned input values (debugging)
-  -v                     version
-  -T <SQL_tsum>          SQL for tree-summary table
-  -S <SQL_sum>           SQL for summary table
-  -E <SQL_ent>           SQL for entries table
-  -a <0|1|2>             0 - if returned row, run next SQL, else stop (continue descent) (default)
-                         1 - skip T, run S and E whether or not a row was returned (old -a)
-                         2 - run T, S, and E whether or not a row was returned
-  -n <threads>           number of threads
-  -j                     print the information in terse form
-  -o <out_fname>         output file (one-per-thread, with thread-id suffix)
-  -d <delim>             delimiter (one char)  [use 'x' for 0x1E]
-  -O <out_DB>            output DB
-  -u                     prefix row with 1 int column count and each column with 1 octet type and 1 size_t length
-  -I <SQL_init>          SQL init
-  -F <SQL_fin>           SQL cleanup
-  -y <min level>         minimum level to go down
-  -z <max level>         maximum level to go down
-  -J <SQL_interm>        SQL for intermediate results
-  -K <create aggregate>  SQL to create the final aggregation table
-  -G <SQL_aggregate>     SQL for aggregated results
-  -m                     Keep mtime and atime same on the database files
-  -B <buffer size>       size of each thread's output buffer in bytes
-  -w                     open the database files in read-write mode instead of read only mode
-  -x                     index/query xattrs
-  -k <filename>          file containing directory names to skip
-  -M <bytes>             target memory footprint
-  -s <path>              File name prefix for swap files
-  -p <path>              Source path prefix
-  -e                     compress work items
+  -h, --help                        help
+  -H, --debug                       show assigned input values (debugging)
+  -v, --version                     version
+  -T <SQL_tsum>                     SQL for tree-summary table
+  -S <SQL_sum>                      SQL for summary table
+  -E <SQL_ent>                      SQL for entries table
+  -a <0|1|2>                        0 - if returned row, run next SQL, else stop (continue descent) (default)
+                                    1 - skip T, run S and E whether or not a row was returned (old -a)
+                                    2 - run T, S, and E whether or not a row was returned
+  -n, --threads <threads>           number of threads
+  -j, --terse-form                  print the information in terse form
+  -o, --output-file <out_fname>     output file (one-per-thread, with thread-id suffix)
+  -d, --delim <delim>               delimiter (one char)  [use 'x' for 0x1E]
+  -O, --output-db <out_DB>          output DB
+  -u                                prefix row with 1 int column count and each column with 1 octet type and 1 size_t length
+  -I <SQL_init>                     SQL init
+  -F <SQL_fin>                      SQL cleanup
+      --min-level <min level>       minimum level to go down
+      --max-level <max level>       maximum level to go down
+  -J <SQL_interm>                   SQL for intermediate results
+  -K <create aggregate>             SQL to create the final aggregation table
+  -G <SQL_aggregate>                SQL for aggregated results
+  -m                                Keep mtime and atime same on the database files
+  -B, --buffer-size <buffer size>   size of each thread's output buffer in bytes
+  -w, --read-write                  open the database files in read-write mode instead of read only mode
+  -x, --xattrs                      index/query xattrs
+  -k, --skip <filename>             file containing directory names to skip
+  -M <bytes>                        target memory footprint
+  -s, --swap-prefix <path>          File name prefix for swap files
+  -p, --path <path>                 Source path prefix for %s in SQL
+  -e                                compress work items
   -Q <basename>
      <table>
      <template>.<table>
-     <view>              External database file basename, per-attach table name, template + table name, and the resultant view
-  -D <filename>          File containing paths at single level to index (not including starting path). Must also use -y
+     <view>                         External database file basename, per-attach table name, template + table name, and the resultant view
+  -D <filename>                     File containing paths at single level to index (not including starting path). Must also use --min-level
 
 GUFI_tree        find GUFI tree here
 

--- a/test/regression/gufi_query.sh.in
+++ b/test/regression/gufi_query.sh.in
@@ -125,12 +125,12 @@ echo "# Get all directory and non-directory names and their xattrs"
 run_sort "${GUFI_QUERY} -d \" \" -n ${THREADS} -S \"SELECT rpath(sname, sroll), xattr_name, xattr_value FROM vrxsummary;\" -E \"SELECT rpath(sname, sroll) || '/' || name, xattr_name, xattr_value FROM vrxpentries;\" -x \"${INDEXROOT}\""
 
 echo "# limit tree traversal to directories at level 1 (missing prefix/ and prefix/directory/subdirectory/)"
-run_sort "${GUFI_QUERY} -d \" \" -n ${THREADS} -y ${DISTRIBUTED_LEVEL} -z 1 -S \"SELECT rpath(sname, sroll) FROM vrsummary;\" -E \"SELECT rpath(sname, sroll) || '/' || name FROM vrpentries;\" \"${INDEXROOT}\""
+run_sort "${GUFI_QUERY} -d \" \" -n ${THREADS} --min-level ${DISTRIBUTED_LEVEL} --max-level 1 -S \"SELECT rpath(sname, sroll) FROM vrsummary;\" -E \"SELECT rpath(sname, sroll) || '/' || name FROM vrpentries;\" \"${INDEXROOT}\""
 
 partial_indexing_setup
 run_no_sort "cat \"${DISTRIBUTED_0}\""
 echo "# limit tree traversal to some directories under at level 1 (only prefix/directory and prefix/empty_directory)"
-run_sort "${GUFI_QUERY} -d \" \" -n ${THREADS} -y ${DISTRIBUTED_LEVEL} -D \"${DISTRIBUTED_0}\" -S \"SELECT rpath(sname, sroll) FROM vrsummary;\" -E \"SELECT rpath(sname, sroll) || '/' || name FROM vrpentries;\" \"${INDEXROOT}\""
+run_sort "${GUFI_QUERY} -d \" \" -n ${THREADS} --min-level ${DISTRIBUTED_LEVEL} -D \"${DISTRIBUTED_0}\" -S \"SELECT rpath(sname, sroll) FROM vrsummary;\" -E \"SELECT rpath(sname, sroll) || '/' || name FROM vrpentries;\" \"${INDEXROOT}\""
 
 echo "# Output TLV columns (no aggregation)"
 run_no_sort "${GUFI_QUERY} -u -n ${THREADS} -E \"SELECT name, size FROM vrpentries WHERE name == '.hidden';\" \"${INDEXROOT}\" | ${HEXLIFY}"
@@ -208,7 +208,7 @@ echo "# Bad thread count"
 run_no_sort "${GUFI_QUERY} -n 18446744073709551615 \"${INDEXROOT}\""
 
 echo "# Bad user data key"
-run_sort "${GUFI_QUERY} -d \" \" -z 0 -E \"SELECT {abc}, {def;\" \"${INDEXROOT}\"" | @SED@ '\%^$%d;'
+run_sort "${GUFI_QUERY} -d \" \" --max-level 0 -E \"SELECT {abc}, {def;\" \"${INDEXROOT}\"" | @SED@ '\%^$%d;'
 
 echo "#####################################"
 echo "# Extra Inputs                      #"
@@ -278,7 +278,7 @@ rm "${INDEXROOT}/db.db"
 run_sort "${GUFI_QUERY} -d \" \" -m -S \"SELECT name FROM vrsummary;\" -E \"SELECT name FROM vrpentries;\" \"${INDEXROOT}\" > /dev/null"
 
 echo "# multiple input directories are not allowed for partial querying"
-run_no_sort "${GUFI_QUERY} -n ${THREADS} -D \"${DISTRIBUTED_0}\" -y ${DISTRIBUTED_LEVEL} \"${SEARCH}\" \"${SEARCH}\""
+run_no_sort "${GUFI_QUERY} -n ${THREADS} -D \"${DISTRIBUTED_0}\" --min-level ${DISTRIBUTED_LEVEL} \"${SEARCH}\" \"${SEARCH}\""
 ) 2>&1 | tee "${OUTPUT}"
 
 echo "# Print terse debug timestamps (not part of expected results)"

--- a/test/regression/gufi_rollup.expected
+++ b/test/regression/gufi_rollup.expected
@@ -2,16 +2,16 @@
 $ gufi_rollup
 usage: gufi_rollup [options] GUFI_tree ...
 options:
-  -h                     help
-  -H                     show assigned input values (debugging)
-  -v                     version
-  -n <threads>           number of threads
-  -L <count>             Highest number of files/links in a directory allowed to be rolled up
-  -X                     Dry run
-  -y <min level>         minimum level to go down
-  -z <max level>         maximum level to go down
-  -D <filename>          File containing paths at single level to index (not including starting path). Must also use -y
-  -l                     if a directory was previously processed, skip descending the subtree
+  -h, --help                        help
+  -H, --debug                       show assigned input values (debugging)
+  -v, --version                     version
+  -n, --threads <threads>           number of threads
+  -L <count>                        Highest number of files/links in a directory allowed to be rolled up
+  -X, --dry-run                     Dry run
+      --min-level <min level>       minimum level to go down
+      --max-level <max level>       maximum level to go down
+  -D <filename>                     File containing paths at single level to index (not including starting path). Must also use --min-level
+  -l                                if a directory was previously processed, skip descending the subtree
 
 GUFI_tree         GUFI tree to roll up
 
@@ -1485,7 +1485,7 @@ Creating GUFI Index search with 1 threads
 Total Dirs:          6
 Total Non-Dirs:      14
 # Partial Rollup up to level 1
-$ gufi_rollup -y 1 -D "path_list" "prefix"
+$ gufi_rollup --min-level 1 -D "path_list" "prefix"
 Roots:
     prefix
 
@@ -1530,7 +1530,7 @@ prefix/unusual#? directory ,|0
 prefix|0
 
 # Full Rollup up to level 1
-$ gufi_rollup -y 1 "prefix"
+$ gufi_rollup --min-level 1 "prefix"
 Roots:
     prefix
 

--- a/test/regression/gufi_rollup.sh.in
+++ b/test/regression/gufi_rollup.sh.in
@@ -165,13 +165,13 @@ rm -rf "${SEARCH}"
 "${GUFI_DIR2INDEX}" "${SRCDIR}" "${SEARCH}" 2>&1
 
 echo "# Partial Rollup up to level 1"
-run_no_sort "${GUFI_ROLLUP} -y 1 -D \"${PATH_LIST}\" \"${INDEXROOT}\""
+run_no_sort "${GUFI_ROLLUP} --min-level 1 -D \"${PATH_LIST}\" \"${INDEXROOT}\""
 
 echo "# Check which directories have been rolled up"
 run_sort "${GUFI_QUERY} -d \"${DELIM}\" -S \"SELECT rpath(sname, sroll), rollupscore FROM vrsummary\" \"${INDEXROOT}\""
 
 echo "# Full Rollup up to level 1"
-run_no_sort "${GUFI_ROLLUP} -y 1 \"${INDEXROOT}\""
+run_no_sort "${GUFI_ROLLUP} --min-level 1 \"${INDEXROOT}\""
 
 echo "# Check which directories have been rolled up"
 run_sort "${GUFI_QUERY} -d \"${DELIM}\" -S \"SELECT rpath(sname, sroll), rollupscore FROM vrsummary\" \"${INDEXROOT}\""

--- a/test/regression/gufi_sqlite3.expected
+++ b/test/regression/gufi_sqlite3.expected
@@ -2,9 +2,9 @@
 $ gufi_sqlite3 -h
 usage: gufi_sqlite3 [options] [db [SQL]...]
 options:
-  -h                     help
-  -v                     version
-  -d <delim>             delimiter (one char)  [use 'x' for 0x1E]
+  -h, --help                        help
+  -v, --version                     version
+  -d, --delim <delim>               delimiter (one char)  [use 'x' for 0x1E]
 
 db                       db file path
 SQL                      SQL statements to run

--- a/test/regression/gufi_stat_bin.expected
+++ b/test/regression/gufi_stat_bin.expected
@@ -1,11 +1,11 @@
 $ gufi_stat_bin -h
 usage: gufi_stat_bin [options] path ...
 options:
-  -h                     help
-  -H                     show assigned input values (debugging)
-  -v                     version
-  -f <FORMAT>            use the specified FORMAT instead of the default; output a newline after each use of FORMAT
-  -j                     print the information in terse form
+  -h, --help                        help
+  -H, --debug                       show assigned input values (debugging)
+  -v, --version                     version
+  -f, --format <FORMAT>             use the specified FORMAT instead of the default; output a newline after each use of FORMAT
+  -j, --terse-form                  print the information in terse form
 
 path                 path to stat
 

--- a/test/regression/gufi_stats.expected
+++ b/test/regression/gufi_stats.expected
@@ -20,8 +20,8 @@ GUFI query is
     -J 'INSERT INTO aggregate SELECT * FROM out ' \
     -K 'CREATE TABLE aggregate(name TEXT)' \
     -G 'SELECT CASE length(name) WHEN 0 THEN 0 ELSE length(name) - length(replace(name, '"'"'/'"'"', '"'"''"'"')) + 1 END FROM aggregate ORDER BY name ASC' \
-    -y 0 \
-    -z 0 \
+    --min-level 0 \
+    --max-level 0 \
     prefix
 1
 

--- a/test/regression/gufi_trace2dir.expected
+++ b/test/regression/gufi_trace2dir.expected
@@ -2,12 +2,12 @@
 $ gufi_trace2dir
 usage: gufi_trace2dir [options] trace_file... output_dir
 options:
-  -h                     help
-  -H                     show assigned input values (debugging)
-  -v                     version
-  -n <threads>           number of threads
-  -d <delim>             delimiter (one char)  [use 'x' for 0x1E]
-  -x                     index/query xattrs
+  -h, --help                        help
+  -H, --debug                       show assigned input values (debugging)
+  -v, --version                     version
+  -n, --threads <threads>           number of threads
+  -d, --delim <delim>               delimiter (one char)  [use 'x' for 0x1E]
+  -x, --xattrs                      index/query xattrs
 
 input_dir         walk this GUFI index to produce a tree
 output_dir        reconstruct the tree under here

--- a/test/regression/gufi_trace2index.expected
+++ b/test/regression/gufi_trace2index.expected
@@ -2,13 +2,13 @@
 $ gufi_trace2index
 usage: gufi_trace2index [options] trace_file... output_dir
 options:
-  -h                     help
-  -H                     show assigned input values (debugging)
-  -v                     version
-  -n <threads>           number of threads
-  -d <delim>             delimiter (one char)  [use 'x' for 0x1E]
-  -M <bytes>             target memory footprint
-  -s <path>              File name prefix for swap files
+  -h, --help                        help
+  -H, --debug                       show assigned input values (debugging)
+  -v, --version                     version
+  -n, --threads <threads>           number of threads
+  -d, --delim <delim>               delimiter (one char)  [use 'x' for 0x1E]
+  -M <bytes>                        target memory footprint
+  -s, --swap-prefix <path>          File name prefix for swap files
 
 trace_file...     parse one or more trace files to produce the GUFI tree
 output_dir        build GUFI tree here

--- a/test/regression/gufi_treesummary.expected
+++ b/test/regression/gufi_treesummary.expected
@@ -2,13 +2,13 @@
 $ gufi_treesummary
 usage: gufi_treesummary [options] GUFI_tree
 options:
-  -h                     help
-  -H                     show assigned input values (debugging)
-  -v                     version
-  -P                     print directories as they are encountered
-  -n <threads>           number of threads
-  -d <delim>             delimiter (one char)  [use 'x' for 0x1E]
-  -X                     Dry run
+  -h, --help                        help
+  -H, --debug                       show assigned input values (debugging)
+  -v, --version                     version
+  -P                                print directories as they are encountered
+  -n, --threads <threads>           number of threads
+  -d, --delim <delim>               delimiter (one char)  [use 'x' for 0x1E]
+  -X, --dry-run                     Dry run
 
 GUFI_tree               path to GUFI tree
 

--- a/test/regression/gufi_treesummary_all.expected
+++ b/test/regression/gufi_treesummary_all.expected
@@ -2,14 +2,14 @@
 $ gufi_treesummary_all
 usage: gufi_treesummary_all [options] GUFI_tree
 options:
-  -h                     help
-  -H                     show assigned input values (debugging)
-  -v                     version
-  -n <threads>           number of threads
-  -y <min level>         minimum level to go down
-  -z <max level>         maximum level to go down
-  -D <filename>          File containing paths at single level to index (not including starting path). Must also use -y
-  -l                     if a directory was previously processed, skip descending the subtree
+  -h, --help                        help
+  -H, --debug                       show assigned input values (debugging)
+  -v, --version                     version
+  -n, --threads <threads>           number of threads
+      --min-level <min level>       minimum level to go down
+      --max-level <max level>       maximum level to go down
+  -D <filename>                     File containing paths at single level to index (not including starting path). Must also use --min-level
+  -l                                if a directory was previously processed, skip descending the subtree
 
 GUFI_tree                path to GUFI tree
 
@@ -19,7 +19,7 @@ $ gufi_query -d " " -S "SELECT '' FROM tree.sqlite_master WHERE (type == 'table'
 
 
 # Generate treesummary tables in some directories at level 1
-$ gufi_treesummary_all -y 1 -D "path_list" "prefix"
+$ gufi_treesummary_all --min-level 1 -D "path_list" "prefix"
 
 # Query treesummary tables
 $ gufi_query -d " " -T "SELECT rpath(s.sname, s.sroll), t.totsubdirs, t.maxsubdirfiles, t.maxsubdirlinks, t.totfiles, t.totlinks FROM treesummary AS t, vrsummary as s;" "prefix"
@@ -29,7 +29,7 @@ prefix/leaf_directory 0 2 0 2 0
 
 
 # Generate treesummary tables in all directories at level 1
-$ gufi_treesummary_all -y 1 "prefix"
+$ gufi_treesummary_all --min-level 1 "prefix"
 
 # Query treesummary tables
 $ gufi_query -d " " -T "SELECT rpath(s.sname, s.sroll), t.totsubdirs, t.maxsubdirfiles, t.maxsubdirlinks, t.totfiles, t.totlinks FROM treesummary AS t, vrsummary as s;" "prefix"
@@ -60,7 +60,7 @@ $ gufi_treesummary_all -l "prefix"
 $ gufi_treesummary_all "search"
 Cannot open database: search/db.db unable to open database file rc 14
 
-# Multiple paths with -y and -D
-$ gufi_treesummary_all -y 1 -D path_list "search" "search"
-Error: Only one root may be provided when a -y and -D are both provided
+# Multiple paths with --min-level and -D
+$ gufi_treesummary_all --min-level 1 -D path_list "search" "search"
+Error: Only one root may be provided when a --min-level and -D are both provided
 

--- a/test/regression/gufi_treesummary_all.sh.in
+++ b/test/regression/gufi_treesummary_all.sh.in
@@ -95,14 +95,14 @@ echo "# Start with no treesummary tables"
 echo
 
 echo "# Generate treesummary tables in some directories at level 1"
-run_no_sort "${GUFI_TREESUMMARY_ALL} -y 1 -D \"${PATH_LIST}\" \"${INDEXROOT}\"" | @SED@ '\%^Started .*$%d;'
+run_no_sort "${GUFI_TREESUMMARY_ALL} --min-level 1 -D \"${PATH_LIST}\" \"${INDEXROOT}\"" | @SED@ '\%^Started .*$%d;'
 
 echo "# Query treesummary tables"
 run_sort "${GUFI_QUERY} -d \" \" -T \"SELECT rpath(s.sname, s.sroll), t.totsubdirs, t.maxsubdirfiles, t.maxsubdirlinks, t.totfiles, t.totlinks FROM treesummary AS t, vrsummary as s;\" \"${INDEXROOT}\""
 echo
 
 echo "# Generate treesummary tables in all directories at level 1"
-run_no_sort "${GUFI_TREESUMMARY_ALL} -y 1 \"${INDEXROOT}\"" | @SED@ '\%^Started .*$%d;'
+run_no_sort "${GUFI_TREESUMMARY_ALL} --min-level 1 \"${INDEXROOT}\"" | @SED@ '\%^Started .*$%d;'
 
 echo "# Query treesummary tables"
 run_sort "${GUFI_QUERY} -d \" \" -T \"SELECT rpath(s.sname, s.sroll), t.totsubdirs, t.maxsubdirfiles, t.maxsubdirlinks, t.totfiles, t.totlinks FROM treesummary AS t, vrsummary as s;\" \"${INDEXROOT}\""
@@ -123,8 +123,8 @@ rm -rf "${SEARCH}/db.db"
 echo "# Missing db.db"
 run_no_sort "${GUFI_TREESUMMARY_ALL} \"${SEARCH}\"" | @SED@ '\%^Started .*$%d;'
 
-echo "# Multiple paths with -y and -D"
-run_no_sort "${GUFI_TREESUMMARY_ALL} -y 1 -D path_list \"${SEARCH}\" \"${SEARCH}\""
+echo "# Multiple paths with --min-level and -D"
+run_no_sort "${GUFI_TREESUMMARY_ALL} --min-level 1 -D path_list \"${SEARCH}\" \"${SEARCH}\""
 ) 2>&1 | replace | tee "${OUTPUT}"
 
 @DIFF@ @CMAKE_CURRENT_BINARY_DIR@/gufi_treesummary_all.expected "${OUTPUT}"

--- a/test/regression/gufi_unrollup.expected
+++ b/test/regression/gufi_unrollup.expected
@@ -2,13 +2,13 @@
 $ gufi_unrollup
 usage: gufi_unrollup [options] GUFI_tree ...
 options:
-  -h                     help
-  -H                     show assigned input values (debugging)
-  -v                     version
-  -n <threads>           number of threads
-  -y <min level>         minimum level to go down
-  -z <max level>         maximum level to go down
-  -D <filename>          File containing paths at single level to index (not including starting path). Must also use -y
+  -h, --help                        help
+  -H, --debug                       show assigned input values (debugging)
+  -v, --version                     version
+  -n, --threads <threads>           number of threads
+      --min-level <min level>       minimum level to go down
+      --max-level <max level>       maximum level to go down
+  -D <filename>                     File containing paths at single level to index (not including starting path). Must also use --min-level
 
 GUFI_tree        GUFI tree to unroll up
 
@@ -298,7 +298,7 @@ Total:          165
 Remaining Dirs: 17 (24.64%)
 
 # only unroll up levels 0 and 1
-$ gufi_unrollup -y 0 -z 1 "prefix"
+$ gufi_unrollup --min-level 0 --max-level 1 "prefix"
 
 # level, COUNT(entries), COUNT(pentries_rollup), rollupscore, directory
 $ gufi_query -d " " -S "SELECT level(), (SELECT COUNT(*) FROM entries), (SELECT COUNT(*) FROM pentries_rollup), rollupscore, rpath(name, rollupscore) AS fullpath FROM summary ORDER BY fullpath ASC" "prefix"
@@ -373,7 +373,7 @@ $ gufi_query -d " " -S "SELECT level(), (SELECT COUNT(*) FROM entries), (SELECT 
 2 0 6 1 ugo/ugo/dir3
 
 # only unroll up level 2 and below
-$ gufi_unrollup -y 2 "prefix"
+$ gufi_unrollup --min-level 2 "prefix"
 
 # level, COUNT(entries), COUNT(pentries_rollup), rollupscore, directory
 $ gufi_query -d " " -S "SELECT level(), (SELECT COUNT(*) FROM entries), (SELECT COUNT(*) FROM pentries_rollup), rollupscore, rpath(name, rollupscore) AS fullpath FROM summary ORDER BY fullpath ASC" "prefix"
@@ -504,7 +504,7 @@ Total:          165
 Remaining Dirs: 17 (24.64%)
 
 # partial unroll up
-$ gufi_unrollup -y 2 -D "path_list" "prefix"
+$ gufi_unrollup --min-level 2 -D "path_list" "prefix"
 
 # level, COUNT(entries), COUNT(pentries_rollup), rollupscore, directory
 $ gufi_query -d " " -S "SELECT level(), (SELECT COUNT(*) FROM entries), (SELECT COUNT(*) FROM pentries_rollup), rollupscore, rpath(name, rollupscore) AS fullpath FROM summary ORDER BY fullpath ASC" "prefix"

--- a/test/regression/gufi_unrollup.sh.in
+++ b/test/regression/gufi_unrollup.sh.in
@@ -130,12 +130,12 @@ query
 rollup
 
 echo "# only unroll up levels 0 and 1"
-run_no_sort "${GUFI_UNROLLUP} -y 0 -z 1 \"${INDEXROOT}\""
+run_no_sort "${GUFI_UNROLLUP} --min-level 0 --max-level 1 \"${INDEXROOT}\""
 
 query
 
 echo "# only unroll up level 2 and below"
-run_no_sort "${GUFI_UNROLLUP} -y 2 \"${INDEXROOT}\""
+run_no_sort "${GUFI_UNROLLUP} --min-level 2 \"${INDEXROOT}\""
 
 query
 # ###########################################
@@ -144,7 +144,7 @@ query
 rollup
 
 echo "# partial unroll up"
-run_no_sort "${GUFI_UNROLLUP} -y 2 -D \"${PATH_LIST}\" \"${INDEXROOT}\""
+run_no_sort "${GUFI_UNROLLUP} --min-level 2 -D \"${PATH_LIST}\" \"${INDEXROOT}\""
 
 query
 # ###########################################

--- a/test/regression/longitudinal_snapshot.expected
+++ b/test/regression/longitudinal_snapshot.expected
@@ -12,8 +12,8 @@ GUFI query is
    gufi_query \
     -n 1 \
     -x \
-    -y 0 \
-    -z 18446744073709551615 \
+    --min-level 0 \
+    --max-level 18446744073709551615 \
     -O flattened_index.db \
     -I 'DROP TABLE IF EXISTS intermediate_treesummary;
               CREATE TABLE intermediate_treesummary(level INT64, inode TEXT, pinode TEXT, totsubdirs INT64, maxsubdirfiles INT64, maxsubdirlinks INT64, maxsubdirsize INT64, totfiles INT64, totlinks INT64, minuid INT64, maxuid INT64, mingid INT64, maxgid INT64, minsize INT64, maxsize INT64, totzero INT64, totltk INT64, totmtk INT64, totltm INT64, totmtm INT64, totmtg INT64, totmtt INT64, totsize INT64, minctime INT64, maxctime INT64, minmtime INT64, maxmtime INT64, minatime INT64, maxatime INT64, minblocks INT64, maxblocks INT64, totxattr INT64, mincrtime INT64, maxcrtime INT64, minossint1 INT64, maxossint1 INT64, totossint1 INT64, minossint2 INT64, maxossint2 INT64, totossint2 INT64, minossint3 INT64, maxossint3 INT64, totossint3 INT64, minossint4 INT64, maxossint4 INT64, totossint4 INT64);

--- a/test/regression/parallel_cpr.expected
+++ b/test/regression/parallel_cpr.expected
@@ -1,11 +1,11 @@
 $ parallel_cpr -h
 usage: parallel_cpr [options] src... dst
 options:
-  -h                     help
-  -H                     show assigned input values (debugging)
-  -v                     version
-  -n <threads>           number of threads
-  -x                     index/query xattrs
+  -h, --help                        help
+  -H, --debug                       show assigned input values (debugging)
+  -v, --version                     version
+  -n, --threads <threads>           number of threads
+  -x, --xattrs                      index/query xattrs
 
 src...     directory to copy
 dst        directory to place sources under

--- a/test/regression/parallel_cpr.sh.in
+++ b/test/regression/parallel_cpr.sh.in
@@ -86,7 +86,7 @@ DIFF_FLAGS="--side-by-side --width 100 --expand-tabs"
 # shellcheck disable=SC2050
 if [[ "@DIFF@" =~ .*colordiff ]]
 then
-    DIFF_FLAGS="${DIFF_FLAGS} --color=no"
+    DIFF_FLAGS="${DIFF_FLAGS} --color=never"
 fi
 
 (

--- a/test/regression/parallel_find.expected
+++ b/test/regression/parallel_find.expected
@@ -1,16 +1,16 @@
 $ parallel_find -h
 usage: parallel_find [options] input_dir...
 options:
-  -h                     help
-  -H                     show assigned input values (debugging)
-  -v                     version
-  -n <threads>           number of threads
-  -f <FORMAT>            use the specified FORMAT instead of the default; output a newline after each use of FORMAT
-  -y <min level>         minimum level to go down
-  -z <max level>         maximum level to go down
-  -t <filter_type>       one or more types to keep ('f', 'd', 'l')
-  -o <out_fname>         output file (one-per-thread, with thread-id suffix)
-  -B <buffer size>       size of each thread's output buffer in bytes
+  -h, --help                        help
+  -H, --debug                       show assigned input values (debugging)
+  -v, --version                     version
+  -n, --threads <threads>           number of threads
+  -f, --format <FORMAT>             use the specified FORMAT instead of the default; output a newline after each use of FORMAT
+      --min-level <min level>       minimum level to go down
+      --max-level <max level>       maximum level to go down
+  -t, --filter-type <filter_type>   one or more types to keep ('f', 'd', 'l')
+  -o, --output-file <out_fname>     output file (one-per-thread, with thread-id suffix)
+  -B, --buffer-size <buffer size>   size of each thread's output buffer in bytes
 
 input_dir...      walk one or more trees to search files
 
@@ -18,16 +18,16 @@ input_dir...      walk one or more trees to search files
 $ parallel_find
 usage: parallel_find [options] input_dir...
 options:
-  -h                     help
-  -H                     show assigned input values (debugging)
-  -v                     version
-  -n <threads>           number of threads
-  -f <FORMAT>            use the specified FORMAT instead of the default; output a newline after each use of FORMAT
-  -y <min level>         minimum level to go down
-  -z <max level>         maximum level to go down
-  -t <filter_type>       one or more types to keep ('f', 'd', 'l')
-  -o <out_fname>         output file (one-per-thread, with thread-id suffix)
-  -B <buffer size>       size of each thread's output buffer in bytes
+  -h, --help                        help
+  -H, --debug                       show assigned input values (debugging)
+  -v, --version                     version
+  -n, --threads <threads>           number of threads
+  -f, --format <FORMAT>             use the specified FORMAT instead of the default; output a newline after each use of FORMAT
+      --min-level <min level>       minimum level to go down
+      --max-level <max level>       maximum level to go down
+  -t, --filter-type <filter_type>   one or more types to keep ('f', 'd', 'l')
+  -o, --output-file <out_fname>     output file (one-per-thread, with thread-id suffix)
+  -B, --buffer-size <buffer size>   size of each thread's output buffer in bytes
 
 input_dir...      walk one or more trees to search files
 
@@ -102,7 +102,7 @@ prefix/directory/subdirectory/directory_symlink/directory_symlink
 prefix/directory/subdirectory/directory_symlink/repeat_name
 
 # only get directories at level 2
-$ parallel_find -n 2 -t d -y 2 -z 2 "prefix"
+$ parallel_find -n 2 -t d --min-level 2 --max-level 2 "prefix"
 prefix/directory/subdirectory
 
 # only get links
@@ -178,7 +178,7 @@ Path: prefix/unusual#? directory ,
 Path: prefix/unusual#? directory ,/unusual, name?#
 
 # level higher than the level of the tree
-$ parallel_find -n 2 -y 10 "prefix"
+$ parallel_find -n 2 --min-level 10 "prefix"
 
 # directory with multiple slashes
 $ parallel_find -n 2 "prefix////"

--- a/test/regression/parallel_find.sh.in
+++ b/test/regression/parallel_find.sh.in
@@ -115,7 +115,7 @@ echo "# mix of files, dirs, links"
 run_sort "${PARALLEL_FIND} -n ${THREADS} \"${SRCDIR}/directory/subdirectory/directory_symlink\" \"${SRCDIR}/1MB\" \"${SRCDIR}/\""
 
 echo "# only get directories at level 2"
-run_sort "${PARALLEL_FIND} -n ${THREADS} -t d -y 2 -z 2 \"${SRCDIR}\""
+run_sort "${PARALLEL_FIND} -n ${THREADS} -t d --min-level 2 --max-level 2 \"${SRCDIR}\""
 
 echo "# only get links"
 run_sort "${PARALLEL_FIND} -n ${THREADS} -t l \"${SRCDIR}\""
@@ -133,7 +133,7 @@ echo "# print non-format characters"
 run_sort "${PARALLEL_FIND} -n ${THREADS} -f \"Path: %p\\n\" \"${SRCDIR}\""
 
 echo "# level higher than the level of the tree"
-run_sort "${PARALLEL_FIND} -n ${THREADS} -y 10 \"${SRCDIR}\""
+run_sort "${PARALLEL_FIND} -n ${THREADS} --min-level 10 \"${SRCDIR}\""
 
 echo "# directory with multiple slashes"
 run_sort "${PARALLEL_FIND} -n ${THREADS} \"${SRCDIR}////\""

--- a/test/regression/parallel_rmr.expected
+++ b/test/regression/parallel_rmr.expected
@@ -1,10 +1,10 @@
 $ parallel_rmr -h
 usage: parallel_rmr [options] directory ...
 options:
-  -h                     help
-  -H                     show assigned input values (debugging)
-  -v                     version
-  -n <threads>           number of threads
+  -h, --help                        help
+  -H, --debug                       show assigned input values (debugging)
+  -v, --version                     version
+  -n, --threads <threads>           number of threads
 
 directory        directory to delete
 

--- a/test/regression/treediff.expected
+++ b/test/regression/treediff.expected
@@ -1,11 +1,11 @@
 $ treediff -h
 usage: treediff [options] lhs rhs
 options:
-  -h                     help
-  -H                     show assigned input values (debugging)
-  -n <threads>           number of threads
-  -z <max level>         maximum level to go down
-  -k <filename>          file containing directory names to skip
+  -h, --help                        help
+  -H, --debug                       show assigned input values (debugging)
+  -n, --threads <threads>           number of threads
+      --max-level <max level>       maximum level to go down
+  -k, --skip <filename>             file containing directory names to skip
 
 lhs               starting path of tree used on left hand side of this comparision
 rhs               starting path of tree used on right hand side of this comparision
@@ -34,7 +34,7 @@ prefix/new_name
 prefix/xyz
 
 # Not enough levels to show differences
-$ treediff -z 0 "prefix" "prefix"
+$ treediff --max-level 0 "prefix" "prefix"
 
 # Bad left hand path
 $ treediff "" "search"

--- a/test/regression/treediff.sh.in
+++ b/test/regression/treediff.sh.in
@@ -85,7 +85,7 @@ run_sort "${TREEDIFF} \"${SRCDIR}\" \"${INDEXROOT}\""
 run_sort "${TREEDIFF} \"${INDEXROOT}\" \"${SRCDIR}\""
 
 echo "# Not enough levels to show differences"
-run_sort "${TREEDIFF} -z 0 \"${SRCDIR}\" \"${INDEXROOT}\""
+run_sort "${TREEDIFF} --max-level 0 \"${SRCDIR}\" \"${INDEXROOT}\""
 
 echo "# Bad left hand path"
 run_no_sort "${TREEDIFF} \"\" \"${SEARCH}\""

--- a/test/unit/googletest/bf.cpp
+++ b/test/unit/googletest/bf.cpp
@@ -97,8 +97,8 @@ static const std::string W = "-W"; static const std::string W_arg = "W arg";
 static const std::string A = "-A"; static const std::string A_arg = "1";
 static const std::string g = "-g"; static const std::string g_arg = "1";
 static const std::string c = "-c"; static const std::string c_arg = "1";
-static const std::string y = "-y"; static const std::string y_arg = "1";
-static const std::string z = "-z"; static const std::string z_arg = "1";
+static const std::string y = "--min-level"; static const std::string y_arg = "1";
+static const std::string z = "--max-level"; static const std::string z_arg = "1";
 static const std::string J = "-J"; static const std::string J_arg = "J arg";
 static const std::string K = "-K"; static const std::string K_arg = "K arg";
 static const std::string G = "-G"; static const std::string G_arg = "G arg";
@@ -243,7 +243,7 @@ static void check_input(struct input *in, const bool helped, const bool version,
 }
 
 TEST(parse_cmd_line, help) {
-    const char opts[] = "h";
+    const struct option opts[] = { FLAG_HELP, FLAG_END };
 
     const char *argv[] = {
         exec.c_str(),
@@ -268,7 +268,7 @@ TEST(parse_cmd_line, help) {
 }
 
 TEST(parse_cmd_line, version) {
-    const char opts[] = "v";
+    const struct option opts[] = { FLAG_VERSION, FLAG_END };
 
     const char *argv[] = {
         exec.c_str(),
@@ -293,7 +293,25 @@ TEST(parse_cmd_line, version) {
 }
 
 TEST(parse_cmd_line, debug) {
-    const char opts[] = "HxPba:n:d:i:t:o:O:uI:T:S:E:F:rRYZW:A:g:c:y:z:J:K:G:mB:wf:jXL:k:M:C:" COMPRESS_OPT "qQ:s:D:";
+    /* flag i is missing */
+    const struct option opts[] = {
+        FLAG_DEBUG, FLAG_XATTRS, FLAG_PRINTDIR, FLAG_BUILDINDEX,
+        FLAG_PROCESS_SQL, FLAG_THREADS, FLAG_DELIM, FLAG_FILTER_TYPE,
+        FLAG_OUTPUT_FILE, FLAG_OUTPUT_DB, FLAG_PREFIX, FLAG_SQL_INIT,
+        FLAG_SQL_TSUM, FLAG_SQL_SUM, FLAG_SQL_ENT, FLAG_SQL_FIN,
+        FLAG_INSERT_FILE_LINK, FLAG_INSERT_DIR, FLAG_SUSPECT_DIR,
+        FLAG_SUSPECT_FILE_LINK, FLAG_INSUSPECT, FLAG_SUSPECT_METHOD,
+        FLAG_STRIDE, FLAG_SUSPECT_TIME, FLAG_MIN_LEVEL, FLAG_MAX_LEVEL,
+        FLAG_SQL_INTERM, FLAG_SQL_CREATE_AGG, FLAG_SQL_AGG, FLAG_KEEP_MATIME,
+        FLAG_BUFFER_SIZE, FLAG_READ_WRITE, FLAG_FORMAT, FLAG_TERSE_FORMAT,
+        FLAG_DRY_RUN, FLAG_MAX_IN_DIR, FLAG_SKIP, FLAG_TARGET_MEMORY_FOOTPRINT,
+        FLAG_SUBDIR_LIMIT, FLAG_CHECK_EXTDB_VALID, FLAG_EXTERNAL_ATTACH,
+        FLAG_SWAP_PREFIX, FLAG_SUBTREE_LIST,
+        #ifdef HAVE_ZLIB
+        FLAG_COMPRESS,
+        #endif
+        FLAG_END
+    };
 
     const char *argv[] = {
         exec.c_str(),
@@ -360,7 +378,16 @@ TEST(parse_cmd_line, debug) {
 }
 
 TEST(parse_cmd_line, flags) {
-    const char opts[] = "xPburRYZmwjX" COMPRESS_OPT "q";
+    const struct option opts[] = {
+        FLAG_XATTRS, FLAG_PRINTDIR, FLAG_BUILDINDEX, FLAG_PREFIX,
+        FLAG_INSERT_FILE_LINK, FLAG_INSERT_DIR, FLAG_SUSPECT_DIR,
+        FLAG_SUSPECT_FILE_LINK, FLAG_KEEP_MATIME, FLAG_READ_WRITE,
+        FLAG_TERSE_FORMAT, FLAG_DRY_RUN,
+        #ifdef HAVE_ZLIB
+        FLAG_COMPRESS,
+        #endif
+        FLAG_CHECK_EXTDB_VALID, FLAG_END
+    };
 
     const char *argv[] = {
         exec.c_str(),
@@ -392,7 +419,16 @@ TEST(parse_cmd_line, flags) {
 }
 
 TEST(parse_cmd_line, options) {
-    const char opts[] = "a:n:d:i:t:I:T:S:E:F:W:A:g:c:y:z:J:K:G:B:f:L:k:M:C:Q:s:D:";
+    const struct option opts[] = {
+        FLAG_PROCESS_SQL, FLAG_THREADS, FLAG_DELIM, FLAG_FILTER_TYPE,
+        FLAG_SQL_INIT, FLAG_SQL_TSUM, FLAG_SQL_SUM, FLAG_SQL_ENT,
+        FLAG_SQL_FIN, FLAG_INSUSPECT, FLAG_SUSPECT_METHOD, FLAG_STRIDE,
+        FLAG_SUSPECT_TIME, FLAG_MIN_LEVEL, FLAG_MAX_LEVEL, FLAG_SQL_INTERM,
+        FLAG_SQL_CREATE_AGG, FLAG_SQL_AGG, FLAG_BUFFER_SIZE, FLAG_FORMAT,
+        FLAG_MAX_IN_DIR, FLAG_SKIP, FLAG_TARGET_MEMORY_FOOTPRINT,
+        FLAG_SUBDIR_LIMIT, FLAG_EXTERNAL_ATTACH, FLAG_SWAP_PREFIX,
+        FLAG_SUBTREE_LIST, FLAG_END
+    };
 
     const char *argv[] = {
         exec.c_str(),
@@ -434,7 +470,7 @@ TEST(parse_cmd_line, options) {
 }
 
 TEST(parse_cmd_line, delimiter) {
-    const char opts[] = "d:";
+    const struct option opts[] = { FLAG_DELIM, FLAG_END };
 
     // x -> \x1E
     {
@@ -474,7 +510,7 @@ TEST(parse_cmd_line, delimiter) {
 }
 
 TEST(parse_cmd_line, output_arguments) {
-    const char opts[] = "o:O:";
+    const struct option opts[] = { FLAG_OUTPUT_FILE, FLAG_OUTPUT_DB, FLAG_END };
 
     // neither
     {
@@ -563,6 +599,7 @@ TEST(parse_cmd_line, output_arguments) {
 }
 
 TEST(parse_cmd_line, positional) {
+    const struct option opt[] = { FLAG_END };
     const std::string pos1 = "positional1";
     const std::string pos2 = "positional2";
 
@@ -576,7 +613,7 @@ TEST(parse_cmd_line, positional) {
 
     struct input in;
     // 1, since no options were read
-    ASSERT_EQ(parse_cmd_line(argc, (char **) argv, "", 0, "", &in), 1);
+    ASSERT_EQ(parse_cmd_line(argc, (char **) argv, opt, 0, "", &in), 1);
 
     check_input(&in, false, false, false, false, RUN_ON_ROW);
 
@@ -584,13 +621,17 @@ TEST(parse_cmd_line, positional) {
 }
 
 TEST(parse_cmd_line, unused) {
-    #define UNUSED "0"
+    #define UNUSED { "", no_argument, 0, '0' }
 
-    const char opts[] = UNUSED;
+    const struct option opts[] = {
+        UNUSED,
+        FLAG_END
+    };
 
+    char unused_opt[] = {'-', static_cast<char>(opts[0].val), '\0'};
     const char *argv[] = {
         exec.c_str(),
-        "-" UNUSED,
+        unused_opt,
     };
 
     int argc = sizeof(argv) / sizeof(argv[0]);
@@ -604,13 +645,17 @@ TEST(parse_cmd_line, unused) {
 }
 
 TEST(parse_cmd_line, invalid) {
-    #define INVALID ";"
+    #define INVALID { "", no_argument, 0, ';' }
 
-    const char opts[] = INVALID;
+    const struct option opts[] = {
+        INVALID,
+        FLAG_END
+    };
 
+    char invalid_opt[] = {'-', static_cast<char>(opts[0].val), '\0'};
     const char *argv[] = {
         exec.c_str(),
-        "-" INVALID,
+        invalid_opt,
     };
 
     int argc = sizeof(argv) / sizeof(argv[0]);


### PR DESCRIPTION
Updated command-line options to support long arguments with `getopt_long`. Replaced `-y` and `-z` with `--min-level` and `--max-level`. Updated tests to reflect the changes.