### PR TITLE
Marfs Plugin

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -119,6 +119,9 @@ jobs:
     - name: Install Python Packages
       run:  python3 -m pip install -r contrib/CI/requirements.txt
 
+    - name: Install Marfs & ISA-L
+      run:  contrib/deps/marfs.sh ${{ github.workspace }}/build/builds ${{ env.DEP_INSTALL_PREFIX }} 2
+
     - name: Uninstall CMake from package manager
       run:  yum -y autoremove cmake3
 
@@ -132,7 +135,7 @@ jobs:
       run:  |
             mkdir -p build
             cd build
-            cmake .. ${{ env.COMMON_CONFIG }}
+            cmake .. ${{ env.COMMON_CONFIG }} -DMARFS_PREFIX=${{ env.DEP_INSTALL_PREFIX }}/marfs
 
     - name: Build
       working-directory: ${{ github.workspace }}/build
@@ -162,8 +165,11 @@ jobs:
     - name: Install Python Packages
       run:  python3 -m pip install -r contrib/CI/requirements.txt
 
+    - name: Install Marfs & ISA-L
+      run:  contrib/deps/marfs.sh ${{ github.workspace }}/build/builds ${{ env.DEP_INSTALL_PREFIX }} 2
+
     - name: Configure CMake
-      run:  cmake -B ${{ github.workspace }}/build ${{ env.COMMON_CONFIG }} -DTEST_WORKING_DIRECTORY=/tmp
+      run:  cmake -B ${{ github.workspace }}/build ${{ env.COMMON_CONFIG }} -DTEST_WORKING_DIRECTORY=/tmp -DMARFS_PREFIX=${{ env.DEP_INSTALL_PREFIX }}/marfs
 
     - name: Build
       run:  cmake --build ${{ github.workspace }}/build -j
@@ -192,8 +198,11 @@ jobs:
     - name: Install Python Packages
       run:  python3 -m pip install -r contrib/CI/requirements.txt
 
+    - name: Install Marfs & ISA-L
+      run:  contrib/deps/marfs.sh ${{ github.workspace }}/build/builds ${{ env.DEP_INSTALL_PREFIX }} 2
+
     - name: Configure CMake
-      run:  cmake -B ${{ github.workspace }}/build ${{ env.COMMON_CONFIG }} -DALLOW_DB_WRITES=Off
+      run:  cmake -B ${{ github.workspace }}/build ${{ env.COMMON_CONFIG }} -DALLOW_DB_WRITES=Off -DMARFS_PREFIX=${{ env.DEP_INSTALL_PREFIX }}/marfs
 
     - name: Build
       run:  cmake --build ${{ github.workspace }}/build -j
@@ -225,8 +234,11 @@ jobs:
     - name: Install Python Packages
       run:  python3 -m pip install -r contrib/CI/requirements.txt
 
+    - name: Install Marfs & ISA-L
+      run:  contrib/deps/marfs.sh ${{ github.workspace }}/build/builds ${{ env.DEP_INSTALL_PREFIX }} 2
+
     - name: Configure CMake
-      run:  cmake -B ${{ github.workspace }}/build ${{ env.COMMON_CONFIG }} -DCMAKE_BUILD_TYPE=Debug -DFSANITIZE="address,leak,pointer-compare,pointer-subtract,undefined"
+      run:  cmake -B ${{ github.workspace }}/build ${{ env.COMMON_CONFIG }} -DCMAKE_BUILD_TYPE=Debug -DFSANITIZE="address,leak,pointer-compare,pointer-subtract,undefined" -DMARFS_PREFIX=${{ env.DEP_INSTALL_PREFIX }}/marfs
 
     - name: Build
       run:  cmake --build ${{ github.workspace }}/build -j
@@ -255,9 +267,11 @@ jobs:
     - name: Install Python Packages
       run:  python3 -m pip install -r contrib/CI/requirements.txt
 
-    - name: Configure CMake
-      run:  cmake -B ${{ github.workspace }}/build ${{ env.COMMON_CONFIG }} -DCMAKE_BUILD_TYPE=Debug -DFSANITIZE="thread"
+    - name: Install Marfs & ISA-L
+      run:  contrib/deps/marfs.sh ${{ github.workspace }}/build/builds ${{ env.DEP_INSTALL_PREFIX }} 2
 
+    - name: Configure CMake
+      run:  cmake -B ${{ github.workspace }}/build ${{ env.COMMON_CONFIG }} -DCMAKE_BUILD_TYPE=Debug -DFSANITIZE="thread" -DMARFS_PREFIX=${{ env.DEP_INSTALL_PREFIX }}/marfs
     - name: Build
       run:  cmake --build ${{ github.workspace }}/build -j
 
@@ -288,8 +302,11 @@ jobs:
     - name: Install Python Packages
       run:  python3 -m pip install -r contrib/CI/requirements.txt
 
+    - name: Install Marfs & ISA-L
+      run:  contrib/deps/marfs.sh ${{ github.workspace }}/build/builds ${{ env.DEP_INSTALL_PREFIX }} 2
+
     - name: Configure CMake
-      run:  cmake -B ${{ github.workspace }}/build ${{ env.COMMON_CONFIG }}
+      run:  cmake -B ${{ github.workspace }}/build ${{ env.COMMON_CONFIG }} -DMARFS_PREFIX=${{ env.DEP_INSTALL_PREFIX }}/marfs
 
     - name: Build
       run:  cmake --build ${{ github.workspace }}/build -j
@@ -317,8 +334,11 @@ jobs:
     - name: Install Python Packages
       run:  python3 -m pip install -r contrib/CI/requirements.txt
 
+    - name: Install Marfs & ISA-L
+      run:  contrib/deps/marfs.sh ${{ github.workspace }}/build/builds ${{ env.DEP_INSTALL_PREFIX }} 2
+
     - name: Configure CMake
-      run:  cmake -B ${{ github.workspace }}/build ${{ env.COMMON_CONFIG }} -DDEP_USE_JEMALLOC=Off -DTEST_WORKING_DIRECTORY="$(pwd)"
+      run:  cmake -B ${{ github.workspace }}/build ${{ env.COMMON_CONFIG }} -DDEP_USE_JEMALLOC=Off -DTEST_WORKING_DIRECTORY="$(pwd)" -DMARFS_PREFIX=${{ env.DEP_INSTALL_PREFIX }}/marfs
 
     - name: Build
       run:  cmake --build ${{ github.workspace }}/build -j

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -116,8 +116,17 @@ jobs:
     - name: Install Python Packages
       run:  python3 -m pip install -r contrib/CI/requirements.txt
 
+    - name: Install Marfs & ISA-L
+      if:   matrix.img != 'alpine:edge'
+      run:  contrib/deps/marfs.sh ${{ github.workspace }}/build/builds ${{ env.DEP_INSTALL_PREFIX }} 2
+
     - name: Configure CMake
+      if:   matrix.img == 'alpine:edge'
       run:  cmake -B ${{ github.workspace }}/build ${{ env.COMMON_CONFIG }}
+
+    - name: Configure CMake
+      if:   matrix.img != 'alpine:edge'
+      run:  cmake -B ${{ github.workspace }}/build ${{ env.COMMON_CONFIG }} -DMARFS_PREFIX=${{ env.DEP_INSTALL_PREFIX }}/marfs
 
     - name: Build
       run:  cmake --build ${{ github.workspace }}/build -j

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -555,11 +555,11 @@ add_subdirectory(scripts)
 # build documentation
 add_subdirectory(docs)
 
-# recurse down into the test subdirectory
-add_subdirectory(test)
-
 # build contrib executables
 add_subdirectory(contrib)
+
+# recurse down into the test subdirectory
+add_subdirectory(test)
 
 # copy examples
 add_subdirectory(examples)

--- a/contrib/CI/almalinux.sh
+++ b/contrib/CI/almalinux.sh
@@ -92,4 +92,16 @@ dnf -y install \
     sudo
 
 # SQLAlchemy needs Python.h
-yum -y install python3-devel
+dnf -y install python3-devel
+
+# packages for marfs
+dnf -y install \
+    automake \
+    environment-modules \
+    fuse-devel \
+    libtool \
+    libxml2-devel \
+    nasm \
+    openmpi-devel \
+    readline-devel \
+    which

--- a/contrib/CI/centos7.sh
+++ b/contrib/CI/centos7.sh
@@ -70,7 +70,7 @@ yum -y install epel-release centos-release-scl
 yum -y install fuse-devel libattr-devel pcre2-devel zlib-devel
 
 # install required packages
-yum -y install attr autoconf cmake3 fuse git llvm-toolset-7 make patch pkgconfig python3 sudo
+yum -y install attr autoconf automake cmake3 fuse git libtool llvm-toolset-7 make nasm patch pkgconfig python3 sudo
 
 # make sure 'cmake' and 'ctest' are valid commands
 ln -sf /usr/bin/cmake3 /usr/bin/cmake

--- a/contrib/CI/centos8.sh
+++ b/contrib/CI/centos8.sh
@@ -74,7 +74,7 @@ yum -y install epel-release
 yum -y install fuse-devel libattr libidn pcre2-devel zlib-devel
 
 # install required packages
-yum -y install attr autoconf clang cmake3 diffutils fuse gettext git make patch pkgconfig python3 sudo
+yum -y install attr autoconf automake clang cmake3 diffutils fuse gettext git libtool make nasm patch pkgconfig python3 sudo
 
 # SQLAlchemy needs Python.h
 yum -y install python3-devel

--- a/contrib/CI/rockylinux.sh
+++ b/contrib/CI/rockylinux.sh
@@ -93,4 +93,15 @@ dnf -y install \
     sudo
 
 # SQLAlchemy needs Python.h
-yum -y install python3-devel
+dnf -y install python3-devel
+
+# packages for marfs
+dnf -y --enablerepo=crb install \
+    automake \
+    environment-modules \
+    fuse-devel \
+    libtool \
+    libxml2-devel \
+    nasm \
+    openmpi-devel \
+    readline-devel

--- a/contrib/CI/suse12.3.sh
+++ b/contrib/CI/suse12.3.sh
@@ -79,7 +79,7 @@ zypper --non-interactive --no-gpg-checks update
 zypper --non-interactive install fuse-devel libattr-devel libuuid-devel pcre2-devel zlib-devel
 
 # install extra packages
-zypper --non-interactive install autoconf binutils cmake libgcc_s1 patch pkg-config python3 python3-setuptools python3-xattr
+zypper --non-interactive install autoconf automake binutils cmake libgcc_s1 libtool nasm patch pkg-config python3 python3-setuptools python3-xattr
 
 if [[ "${C_COMPILER}" = gcc-* ]]; then
     C_PACKAGE="gcc${C_COMPILER##*-}"

--- a/contrib/CI/ubuntu.sh
+++ b/contrib/CI/ubuntu.sh
@@ -81,7 +81,6 @@ apt -y install \
 apt -y install \
     attr \
     autoconf \
-    automake \
     bsdmainutils \
     clang \
     cmake \
@@ -92,3 +91,13 @@ apt -y install \
     python3 \
     python3-pip \
     sudo
+
+# extra packages for marfs
+apt -y install \
+    automake \
+    libfuse-dev \
+    libopenmpi-dev \
+    libreadline-dev \
+    libtool \
+    libxml2-dev \
+    nasm

--- a/contrib/deps/marfs.sh
+++ b/contrib/deps/marfs.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env ash
+#!/usr/bin/env bash
 # This file is part of GUFI, which is part of MarFS, which is released
 # under the BSD license.
 #
@@ -61,43 +61,59 @@
 
 
 
-# shellcheck shell=dash
-
 set -e
 
-apk update
+BUILD_DIR="$1"
+INSTALL_DIR="$2"
+THREADS="${3:-1}"
 
-# install libraries
-apk add \
-    attr-dev \
-    fuse3-dev \
-    jemalloc-dev \
-    jemalloc-static \
-    linux-headers \
-    openmp-dev \
-    pcre2-dev \
-    zlib-dev
+isal_name="isa-l"
+isal_version="master"
+isal_build="${BUILD_DIR}/${isal_name}-${isal_version}"
+isal_prefix="${INSTALL_DIR}/${isal_name}-${isal_version}"
 
-# install required packages
-apk add \
-    attr \
-    autoconf \
-    bash \
-    bash-completion \
-    clang20 \
-    cmake \
-    diffutils \
-    findutils \
-    gettext-envsubst \
-    git \
-    grep \
-    make \
-    patch \
-    pkgconf \
-    py3-pip \
-    python3 \
-    sudo \
-    util-linux-misc
+marfs_name="marfs"
+marfs_build="${BUILD_DIR}/${marfs_name}"
+marfs_prefix="${INSTALL_DIR}/${marfs_name}"
 
-ln -sf /usr/bin/clang-20   /usr/bin/clang
-ln -sf /usr/bin/clang++-20 /usr/bin/clang++
+if [[ ! -d "${marfs_prefix}" ]]; then
+    if [[ ! -d "${isal_prefix}" ]]; then
+        # build and install isa-l
+        if [[ ! -d "${isal_build}" ]]; then
+            # Clone ISA-L repository
+            git clone --depth 1 --branch "${isal_version}" https://github.com/intel/isa-l.git "${isal_build}"
+        fi
+
+        cd "${isal_build}"
+
+        ./autogen.sh
+        ./configure --prefix="${isal_prefix}"
+        make -j "${THREADS}"
+        make install
+    fi
+
+    # build and install marfs
+    if [[ ! -d "${marfs_build}" ]]; then
+        # Clone MarFS repository
+        git clone --depth 1 --branch master https://github.com/mar-file-system/marfs.git "${marfs_build}"
+    fi
+
+    cd "${marfs_build}"
+
+    export LD_LIBRARY_PATH="${marfs_prefix}/lib${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
+
+    if grep -e "Rocky" -e "alma" /etc/os-release > /dev/null ; then
+        source /etc/profile.d/modules.sh
+        module load mpi
+    fi
+
+    ./autogen.sh
+
+    CC=mpicc \
+    CPPFLAGS="-I${isal_prefix}/include ${CPPFLAGS:-}" \
+    LDFLAGS="-L${isal_prefix}/lib -Wl,-rpath,${isal_prefix}/lib ${LDFLAGS:-}" \
+    ./configure --prefix="${marfs_prefix}"
+
+    make -j "${THREADS}"
+    make install
+fi

--- a/contrib/plugins/CMakeLists.txt
+++ b/contrib/plugins/CMakeLists.txt
@@ -102,21 +102,19 @@ install(TARGETS dsi_querying DESTINATION "${CLIENT_LIB}" COMPONENT Client EXCLUD
 
 # marfs plugin
 set(MARFS_PREFIX "" CACHE PATH "MarFS install prefix")
-set(MARFS_SRC    "" CACHE PATH "MarFS source root")
-if (MARFS_PREFIX AND MARFS_SRC)
+if (MARFS_PREFIX)
   find_package(LibXml2 REQUIRED)
   message(STATUS "MARFS_PREFIX: ${MARFS_PREFIX}")
-  message(STATUS "MARFS_SRC: ${MARFS_SRC}")
   message(STATUS "Building marfs plugin.")
   add_library(marfs_plugin SHARED
     marfs_plugin.c
     "${CMAKE_SOURCE_DIR}/src/str.c"
   )
-  target_include_directories(marfs_plugin SYSTEM PUBLIC "${MARFS_PREFIX}" "${MARFS_SRC}/src" "${LIBXML2_INCLUDE_DIRS}")
+  target_include_directories(marfs_plugin SYSTEM PUBLIC "${MARFS_PREFIX}" "${LIBXML2_INCLUDE_DIRS}")
   target_link_libraries(marfs_plugin PUBLIC marfs)
   target_link_directories(marfs_plugin PUBLIC "${MARFS_PREFIX}/lib")
   add_dependencies(marfs_plugin install_dependencies)
   install(TARGETS marfs_plugin DESTINATION "${SERVER_LIB}" COMPONENT Server)
 else()
-  message(STATUS "MARFS_PREFIX and MARFS_SRC not set. Not building marfs plugin.")
+  message(STATUS "MARFS_PREFIX not set. Not building marfs plugin.")
 endif()

--- a/contrib/plugins/CMakeLists.txt
+++ b/contrib/plugins/CMakeLists.txt
@@ -99,3 +99,24 @@ target_link_libraries(dsi_querying
 add_dependencies(dsi_querying install_dependencies)
 install(TARGETS dsi_querying DESTINATION "${SERVER_LIB}" COMPONENT Server)
 install(TARGETS dsi_querying DESTINATION "${CLIENT_LIB}" COMPONENT Client EXCLUDE_FROM_ALL)
+
+# marfs plugin
+set(MARFS_PREFIX "" CACHE PATH "MarFS install prefix")
+set(MARFS_SRC    "" CACHE PATH "MarFS source root")
+if (MARFS_PREFIX AND MARFS_SRC)
+  find_package(LibXml2 REQUIRED)
+  message(STATUS "MARFS_PREFIX: ${MARFS_PREFIX}")
+  message(STATUS "MARFS_SRC: ${MARFS_SRC}")
+  message(STATUS "Building marfs plugin.")
+  add_library(marfs_plugin SHARED
+    marfs_plugin.c
+    "${CMAKE_SOURCE_DIR}/src/str.c"
+  )
+  target_include_directories(marfs_plugin SYSTEM PUBLIC "${MARFS_PREFIX}" "${MARFS_SRC}/src" "${LIBXML2_INCLUDE_DIRS}")
+  target_link_libraries(marfs_plugin PUBLIC marfs)
+  target_link_directories(marfs_plugin PUBLIC "${MARFS_PREFIX}/lib")
+  add_dependencies(marfs_plugin install_dependencies)
+  install(TARGETS marfs_plugin DESTINATION "${SERVER_LIB}" COMPONENT Server)
+else()
+  message(STATUS "MARFS_PREFIX and MARFS_SRC not set. Not building marfs plugin.")
+endif()

--- a/contrib/plugins/dsi_indexing.c
+++ b/contrib/plugins/dsi_indexing.c
@@ -319,6 +319,7 @@ static void dsi_indexing_dir(void *ptr, void *user_data) {
 struct plugin_operations gufi_plugin_operations = {
     .type = PLUGIN_INDEX,
     .global_init = dsi_indexing_global_init,
+    .dir_action = NULL,
     .ctx_init = NULL,
     .process_dir = dsi_indexing_dir,
     .process_file = NULL,

--- a/contrib/plugins/dsi_querying.c
+++ b/contrib/plugins/dsi_querying.c
@@ -280,6 +280,7 @@ static void dsi_querying_global_exit(void *global) {
 struct plugin_operations gufi_plugin_operations = {
     .type = PLUGIN_QUERY,
     .global_init = dsi_querying_global_init,
+    .dir_action = NULL,
     .ctx_init = dsi_querying_ctx_init,
     .process_dir = NULL,
     .process_file = NULL,

--- a/contrib/plugins/lustre_plugin.c
+++ b/contrib/plugins/lustre_plugin.c
@@ -426,6 +426,7 @@ static void db_exit(void *ptr, void *user_data) {
 struct plugin_operations gufi_plugin_operations = {
     .type = PLUGIN_INDEX,
     .global_init = NULL,
+    .dir_action = NULL,
     .ctx_init = db_init,
     .process_dir = process_dir,
     .process_file = process_file,

--- a/contrib/plugins/marfs_plugin.c
+++ b/contrib/plugins/marfs_plugin.c
@@ -58,71 +58,120 @@ INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
 CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
 IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
 OF SUCH DAMAGE.
-*/
 
 /*
-build instruction:
-
-cd contrib
-
-gcc -g -c -fPIC plugins/marfs_plugin.c \
-  -I../include \
-  -I../build/deps/sqlite3/include \
-  -I/path/to/marfs/install/include \
-  -I/path/to/marfs/src/marfs/src \
-  -I/usr/include/libxml2
-
-gcc -shared -o marfs_plugin.so marfs_plugin.o \
-  -L/path/to/marfs/install/lib \
-  -lmarfs \
-  -lxml2 \
-  -Wl,-rpath,/path/to/marfs/install/lib
-
-run example:
-MARFS_CONFIG_PATH=/path/to/marfs/install/etc/marfs-config.xml \
-  ./build/src/gufi_dir2index \
-  --plugin ./contrib/marfs_plugin.so \
-  /path/to/mdal-root/sec-root /home/$USER/gufi-index-dir
+ * MarFS GUFI indexing plugin
+ *
+ * This plugin adapts a MarFS MDAL-sec-root tree so GUFI can index it in a
+ * useful way, while hiding MarFS specific implementation details from the
+ * final index.
+ *
+ * High level behavior:
+ *
+ * 1. Reads the MarFS config specified by MARFS_CONFIG_PATH and discovers all
+ *    configured namespaces under the selected root namespace.
+ *
+ * 2. Builds a sorted list of namespace pairs:
+ *      - namespace:        the real namespace path under sec-root
+ *      - index_namespace:  the corresponding path GUFI will see in the
+ *                          temporary index tree
+ *
+ * 3. Before indexing begins, rewrites the on-disk index layout to match the
+ *    MarFS namespace structure expected by this plugin. In particular, it
+ *    restores MDAL_subspaces directories and renames the indexed root from
+ *    the MarFS mountpoint back to the configured root namespace so repeated
+ *    indexing runs work correctly.
+ *
+ * 4. During traversal, filters out MarFS internal directories and files
+ *    (such as MDAL_* entries) so GUFI does not index MarFS metadata as user
+ *    content. It also skips namespaces that exist on disk but are no longer
+ *    present in the current MarFS config.
+ *
+ * 5. While processing files, removes MarFS specific database entries,
+ *    decrements link counts to account for MarFS metadata links, and strips
+ *    MarFS xattrs from the stored xattr list.
+ *
+ * 6. While processing directories, renames the indexed root namespace in the
+ *    GUFI summary table so the final index presents the MarFS mountpoint name
+ *    instead of the raw sec-root namespace name.
+ *
+ * 7. After indexing completes, restores the index tree into a cleaner final
+ *    form by moving namespace directories up out of MDAL_subspaces, removing
+ *    empty MDAL_subspaces directories, and renaming the indexed root back to
+ *    the MarFS mountpoint basename.
+ *
+ * build instruction:
+ *
+ * cd contrib
+ *
+ * gcc -g -c -fPIC plugins/marfs_plugin.c \
+ *   -I../include \
+ *   -I../build/deps/sqlite3/include \
+ *   -I/path/to/marfs/install/include \
+ *   -I/path/to/marfs/src/marfs/src \
+ *   -I/usr/include/libxml2
+ *
+ * gcc -shared -o marfs_plugin.so marfs_plugin.o \
+ *   ../build/src/libGUFI.a \
+ *   -L/path/to/marfs/install/lib \
+ *   -lmarfs \
+ *   -lxml2 \
+ *   -Wl,-rpath,/path/to/marfs/install/lib
+ *
+ * run example:
+ * MARFS_CONFIG_PATH=/path/to/marfs/install/etc/marfs-config.xml \
+ *   ./build/src/gufi_dir2index \
+ *   --plugin ./contrib/marfs_plugin.so \
+ *   /path/to/mdal-root/sec-root /home/$USER/gufi-index-dir
 */
 
 #include <errno.h>
 #include <fcntl.h>
-#include <stdio.h>
-#include <string.h>
-#include <unistd.h>
 #include <pthread.h>
 #include <stddef.h>
+#include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
 
 #include "bf.h"
+#include "config/config.h"
+#include "hash/hash.h"
 #include "plugin.h"
 #include "str.h"
 #include "utils.h"
 #include "xattrs.h"
 
-#include "config/config.h"
-#include "hash/hash.h"
+static const char MARFS_PREFIX[] = "MDAL_";
+static const size_t MARFS_PREFIX_LEN = sizeof(MARFS_PREFIX) - 1;
+static const char MARFS_SUBSPACES_NAME[] = "MDAL_subspaces";
+static const size_t MARFS_SUBSPACES_NAME_LEN = sizeof(MARFS_SUBSPACES_NAME) - 1;
+static const char MARFS_XATTR_NAME[] = "user.MDAL_MARFS-FILE";
+static const size_t MARFS_XATTR_NAME_LEN = sizeof(MARFS_XATTR_NAME) - 1;
+static const size_t ROOT_NAMESPACE_LEVEL = 0;
+static const mode_t MARFS_DIR_MODE = 0701;
 
-static const char* MARFS_PREFIX = "MDAL_";
-static const char* MARFS_SUBSPACES_NAME = "MDAL_subspaces";
 static const char* MARFS_CONFIG_ENV = "MARFS_CONFIG_PATH";
 
-static const char MARFS_XATTR_NAME[] = "user.MDAL_MARFS-FILE";
+typedef struct {
+    str_t namespace;
+    str_t index_namespace;
+} namespace_pair;
 
 // used for sorting namespaces
-static int cmp_cstr_ptr(const void* a, const void* b) {
-    const char* sa = *(const char* const*)a;
-    const char* sb = *(const char* const*)b;
-    return strcmp(sa, sb);
+static int cmp_str_t_ptr(const void* a, const void* b) {
+    const namespace_pair* pa = (const namespace_pair*)a;
+    const namespace_pair* pb = (const namespace_pair*)b;
+    return str_cmp(&pa->namespace, &pb->namespace);
 }
 
 // sort namespace paths
-static void sort_namespaces(char** namespace_list, size_t namespace_count) {
-    qsort(namespace_list, namespace_count, sizeof *namespace_list, cmp_cstr_ptr);
+static void sort_namespace_pairs(namespace_pair* namespace_list, size_t namespace_count) {
+    qsort(namespace_list, namespace_count, sizeof *namespace_list, cmp_str_t_ptr);
 }
 
 // returns the basename of a path
-str_t get_basename(str_t path) {
+static str_t get_basename(str_t path) {
     if (!path.data || path.len == 0) return (str_t)REFSTR(NULL, 0);
 
     size_t len = path.len;
@@ -137,7 +186,7 @@ str_t get_basename(str_t path) {
 }
 
 // returns the parent of a path
-str_t get_parent(str_t path) {
+static str_t get_parent(str_t path) {
     if (!path.data || path.len == 0) return (str_t)REFSTR(NULL, 0);
 
     size_t len = path.len;
@@ -157,11 +206,8 @@ str_t get_parent(str_t path) {
     return (str_t)REFSTR(path.data, parent_len);
 }
 
-// returns the grandparent of a path
-str_t get_grandparent(str_t path) { return get_parent(get_parent(path)); }
-
 // join two str_t file paths together
-char* join_path(str_t lhs, str_t rhs) {
+static char* join_path(str_t lhs, str_t rhs) {
     size_t len = lhs.len + 1 + rhs.len + 1;
     char* out = malloc(len);
     if (!out) return NULL;
@@ -171,39 +217,26 @@ char* join_path(str_t lhs, str_t rhs) {
 }
 
 // check if str_t starts with a prefix
-static int str_t_startswith(str_t s, const char* prefix) {
-    size_t plen = strlen(prefix);
-    return s.data && s.len >= plen && memcmp(s.data, prefix, plen) == 0;
+static int starts_with_mdal(str_t s) {
+    if (!s.data || s.len < MARFS_PREFIX_LEN) return 0;
+
+    return strncmp(s.data, MARFS_PREFIX, MARFS_PREFIX_LEN) == 0;
 }
 
 // check if a str_t is equal to a char*
-static int str_t_eq_cstr(str_t s, const char* cstr) {
-    size_t len = strlen(cstr);
-    return s.data && s.len == len && memcmp(s.data, cstr, len) == 0;
-}
+static int str_t_eq_cstr(str_t s, const char* cstr, size_t cstr_len) {
+    if (!s.data || s.len != cstr_len) return 0;
 
-// free a str_t
-static void free_str_members(str_t* s) {
-    if (!s) return;
-
-    if (s->free) {
-        s->free(s->data);
-    }
-
-    s->data = NULL;
-    s->len = 0;
-    s->free = NULL;
+    return strncmp(s.data, cstr, cstr_len) == 0;
 }
 
 struct marfs_plugin {
-    char** namespaces;
-    char** index_namespaces;
+    namespace_pair* namespaces;
     size_t namespaces_count;
 
     str_t index_parent;  // actual index is placed at <index parent>/$(basename <src>)
     str_t marfs_mountpoint;
     str_t root_namespace;
-    size_t root_namespace_level;
 };
 
 static struct marfs_plugin g_state;
@@ -211,24 +244,17 @@ static struct marfs_plugin g_state;
 static void marfs_plugin_cleanup(void) {
     if (g_state.namespaces) {
         for (size_t i = 0; i < g_state.namespaces_count; i++) {
-            free(g_state.namespaces[i]);
+            str_free_existing(&g_state.namespaces[i].namespace);
+            str_free_existing(&g_state.namespaces[i].index_namespace);
         }
         free(g_state.namespaces);
     }
 
-    if (g_state.index_namespaces) {
-        for (size_t i = 0; i < g_state.namespaces_count; i++) {
-            free(g_state.index_namespaces[i]);
-        }
-        free(g_state.index_namespaces);
-    }
-
-    free_str_members(&g_state.index_parent);
-    free_str_members(&g_state.marfs_mountpoint);
-    free_str_members(&g_state.root_namespace);
+    str_free_existing(&g_state.index_parent);
+    str_free_existing(&g_state.marfs_mountpoint);
+    str_free_existing(&g_state.root_namespace);
 
     g_state.namespaces = NULL;
-    g_state.index_namespaces = NULL;
     g_state.namespaces_count = 0;
 }
 
@@ -251,9 +277,10 @@ static size_t count_ns_paths(marfs_ns* ns) {
     return total;
 }
 
-// retrieve the namespace paths from the marfs config
-static int collect_ns_paths(marfs_ns* ns, const char* parent_path, char** paths, size_t* index) {
-    if (!ns || !paths || !index) return -1;
+// retrieve the namespace paths from the marfs config and build namespace pairs
+static int collect_ns_paths(marfs_ns* ns, str_t parent_path, namespace_pair* paths, size_t* index, str_t root_namespace,
+                            str_t index_parent, str_t rn_base) {
+    if (!ns || !paths || !index || !root_namespace.data || !index_parent.data || !rn_base.data) return -1;
 
     for (size_t i = 0; i < ns->subnodecount; i++) {
         HASH_NODE* hn = &ns->subnodes[i];
@@ -261,36 +288,61 @@ static int collect_ns_paths(marfs_ns* ns, const char* parent_path, char** paths,
 
         if (!hn->name || !child) continue;
 
-        char* path = NULL;
-        int n;
+        str_t path = {0};
+        const size_t name_len = strlen(hn->name);
 
-        if (!parent_path || parent_path[0] == '\0') {
-            n = snprintf(NULL, 0, "%s", hn->name);
-            if (n < 0) return -1;
+        if (parent_path.len == 0) {
+            const size_t path_len = name_len;
 
-            path = malloc((size_t)n + 1);
-            if (!path) return -1;
+            if (!str_alloc_existing(&path, path_len)) return -1;
 
-            snprintf(path, (size_t)n + 1, "%s", hn->name);
+            snprintf(path.data, path_len + 1, "%s", hn->name);
         } else {
-            n = snprintf(NULL, 0, "%s/%s/%s", parent_path, MARFS_SUBSPACES_NAME, hn->name);
-            if (n < 0) return -1;
+            // add an MDAL_subspaces dir into the path
+            const size_t path_len = parent_path.len + 1 + MARFS_SUBSPACES_NAME_LEN + 1 + name_len;
 
-            path = malloc((size_t)n + 1);
-            if (!path) return -1;
+            if (!str_alloc_existing(&path, path_len)) return -1;
 
-            snprintf(path, (size_t)n + 1, "%s/%s/%s", parent_path, MARFS_SUBSPACES_NAME, hn->name);
+            snprintf(path.data, path_len + 1, "%.*s/%s/%s", (int)parent_path.len, parent_path.data,
+                     MARFS_SUBSPACES_NAME, hn->name);
         }
 
-        paths[*index] = path;
+        // build namespace and index namespace paths
+        {
+            namespace_pair* pair = &paths[*index];
+            const size_t namespace_len = root_namespace.len + 1 + MARFS_SUBSPACES_NAME_LEN + 1 + path.len;
+            const size_t index_namespace_len =
+                index_parent.len + 1 + rn_base.len + 1 + MARFS_SUBSPACES_NAME_LEN + 1 + path.len;
+
+            if (!str_alloc_existing(&pair->namespace, namespace_len)) {
+                str_free_existing(&path);
+                return -1;
+            }
+
+            snprintf(pair->namespace.data, namespace_len + 1, "%.*s/%s/%.*s", (int)root_namespace.len,
+                     root_namespace.data, MARFS_SUBSPACES_NAME, (int)path.len, path.data);
+
+            if (!str_alloc_existing(&pair->index_namespace, index_namespace_len)) {
+                str_free_existing(&pair->namespace);
+                str_free_existing(&path);
+                return -1;
+            }
+
+            snprintf(pair->index_namespace.data, index_namespace_len + 1, "%.*s/%.*s/%s/%.*s", (int)index_parent.len,
+                     index_parent.data, (int)rn_base.len, rn_base.data, MARFS_SUBSPACES_NAME, (int)path.len, path.data);
+        }
+
         (*index)++;
 
-        if (collect_ns_paths(child, path, paths, index) != 0) {
+        if (collect_ns_paths(child, path, paths, index, root_namespace, index_parent, rn_base) != 0) {
             (*index)--;
-            paths[*index] = NULL;
-            free(path);
+            str_free_existing(&paths[*index].namespace);
+            str_free_existing(&paths[*index].index_namespace);
+            str_free_existing(&path);
             return -1;
         }
+
+        str_free_existing(&path);
     }
 
     return 0;
@@ -308,7 +360,6 @@ static int validate_sec_root(void) {
 
     if (!g_state.root_namespace.data || g_state.root_namespace.len == 0) goto cleanup;
     if (!g_state.namespaces || g_state.namespaces_count == 0) goto cleanup;
-    if (!g_state.namespaces[0]) goto cleanup;
 
     // check if MDAL_subspaces exists under the target dir
     len = snprintf(NULL, 0, "%s/%s", g_state.root_namespace.data, MARFS_SUBSPACES_NAME);
@@ -322,7 +373,7 @@ static int validate_sec_root(void) {
     if (stat(path, &st) != 0 || !S_ISDIR(st.st_mode)) goto cleanup;
 
     // check if one of the top namespaces is in the first MDAL_subspaces
-    if (stat(g_state.namespaces[0], &st) != 0 || !S_ISDIR(st.st_mode)) goto cleanup;
+    if (stat(g_state.namespaces[0].namespace.data, &st) != 0 || !S_ISDIR(st.st_mode)) goto cleanup;
 
     ret = 1;
 
@@ -334,16 +385,16 @@ cleanup:
 // cleanup_marfs_index will go through each namesapce defined in the marfs config, move it up a directory, and delete
 // the empty MDAL_subspaces that remains. It also removes any empty MDAL_subspaces that exist within the namespace as
 // well as renaming the root directory to the basename of the specified moutnpoint in the marfs config
-static int cleanup_marfs_index() {
+static int cleanup_marfs_index(void) {
     int ret = 0;
 
     // loop through our index namespaces and move them up a directory and delete the unecessary MDAL_subspaces
     for (size_t i = g_state.namespaces_count; i-- > 0;) {
-        const str_t old = (str_t)REFSTR(g_state.index_namespaces[i], strlen(g_state.index_namespaces[i]));
+        const str_t old = g_state.namespaces[i].index_namespace;
 
         const str_t basename = get_basename(old);
         const str_t parent = get_parent(old);
-        const str_t grandparent = get_grandparent(old);
+        const str_t grandparent = get_parent(parent);
 
         char* new_path = NULL;
         char* parent_path = NULL;
@@ -352,7 +403,7 @@ static int cleanup_marfs_index() {
         // check to see if there is an empty MDAL_subspaces within this namespace
         {
             size_t child_subspaces_len =
-                old.len + 1 + strlen(MARFS_SUBSPACES_NAME) + 1;  // old + "/" + MDAL_subspaces + NUL
+                old.len + 1 + MARFS_SUBSPACES_NAME_LEN + 1;  // old + "/" + MDAL_subspaces + NUL
             child_subspaces = malloc(child_subspaces_len);
             if (!child_subspaces) {
                 fprintf(stderr, "malloc failed for child_subspaces\n");
@@ -370,7 +421,7 @@ static int cleanup_marfs_index() {
             free(child_subspaces);
         }
 
-        // move this namespace up a directory (into it's grandparent)
+        // move this namespace up a directory (into its grandparent)
         {
             size_t new_len = grandparent.len + 1 + basename.len + 1;  // gp + "/" + base + NUL
             new_path = malloc(new_len);
@@ -392,8 +443,6 @@ static int cleanup_marfs_index() {
                 free(new_path);
                 ret = -1;
                 continue;
-            } else {
-                // printf("moved: %s -> %s\n", old, new_path);
             }
             free(new_path);
         }
@@ -442,8 +491,6 @@ static int cleanup_marfs_index() {
         free(mm_path);
         free(rn_path);
         return -1;
-    } else {
-        // printf("moved: %s -> %s\n", rn_path, mm_path);
     }
 
     free(mm_path);
@@ -454,8 +501,7 @@ static int cleanup_marfs_index() {
 
 // revert_marfs_index will undo everything that's in cleanup_marfs_index. This allows for indexing to be run over an
 // existing index tree without error
-static int revert_marfs_index() {
-    mode_t mode = 0701;
+static int revert_marfs_index(void) {
     int ret = 0;
 
     // rename the marfs mountpoint from the marfs config to the root namespace
@@ -472,22 +518,18 @@ static int revert_marfs_index() {
         return -1;
     }
 
-    if (rename(mm_path, rn_path) != 0) {
-        // fprintf(stderr, "rename('%s' -> '%s') failed: %s\n", mm_path, rn_path, strerror(errno));
-    } else {
-        // printf("moved: %s -> %s\n", mm_path, rn_path);
-    }
+    rename(mm_path, rn_path);
 
     free(mm_path);
     free(rn_path);
 
     // loop through our index namespaces and add a subspaces into them. then move them down into each subspace
     for (size_t i = 0; i < g_state.namespaces_count; i++) {
-        const str_t old = (str_t)REFSTR(g_state.index_namespaces[i], strlen(g_state.index_namespaces[i]));
+        const str_t old = g_state.namespaces[i].index_namespace;
 
         const str_t basename = get_basename(old);
         const str_t parent = get_parent(old);
-        const str_t grandparent = get_grandparent(old);
+        const str_t grandparent = get_parent(parent);
 
         char* indexed_path = NULL;
         char* parent_path = NULL;
@@ -522,16 +564,12 @@ static int revert_marfs_index() {
                 memcpy(parent_path, parent.data, parent.len);
                 parent_path[parent.len] = '\0';
 
-                if (mkdir(parent_path, mode) != 0) {
+                if (mkdir(parent_path, MARFS_DIR_MODE) != 0) {
                     if (errno != ENOTEMPTY && errno != EEXIST) {
-                        // fprintf(stderr, "mkdir('%s') failed: %s\n", parent_path, strerror(errno));
                         free(parent_path);
                         free(indexed_path);
-                        // ret = -1;
                         continue;
                     }
-                } else {
-                    // printf("added empty %s: %s\n", MARFS_SUBSPACES_NAME, parent_path);
                 }
 
                 free(parent_path);
@@ -543,10 +581,7 @@ static int revert_marfs_index() {
             if (rename(indexed_path, old.data) != 0) {
                 fprintf(stderr, "rename('%s' -> '%s') failed: %s\n", indexed_path, old.data, strerror(errno));
                 free(indexed_path);
-                // ret = -1;
                 continue;
-            } else {
-                // printf("moved: %s -> %s\n", indexed_path, old.data);
             }
 
             free(indexed_path);
@@ -561,9 +596,7 @@ static void marfs_indexing_global_init(void* global) {
     struct input* in = (struct input*)global;
     pthread_mutex_t marfs_erasurelock = PTHREAD_MUTEX_INITIALIZER;
 
-    char** config_namespaces = NULL;
     size_t config_index = 0;
-    size_t i = 0;
     int ret = -1;
 
     // We can only allow for a single dir to be indexed at a time. this is because we have no way to taking in multiple
@@ -577,9 +610,11 @@ static void marfs_indexing_global_init(void* global) {
     INSTALL_STR(&g_state.index_parent, in->pos.argv[in->pos.argc - 1]);
     INSTALL_STR(&g_state.root_namespace, in->pos.argv[0]);
 
-    g_state.root_namespace_level = 0;
-
     char* marfs_config_path = getenv(MARFS_CONFIG_ENV);
+    if (!marfs_config_path || marfs_config_path[0] == '\0') {
+        fprintf(stderr, "Error: %s is not set\n", MARFS_CONFIG_ENV);
+        goto cleanup;
+    }
 
     errno = 0;
     marfs_config* cfg = config_init(marfs_config_path, &marfs_erasurelock);
@@ -599,15 +634,21 @@ static void marfs_indexing_global_init(void* global) {
         goto cleanup;
     }
 
-    config_namespaces = calloc(g_state.namespaces_count, sizeof(char*));
-    if (!config_namespaces) {
-        fprintf(stderr, "Error: config_namespaces calloc failed\n");
+    g_state.namespaces = calloc(g_state.namespaces_count, sizeof(namespace_pair));
+    if (!g_state.namespaces) {
+        fprintf(stderr, "Error: namespace array allocation failed\n");
         goto cleanup;
     }
 
-    if (collect_ns_paths(cfg->rootns, "", config_namespaces, &config_index) != 0) {
-        fprintf(stderr, "Error: collect_ns_paths failed\n");
-        goto cleanup;
+    {
+        const str_t rn_base = get_basename(g_state.root_namespace);
+        const str_t empty = REFSTR("", 0);
+
+        if (collect_ns_paths(cfg->rootns, empty, g_state.namespaces, &config_index, g_state.root_namespace,
+                             g_state.index_parent, rn_base) != 0) {
+            fprintf(stderr, "Error: collect_ns_paths failed\n");
+            goto cleanup;
+        }
     }
 
     if (config_index != g_state.namespaces_count) {
@@ -616,55 +657,7 @@ static void marfs_indexing_global_init(void* global) {
         goto cleanup;
     }
 
-    g_state.namespaces = calloc(g_state.namespaces_count, sizeof(char*));
-    g_state.index_namespaces = calloc(g_state.namespaces_count, sizeof(char*));
-
-    if (!g_state.namespaces || !g_state.index_namespaces) {
-        fprintf(stderr, "Error: namespace array allocation failed\n");
-        goto cleanup;
-    }
-
-    const str_t rn_base = get_basename(g_state.root_namespace);
-
-    // prepend our prefix to each namespace
-    for (i = 0; i < g_state.namespaces_count; i++) {
-        int len =
-            snprintf(NULL, 0, "%s/%s/%s", g_state.root_namespace.data, MARFS_SUBSPACES_NAME, config_namespaces[i]);
-        if (len < 0) {
-            fprintf(stderr, "Error: snprintf failed for namespace[%zu]\n", i);
-            goto cleanup;
-        }
-
-        g_state.namespaces[i] = malloc((size_t)len + 1);
-        if (!g_state.namespaces[i]) {
-            fprintf(stderr, "Error: malloc failed for namespace[%zu]\n", i);
-            goto cleanup;
-        }
-
-        snprintf(g_state.namespaces[i], (size_t)len + 1, "%s/%s/%s", g_state.root_namespace.data, MARFS_SUBSPACES_NAME,
-                 config_namespaces[i]);
-
-        // printf("namespace: %s\n", g_state.namespaces[i]);
-
-        len = snprintf(NULL, 0, "%.*s/%.*s/%s/%s", (int)g_state.index_parent.len, g_state.index_parent.data,
-                       (int)rn_base.len, rn_base.data, MARFS_SUBSPACES_NAME, config_namespaces[i]);
-        if (len < 0) {
-            fprintf(stderr, "Error: snprintf failed for index_namespace[%zu]\n", i);
-            goto cleanup;
-        }
-
-        g_state.index_namespaces[i] = malloc((size_t)len + 1);
-        if (!g_state.index_namespaces[i]) {
-            fprintf(stderr, "Error: malloc failed for index_namespace[%zu]\n", i);
-            goto cleanup;
-        }
-
-        snprintf(g_state.index_namespaces[i], (size_t)len + 1, "%.*s/%.*s/%s/%s", (int)g_state.index_parent.len,
-                 g_state.index_parent.data, (int)rn_base.len, rn_base.data, MARFS_SUBSPACES_NAME, config_namespaces[i]);
-    }
-
-    sort_namespaces(g_state.namespaces, g_state.namespaces_count);
-    sort_namespaces(g_state.index_namespaces, g_state.namespaces_count);
+    sort_namespace_pairs(g_state.namespaces, g_state.namespaces_count);
 
     if (!validate_sec_root()) {
         fprintf(stderr, "Error: provided dir is not the root of the parent marfs namespace\n");
@@ -676,16 +669,11 @@ static void marfs_indexing_global_init(void* global) {
         goto cleanup;
     }
 
+    sqlite3_initialize();
+
     ret = 0;
 
 cleanup:
-    if (config_namespaces) {
-        for (size_t j = 0; j < config_index; j++) {
-            free(config_namespaces[j]);
-        }
-        free(config_namespaces);
-    }
-
     if (ret != 0) {
         marfs_plugin_cleanup();
         exit(EXIT_FAILURE);
@@ -699,17 +687,16 @@ static int is_namespace(str_t path) {
     }
 
     for (size_t i = 0; i < g_state.namespaces_count; i++) {
-        const char* ns = g_state.namespaces[i];
-        if (!ns) {
+        str_t ns = g_state.namespaces[i].namespace;
+        if (!ns.data) {
             continue;
         }
 
-        size_t ns_len = strlen(ns);
-        if (ns_len != path.len) {
+        if (ns.len != path.len) {
             continue;
         }
 
-        if (memcmp(ns, path.data, path.len) == 0) {
+        if (str_cmp(&ns, &path) == 0) {
             return 1;
         }
     }
@@ -719,59 +706,59 @@ static int is_namespace(str_t path) {
 
 // marfs_pre_processing_dir checks if we're about to process a marfs specific directory (MDAL_reference, MDAL_subspaces)
 // or a namespace that is no longer active in the marfs config
-static process_action marfs_pre_processing_dir(void* ptr, void* user_data) {
+static plugin_process_action marfs_pre_processing_dir(void* ptr, void* user_data) {
     PCS_t* pcs = (PCS_t*)ptr;
     (void)user_data;
 
     if (!pcs || !pcs->work || !pcs->work->name) {
         fprintf(stderr, "Error: gufi pcs is NULL\n");
-        return PROCESS_DIR;
+        return PLUGIN_PROCESS_DIR;
     }
 
-    const str_t path = (str_t)REFSTR(pcs->work->name, strlen(pcs->work->name));
+    const str_t path = (str_t)REFSTR(pcs->work->name, pcs->work->name_len);
     const str_t basename = get_basename(path);
     const str_t parent = get_parent(path);
 
-    if (str_t_startswith(basename, MARFS_PREFIX)) {
+    if (starts_with_mdal(basename)) {
         // this directory starts with MDAL_
 
-        // determine if this is actual a marfs directory or a user dir
+        // determine if this is a marfs directory or a user dir.
         // cases for being a marfs dir:
         // 1. directly under sec-root
         // 2. directly under a namespace
-        if (g_state.root_namespace_level == pcs->work->level - 1 || is_namespace(parent)) {
-            if (str_t_eq_cstr(basename, MARFS_SUBSPACES_NAME)) {
+        if (ROOT_NAMESPACE_LEVEL == pcs->work->level - 1 || is_namespace(parent)) {
+            if (str_t_eq_cstr(basename, MARFS_SUBSPACES_NAME, MARFS_SUBSPACES_NAME_LEN)) {
                 // this is a subspaces dir. do not process, but still descend
-                return NO_PROCESS_DIR;
+                return PLUGIN_NO_PROCESS_DIR;
             } else {
                 // this is any other marfs dir. do not process, do not descend
-                return NO_PROCESS_NO_DESCEND_DIR;
+                return PLUGIN_NO_PROCESS_NO_DESCEND_DIR;
             }
         } else {
-            return PROCESS_DIR;
+            return PLUGIN_PROCESS_DIR;
         }
     }
 
-    if (str_t_startswith(get_basename(parent), MARFS_PREFIX)) {
+    if (starts_with_mdal(get_basename(parent))) {
         // parent directory starts with MDAL_
         // check to see if it's even possible for this dir to be a marfs namespace
         // cases for this being a marfs namespace:
         // 1. grandparent is sec-root
         // 2. grandparent is a namespace
-        const str_t grandparent = get_grandparent(path);
-        if (g_state.root_namespace_level == pcs->work->level - 2 || is_namespace(grandparent)) {
+        const str_t grandparent = get_parent(parent);
+        if (ROOT_NAMESPACE_LEVEL == pcs->work->level - 2 || is_namespace(grandparent)) {
             // it's possible for this to be a marfs namespace. check the marfs config to be sure that it is currently
             // active
             if (is_namespace(path)) {
-                return PROCESS_DIR;
+                return PLUGIN_PROCESS_DIR;
             } else {
                 // this dir is not listed in the marfs config so do not process it or descend
-                return NO_PROCESS_NO_DESCEND_DIR;
+                return PLUGIN_NO_PROCESS_NO_DESCEND_DIR;
             }
         }
     }
 
-    return PROCESS_DIR;
+    return PLUGIN_PROCESS_DIR;
 }
 
 // marfs_ctx is used for database init and cleanup
@@ -873,14 +860,13 @@ static void* marfs_ctx_init(void* ptr) {
 }
 
 // filter out the marfs specific xattrs and rebuild the blob to update the gufi db
-static sqlite3_int64 build_xattr_names_filtered(struct entry_data* ed, const char* remove_name, char* out,
-                                                size_t out_sz) {
+static sqlite3_int64 build_xattr_names_filtered(struct entry_data* ed, char* out, size_t out_sz) {
     size_t w = 0;
 
     for (size_t i = 0; i < ed->xattrs.count; i++) {
         const struct xattr* x = &ed->xattrs.pairs[i];
 
-        if (strcmp(x->name, remove_name) == 0) {
+        if ((x->name_len == MARFS_XATTR_NAME_LEN) && (strncmp(x->name, MARFS_XATTR_NAME, MARFS_XATTR_NAME_LEN) == 0)) {
             continue;
         }
 
@@ -904,6 +890,7 @@ static sqlite3_int64 build_xattr_names_filtered(struct entry_data* ed, const cha
 // any marfs specific xattrs
 static void marfs_process_file(void* ptr, void* user_data) {
     PCS_t* pcs = (PCS_t*)ptr;
+    sqlite3* db = pcs->db;
     struct entry_data* ed = pcs->ed;
     struct marfs_ctx* ctx = (struct marfs_ctx*)user_data;
 
@@ -913,7 +900,7 @@ static void marfs_process_file(void* ptr, void* user_data) {
 
     int rc;
 
-    const str_t path = (str_t)REFSTR(pcs->work->name, strlen(pcs->work->name));
+    const str_t path = (str_t)REFSTR(pcs->work->name, pcs->work->name_len);
     const str_t basename = get_basename(path);
 
     if (!basename.data || basename.len == 0) {
@@ -921,17 +908,16 @@ static void marfs_process_file(void* ptr, void* user_data) {
     }
 
     // remove mdal specific files
-    if (basename.len >= strlen(MARFS_PREFIX) && str_t_startswith(basename, MARFS_PREFIX)) {
+    if (basename.len >= MARFS_PREFIX_LEN && starts_with_mdal(basename)) {
         // this files starts with MDAL_
-
-        // determine if this is actual a marfs directory or a user dir
-        // cases for being a marfs dir:
-        // 1. directly under sec-root
-        // 2. directly under a namespace
 
         const str_t parent = get_parent(path);
 
-        if (g_state.root_namespace_level == pcs->work->level - 1 || is_namespace(parent)) {
+        // determine if this is actual a marfs file or a user file
+        // cases for being a marfs file:
+        // 1. directly under sec-root
+        // 2. directly under a namespace
+        if (ROOT_NAMESPACE_LEVEL == pcs->work->level - 1 || is_namespace(parent)) {
             // this is a marfs file. remove it from the database
 
             sqlite3_stmt* stmt = ctx->delete_entry;
@@ -939,7 +925,7 @@ static void marfs_process_file(void* ptr, void* user_data) {
             sqlite3_reset(stmt);
             sqlite3_clear_bindings(stmt);
 
-            rc = sqlite3_bind_text(stmt, 1, basename.data, (int)basename.len, SQLITE_TRANSIENT);
+            rc = sqlite3_bind_text(stmt, 1, basename.data, (int)basename.len, SQLITE_STATIC);
             if (rc != SQLITE_OK) {
                 fprintf(stderr, "plugin: bind DELETE failed for %.*s: %s\n", (int)basename.len, basename.data,
                         sqlite3_errmsg(ctx->db));
@@ -965,7 +951,7 @@ static void marfs_process_file(void* ptr, void* user_data) {
         sqlite3_reset(stmt);
         sqlite3_clear_bindings(stmt);
 
-        rc = sqlite3_bind_text(stmt, 1, basename.data, (int)basename.len, SQLITE_TRANSIENT);
+        rc = sqlite3_bind_text(stmt, 1, basename.data, (int)basename.len, SQLITE_STATIC);
         if (rc != SQLITE_OK) {
             fprintf(stderr, "plugin: bind nlink failed for %.*s: %s\n", (int)basename.len, basename.data,
                     sqlite3_errmsg(ctx->db));
@@ -987,20 +973,20 @@ static void marfs_process_file(void* ptr, void* user_data) {
         sqlite3_stmt* stmt = ctx->update_xattr_names;
 
         char xattr_names[MAXXATTR];
-        sqlite3_int64 xlen = build_xattr_names_filtered(ed, MARFS_XATTR_NAME, xattr_names, sizeof(xattr_names));
+        sqlite3_int64 xlen = build_xattr_names_filtered(ed, xattr_names, sizeof(xattr_names));
         if (xlen < 0) xlen = 0;
 
         sqlite3_reset(stmt);
         sqlite3_clear_bindings(stmt);
 
-        rc = sqlite3_bind_text(stmt, 1, basename.data, (int)basename.len, SQLITE_TRANSIENT);
+        rc = sqlite3_bind_text(stmt, 1, basename.data, (int)basename.len, SQLITE_STATIC);
         if (rc != SQLITE_OK) {
             fprintf(stderr, "plugin: bind xattr name failed for %.*s: %s\n", (int)basename.len, basename.data,
                     sqlite3_errmsg(ctx->db));
             return;
         }
 
-        rc = sqlite3_bind_blob64(stmt, 2, xattr_names, (sqlite3_uint64)xlen, SQLITE_TRANSIENT);
+        rc = sqlite3_bind_blob64(stmt, 2, xattr_names, (sqlite3_uint64)xlen, SQLITE_STATIC);
         if (rc != SQLITE_OK) {
             fprintf(stderr, "plugin: bind xattr_names failed for %.*s: %s\n", (int)basename.len, basename.data,
                     sqlite3_errmsg(ctx->db));
@@ -1029,9 +1015,10 @@ static void marfs_process_dir(void* ptr, void* user_data) {
     }
 
     // determine if this is the root namespace dir
-    if (g_state.root_namespace_level == pcs->work->level && str_t_eq_cstr(g_state.root_namespace, pcs->work->name)) {
+    if (ROOT_NAMESPACE_LEVEL == pcs->work->level &&
+        str_t_eq_cstr(g_state.root_namespace, pcs->work->name, pcs->work->name_len)) {
         // rename this to the marfs mountpoint in the database
-        const str_t path = (str_t)REFSTR(pcs->work->name, strlen(pcs->work->name));
+        const str_t path = (str_t)REFSTR(pcs->work->name, pcs->work->name_len);
         const str_t basename = get_basename(path);
         const str_t mountpoint = get_basename(g_state.marfs_mountpoint);
 
@@ -1042,7 +1029,7 @@ static void marfs_process_dir(void* ptr, void* user_data) {
         sqlite3_clear_bindings(stmt);
 
         // old name
-        rc = sqlite3_bind_text(stmt, 1, basename.data, (int)basename.len, SQLITE_TRANSIENT);
+        rc = sqlite3_bind_text(stmt, 1, basename.data, (int)basename.len, SQLITE_STATIC);
         if (rc != SQLITE_OK) {
             fprintf(stderr, "plugin: bind summary name failed for %.*s: %s\n", (int)basename.len, basename.data,
                     sqlite3_errmsg(ctx->db));
@@ -1052,7 +1039,7 @@ static void marfs_process_dir(void* ptr, void* user_data) {
         }
 
         // new name
-        rc = sqlite3_bind_text(stmt, 2, mountpoint.data, (int)mountpoint.len, SQLITE_TRANSIENT);
+        rc = sqlite3_bind_text(stmt, 2, mountpoint.data, (int)mountpoint.len, SQLITE_STATIC);
         if (rc != SQLITE_OK) {
             fprintf(stderr, "plugin: bind new summary name failed for %.*s: %s\n", (int)mountpoint.len, mountpoint.data,
                     sqlite3_errmsg(ctx->db));
@@ -1075,6 +1062,8 @@ static void marfs_process_dir(void* ptr, void* user_data) {
 // marfs_indexing_global_exit cleans up the marfs index tree and cleans up the global state
 static void marfs_indexing_global_exit(void* global) {
     (void)global;
+
+    sqlite3_shutdown();
 
     if (cleanup_marfs_index() != 0) {
         fprintf(stderr, "Warning: cleanup_marfs_index failed\n");

--- a/contrib/plugins/marfs_plugin.c
+++ b/contrib/plugins/marfs_plugin.c
@@ -592,7 +592,7 @@ static int revert_marfs_index(void) {
 }
 
 // marfs_indexing_global_init reads the marfs config and adds the namespaces to a global state.
-static void marfs_indexing_global_init(void* global) {
+static int marfs_indexing_global_init(void* global) {
     struct input* in = (struct input*)global;
     pthread_mutex_t marfs_erasurelock = PTHREAD_MUTEX_INITIALIZER;
 
@@ -603,7 +603,7 @@ static void marfs_indexing_global_init(void* global) {
     // marfs configs
     if (in->pos.argc != 2) {
         fprintf(stderr, "Error: Marfs plugin requires exactly 2 paths\n");
-        exit(EXIT_FAILURE);
+        return ret;
     }
 
     // add index parent and root namespace to global state
@@ -676,8 +676,9 @@ static void marfs_indexing_global_init(void* global) {
 cleanup:
     if (ret != 0) {
         marfs_plugin_cleanup();
-        exit(EXIT_FAILURE);
     }
+
+    return ret;
 }
 
 // simple check to determine if a provided file path is a namespace in the marfs config
@@ -706,9 +707,8 @@ static int is_namespace(str_t path) {
 
 // marfs_pre_processing_dir checks if we're about to process a marfs specific directory (MDAL_reference, MDAL_subspaces)
 // or a namespace that is no longer active in the marfs config
-static plugin_process_action marfs_pre_processing_dir(void* ptr, void* user_data) {
+static plugin_process_action marfs_pre_processing_dir(void* ptr) {
     PCS_t* pcs = (PCS_t*)ptr;
-    (void)user_data;
 
     if (!pcs || !pcs->work || !pcs->work->name) {
         fprintf(stderr, "Error: gufi pcs is NULL\n");

--- a/contrib/plugins/marfs_plugin.c
+++ b/contrib/plugins/marfs_plugin.c
@@ -1,0 +1,1094 @@
+/*
+This file is part of GUFI, which is part of MarFS, which is released
+under the BSD license.
+
+
+Copyright (c) 2017, Los Alamos National Security (LANS), LLC
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation and/or
+other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors
+may be used to endorse or promote products derived from this software without
+specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+From Los Alamos National Security, LLC:
+LA-CC-15-039
+
+Copyright (c) 2017, Los Alamos National Security, LLC All rights reserved.
+Copyright 2017. Los Alamos National Security, LLC. This software was produced
+under U.S. Government contract DE-AC52-06NA25396 for Los Alamos National
+Laboratory (LANL), which is operated by Los Alamos National Security, LLC for
+the U.S. Department of Energy. The U.S. Government has rights to use,
+reproduce, and distribute this software.  NEITHER THE GOVERNMENT NOR LOS
+ALAMOS NATIONAL SECURITY, LLC MAKES ANY WARRANTY, EXPRESS OR IMPLIED, OR
+ASSUMES ANY LIABILITY FOR THE USE OF THIS SOFTWARE.  If software is
+modified to produce derivative works, such modified software should be
+clearly marked, so as not to confuse it with the version available from
+LANL.
+
+THIS SOFTWARE IS PROVIDED BY LOS ALAMOS NATIONAL SECURITY, LLC AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL LOS ALAMOS NATIONAL SECURITY, LLC OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+OF SUCH DAMAGE.
+*/
+
+/*
+build instruction:
+
+cd contrib
+
+gcc -g -c -fPIC plugins/marfs_plugin.c \
+  -I../include \
+  -I../build/deps/sqlite3/include \
+  -I/path/to/marfs/install/include \
+  -I/path/to/marfs/src/marfs/src \
+  -I/usr/include/libxml2
+
+gcc -shared -o marfs_plugin.so marfs_plugin.o \
+  -L/path/to/marfs/install/lib \
+  -lmarfs \
+  -lxml2 \
+  -Wl,-rpath,/path/to/marfs/install/lib
+
+run example:
+MARFS_CONFIG_PATH=/path/to/marfs/install/etc/marfs-config.xml \
+  ./build/src/gufi_dir2index \
+  --plugin ./contrib/marfs_plugin.so \
+  /path/to/mdal-root/sec-root /home/$USER/gufi-index-dir
+*/
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+#include <pthread.h>
+#include <stddef.h>
+#include <stdlib.h>
+
+#include "bf.h"
+#include "plugin.h"
+#include "str.h"
+#include "utils.h"
+#include "xattrs.h"
+
+#include "config/config.h"
+#include "hash/hash.h"
+
+static const char* MARFS_PREFIX = "MDAL_";
+static const char* MARFS_SUBSPACES_NAME = "MDAL_subspaces";
+static const char* MARFS_CONFIG_ENV = "MARFS_CONFIG_PATH";
+
+static const char MARFS_XATTR_NAME[] = "user.MDAL_MARFS-FILE";
+
+// used for sorting namespaces
+static int cmp_cstr_ptr(const void* a, const void* b) {
+    const char* sa = *(const char* const*)a;
+    const char* sb = *(const char* const*)b;
+    return strcmp(sa, sb);
+}
+
+// sort namespace paths
+static void sort_namespaces(char** namespace_list, size_t namespace_count) {
+    qsort(namespace_list, namespace_count, sizeof *namespace_list, cmp_cstr_ptr);
+}
+
+// returns the basename of a path
+str_t get_basename(str_t path) {
+    if (!path.data || path.len == 0) return (str_t)REFSTR(NULL, 0);
+
+    size_t len = path.len;
+
+    // trim trailing slashes except root
+    while (len > 1 && path.data[len - 1] == '/') len--;
+
+    size_t i = len;
+    while (i > 0 && path.data[i - 1] != '/') i--;
+
+    return (str_t)REFSTR(path.data + i, len - i);
+}
+
+// returns the parent of a path
+str_t get_parent(str_t path) {
+    if (!path.data || path.len == 0) return (str_t)REFSTR(NULL, 0);
+
+    size_t len = path.len;
+
+    // trim trailing slashes except root
+    while (len > 1 && path.data[len - 1] == '/') len--;
+
+    // root stays root
+    if (len == 1 && path.data[0] == '/') return (str_t)REFSTR(path.data, 1);
+
+    size_t i = len;
+    while (i > 0 && path.data[i - 1] != '/') i--;
+
+    if (i == 0) return (str_t)REFSTR(NULL, 0);
+
+    size_t parent_len = (i - 1 == 0) ? 1 : (i - 1);
+    return (str_t)REFSTR(path.data, parent_len);
+}
+
+// returns the grandparent of a path
+str_t get_grandparent(str_t path) { return get_parent(get_parent(path)); }
+
+// join two str_t file paths together
+char* join_path(str_t lhs, str_t rhs) {
+    size_t len = lhs.len + 1 + rhs.len + 1;
+    char* out = malloc(len);
+    if (!out) return NULL;
+
+    snprintf(out, len, "%.*s/%.*s", (int)lhs.len, lhs.data, (int)rhs.len, rhs.data);
+    return out;
+}
+
+// check if str_t starts with a prefix
+static int str_t_startswith(str_t s, const char* prefix) {
+    size_t plen = strlen(prefix);
+    return s.data && s.len >= plen && memcmp(s.data, prefix, plen) == 0;
+}
+
+// check if a str_t is equal to a char*
+static int str_t_eq_cstr(str_t s, const char* cstr) {
+    size_t len = strlen(cstr);
+    return s.data && s.len == len && memcmp(s.data, cstr, len) == 0;
+}
+
+// free a str_t
+static void free_str_members(str_t* s) {
+    if (!s) return;
+
+    if (s->free) {
+        s->free(s->data);
+    }
+
+    s->data = NULL;
+    s->len = 0;
+    s->free = NULL;
+}
+
+struct marfs_plugin {
+    char** namespaces;
+    char** index_namespaces;
+    size_t namespaces_count;
+
+    str_t index_parent;  // actual index is placed at <index parent>/$(basename <src>)
+    str_t marfs_mountpoint;
+    str_t root_namespace;
+    size_t root_namespace_level;
+};
+
+static struct marfs_plugin g_state;
+
+static void marfs_plugin_cleanup(void) {
+    if (g_state.namespaces) {
+        for (size_t i = 0; i < g_state.namespaces_count; i++) {
+            free(g_state.namespaces[i]);
+        }
+        free(g_state.namespaces);
+    }
+
+    if (g_state.index_namespaces) {
+        for (size_t i = 0; i < g_state.namespaces_count; i++) {
+            free(g_state.index_namespaces[i]);
+        }
+        free(g_state.index_namespaces);
+    }
+
+    free_str_members(&g_state.index_parent);
+    free_str_members(&g_state.marfs_mountpoint);
+    free_str_members(&g_state.root_namespace);
+
+    g_state.namespaces = NULL;
+    g_state.index_namespaces = NULL;
+    g_state.namespaces_count = 0;
+}
+
+// count the number of namespace paths in the marfs config
+static size_t count_ns_paths(marfs_ns* ns) {
+    if (!ns) return 0;
+
+    size_t total = 0;
+
+    for (size_t i = 0; i < ns->subnodecount; i++) {
+        HASH_NODE* hn = &ns->subnodes[i];
+        marfs_ns* child = (marfs_ns*)hn->content;
+
+        if (!hn->name || !child) continue;
+
+        total++;
+        total += count_ns_paths(child);
+    }
+
+    return total;
+}
+
+// retrieve the namespace paths from the marfs config
+static int collect_ns_paths(marfs_ns* ns, const char* parent_path, char** paths, size_t* index) {
+    if (!ns || !paths || !index) return -1;
+
+    for (size_t i = 0; i < ns->subnodecount; i++) {
+        HASH_NODE* hn = &ns->subnodes[i];
+        marfs_ns* child = (marfs_ns*)hn->content;
+
+        if (!hn->name || !child) continue;
+
+        char* path = NULL;
+        int n;
+
+        if (!parent_path || parent_path[0] == '\0') {
+            n = snprintf(NULL, 0, "%s", hn->name);
+            if (n < 0) return -1;
+
+            path = malloc((size_t)n + 1);
+            if (!path) return -1;
+
+            snprintf(path, (size_t)n + 1, "%s", hn->name);
+        } else {
+            n = snprintf(NULL, 0, "%s/%s/%s", parent_path, MARFS_SUBSPACES_NAME, hn->name);
+            if (n < 0) return -1;
+
+            path = malloc((size_t)n + 1);
+            if (!path) return -1;
+
+            snprintf(path, (size_t)n + 1, "%s/%s/%s", parent_path, MARFS_SUBSPACES_NAME, hn->name);
+        }
+
+        paths[*index] = path;
+        (*index)++;
+
+        if (collect_ns_paths(child, path, paths, index) != 0) {
+            (*index)--;
+            paths[*index] = NULL;
+            free(path);
+            return -1;
+        }
+    }
+
+    return 0;
+}
+
+// validate that we are actually pointed at the root namespace of a marfs-mdal (sec-root).
+// There should be an MDAL_subspaces directly under the root namespace
+// then there should be our first namespaces right under the MDAL_subspaces
+// NOTE: this requires that the namespaces be sorted beforehand
+static int validate_sec_root(void) {
+    struct stat st;
+    int ret = 0;
+    char* path = NULL;
+    int len;
+
+    if (!g_state.root_namespace.data || g_state.root_namespace.len == 0) goto cleanup;
+    if (!g_state.namespaces || g_state.namespaces_count == 0) goto cleanup;
+    if (!g_state.namespaces[0]) goto cleanup;
+
+    // check if MDAL_subspaces exists under the target dir
+    len = snprintf(NULL, 0, "%s/%s", g_state.root_namespace.data, MARFS_SUBSPACES_NAME);
+    if (len < 0) goto cleanup;
+
+    path = malloc((size_t)len + 1);
+    if (!path) goto cleanup;
+
+    snprintf(path, (size_t)len + 1, "%s/%s", g_state.root_namespace.data, MARFS_SUBSPACES_NAME);
+
+    if (stat(path, &st) != 0 || !S_ISDIR(st.st_mode)) goto cleanup;
+
+    // check if one of the top namespaces is in the first MDAL_subspaces
+    if (stat(g_state.namespaces[0], &st) != 0 || !S_ISDIR(st.st_mode)) goto cleanup;
+
+    ret = 1;
+
+cleanup:
+    free(path);
+    return ret;
+}
+
+// cleanup_marfs_index will go through each namesapce defined in the marfs config, move it up a directory, and delete
+// the empty MDAL_subspaces that remains. It also removes any empty MDAL_subspaces that exist within the namespace as
+// well as renaming the root directory to the basename of the specified moutnpoint in the marfs config
+static int cleanup_marfs_index() {
+    int ret = 0;
+
+    // loop through our index namespaces and move them up a directory and delete the unecessary MDAL_subspaces
+    for (size_t i = g_state.namespaces_count; i-- > 0;) {
+        const str_t old = (str_t)REFSTR(g_state.index_namespaces[i], strlen(g_state.index_namespaces[i]));
+
+        const str_t basename = get_basename(old);
+        const str_t parent = get_parent(old);
+        const str_t grandparent = get_grandparent(old);
+
+        char* new_path = NULL;
+        char* parent_path = NULL;
+        char* child_subspaces = NULL;
+
+        // check to see if there is an empty MDAL_subspaces within this namespace
+        {
+            size_t child_subspaces_len =
+                old.len + 1 + strlen(MARFS_SUBSPACES_NAME) + 1;  // old + "/" + MDAL_subspaces + NUL
+            child_subspaces = malloc(child_subspaces_len);
+            if (!child_subspaces) {
+                fprintf(stderr, "malloc failed for child_subspaces\n");
+                ret = -1;
+                continue;
+            }
+
+            snprintf(child_subspaces, child_subspaces_len, "%.*s/%s", (int)old.len, old.data, MARFS_SUBSPACES_NAME);
+            if (rmdir(child_subspaces) != 0) {
+                if (errno != ENOTEMPTY && errno != ENOENT) {
+                    fprintf(stderr, "rmdir('%s') failed: %s\n", child_subspaces, strerror(errno));
+                    ret = -1;
+                }
+            }
+            free(child_subspaces);
+        }
+
+        // move this namespace up a directory (into it's grandparent)
+        {
+            size_t new_len = grandparent.len + 1 + basename.len + 1;  // gp + "/" + base + NUL
+            new_path = malloc(new_len);
+            if (!new_path) {
+                fprintf(stderr, "malloc failed for new_path\n");
+                ret = -1;
+                continue;
+            }
+
+            if (grandparent.len == 1 && grandparent.data[0] == '/') {
+                snprintf(new_path, new_len, "/%.*s", (int)basename.len, basename.data);
+            } else {
+                snprintf(new_path, new_len, "%.*s/%.*s", (int)grandparent.len, grandparent.data, (int)basename.len,
+                         basename.data);
+            }
+
+            if (rename(old.data, new_path) != 0) {
+                fprintf(stderr, "rename('%s' -> '%s') failed: %s\n", old.data, new_path, strerror(errno));
+                free(new_path);
+                ret = -1;
+                continue;
+            } else {
+                // printf("moved: %s -> %s\n", old, new_path);
+            }
+            free(new_path);
+        }
+
+        // attempt to remove the old "parent" of the namespace
+        {
+            if (parent.len > 0) {
+                parent_path = malloc(parent.len + 1);
+                if (!parent_path) {
+                    fprintf(stderr, "malloc failed for parent_path\n");
+                    ret = -1;
+                    continue;
+                }
+
+                memcpy(parent_path, parent.data, parent.len);
+                parent_path[parent.len] = '\0';
+
+                if (rmdir(parent_path) != 0) {
+                    if (errno != ENOTEMPTY) {
+                        fprintf(stderr, "rmdir('%s') failed: %s\n", parent_path, strerror(errno));
+                        ret = -1;
+                    }
+                }
+            }
+
+            free(parent_path);
+        }
+    }
+
+    // rename the root namespace to the marfs mountpoint from the marfs config
+    const str_t rn_base = get_basename(g_state.root_namespace);
+    const str_t mm_base = get_basename(g_state.marfs_mountpoint);
+
+    char* rn_path = join_path(g_state.index_parent, rn_base);
+    char* mm_path = join_path(g_state.index_parent, mm_base);
+
+    if (!mm_path || !rn_path) {
+        fprintf(stderr, "join_path failed\n");
+        free(mm_path);
+        free(rn_path);
+        return -1;
+    }
+
+    if (rename(rn_path, mm_path) != 0) {
+        fprintf(stderr, "rename('%s' -> '%s') failed: %s\n", rn_path, mm_path, strerror(errno));
+        free(mm_path);
+        free(rn_path);
+        return -1;
+    } else {
+        // printf("moved: %s -> %s\n", rn_path, mm_path);
+    }
+
+    free(mm_path);
+    free(rn_path);
+
+    return ret;
+}
+
+// revert_marfs_index will undo everything that's in cleanup_marfs_index. This allows for indexing to be run over an
+// existing index tree without error
+static int revert_marfs_index() {
+    mode_t mode = 0701;
+    int ret = 0;
+
+    // rename the marfs mountpoint from the marfs config to the root namespace
+    const str_t mm_base = get_basename(g_state.marfs_mountpoint);
+    const str_t rn_base = get_basename(g_state.root_namespace);
+
+    char* mm_path = join_path(g_state.index_parent, mm_base);
+    char* rn_path = join_path(g_state.index_parent, rn_base);
+
+    if (!mm_path || !rn_path) {
+        fprintf(stderr, "join_path failed\n");
+        free(mm_path);
+        free(rn_path);
+        return -1;
+    }
+
+    if (rename(mm_path, rn_path) != 0) {
+        // fprintf(stderr, "rename('%s' -> '%s') failed: %s\n", mm_path, rn_path, strerror(errno));
+    } else {
+        // printf("moved: %s -> %s\n", mm_path, rn_path);
+    }
+
+    free(mm_path);
+    free(rn_path);
+
+    // loop through our index namespaces and add a subspaces into them. then move them down into each subspace
+    for (size_t i = 0; i < g_state.namespaces_count; i++) {
+        const str_t old = (str_t)REFSTR(g_state.index_namespaces[i], strlen(g_state.index_namespaces[i]));
+
+        const str_t basename = get_basename(old);
+        const str_t parent = get_parent(old);
+        const str_t grandparent = get_grandparent(old);
+
+        char* indexed_path = NULL;
+        char* parent_path = NULL;
+
+        size_t new_len = grandparent.len + 1 + basename.len + 1;  // gp + "/" + base + NUL
+        indexed_path = malloc(new_len);
+        if (!indexed_path) {
+            fprintf(stderr, "malloc failed for indexed_path\n");
+            ret = -1;
+            continue;
+        }
+
+        if (grandparent.len == 1 && grandparent.data[0] == '/') {
+            snprintf(indexed_path, new_len, "/%.*s", (int)basename.len, basename.data);
+        } else {
+            snprintf(indexed_path, new_len, "%.*s/%.*s", (int)grandparent.len, grandparent.data, (int)basename.len,
+                     basename.data);
+        }
+
+        // make an empty MDAL_subspaces in this namespace's parent
+        {
+            // parent is a slice, so make a real C string before mkdir()
+            if (parent.len > 1) {
+                parent_path = malloc(parent.len + 1);
+                if (!parent_path) {
+                    fprintf(stderr, "malloc failed for parent_path\n");
+                    free(indexed_path);
+                    ret = -1;
+                    continue;
+                }
+
+                memcpy(parent_path, parent.data, parent.len);
+                parent_path[parent.len] = '\0';
+
+                if (mkdir(parent_path, mode) != 0) {
+                    if (errno != ENOTEMPTY && errno != EEXIST) {
+                        // fprintf(stderr, "mkdir('%s') failed: %s\n", parent_path, strerror(errno));
+                        free(parent_path);
+                        free(indexed_path);
+                        // ret = -1;
+                        continue;
+                    }
+                } else {
+                    // printf("added empty %s: %s\n", MARFS_SUBSPACES_NAME, parent_path);
+                }
+
+                free(parent_path);
+            }
+        }
+
+        // move this namespace into the MDAL_subspaces we just made
+        {
+            if (rename(indexed_path, old.data) != 0) {
+                fprintf(stderr, "rename('%s' -> '%s') failed: %s\n", indexed_path, old.data, strerror(errno));
+                free(indexed_path);
+                // ret = -1;
+                continue;
+            } else {
+                // printf("moved: %s -> %s\n", indexed_path, old.data);
+            }
+
+            free(indexed_path);
+        }
+    }
+
+    return ret;
+}
+
+// marfs_indexing_global_init reads the marfs config and adds the namespaces to a global state.
+static void marfs_indexing_global_init(void* global) {
+    struct input* in = (struct input*)global;
+    pthread_mutex_t marfs_erasurelock = PTHREAD_MUTEX_INITIALIZER;
+
+    char** config_namespaces = NULL;
+    size_t config_index = 0;
+    size_t i = 0;
+    int ret = -1;
+
+    // We can only allow for a single dir to be indexed at a time. this is because we have no way to taking in multiple
+    // marfs configs
+    if (in->pos.argc != 2) {
+        fprintf(stderr, "Error: Marfs plugin requires exactly 2 paths\n");
+        exit(EXIT_FAILURE);
+    }
+
+    // add index parent and root namespace to global state
+    INSTALL_STR(&g_state.index_parent, in->pos.argv[in->pos.argc - 1]);
+    INSTALL_STR(&g_state.root_namespace, in->pos.argv[0]);
+
+    g_state.root_namespace_level = 0;
+
+    char* marfs_config_path = getenv(MARFS_CONFIG_ENV);
+
+    errno = 0;
+    marfs_config* cfg = config_init(marfs_config_path, &marfs_erasurelock);
+    if (!cfg) {
+        int e = errno;
+        fprintf(stderr, "marfs config_init returned NULL (errno=%d)\n", e);
+        goto cleanup;
+    }
+
+    // add marfs config mountpoint to global state
+    INSTALL_STR(&g_state.marfs_mountpoint, cfg->mountpoint);
+
+    g_state.namespaces_count = count_ns_paths(cfg->rootns);
+
+    if (g_state.namespaces_count == 0) {
+        fprintf(stderr, "Error: no namespaces found in MarFS config\n");
+        goto cleanup;
+    }
+
+    config_namespaces = calloc(g_state.namespaces_count, sizeof(char*));
+    if (!config_namespaces) {
+        fprintf(stderr, "Error: config_namespaces calloc failed\n");
+        goto cleanup;
+    }
+
+    if (collect_ns_paths(cfg->rootns, "", config_namespaces, &config_index) != 0) {
+        fprintf(stderr, "Error: collect_ns_paths failed\n");
+        goto cleanup;
+    }
+
+    if (config_index != g_state.namespaces_count) {
+        fprintf(stderr, "Error: namespace count mismatch (expected %zu, got %zu)\n", g_state.namespaces_count,
+                config_index);
+        goto cleanup;
+    }
+
+    g_state.namespaces = calloc(g_state.namespaces_count, sizeof(char*));
+    g_state.index_namespaces = calloc(g_state.namespaces_count, sizeof(char*));
+
+    if (!g_state.namespaces || !g_state.index_namespaces) {
+        fprintf(stderr, "Error: namespace array allocation failed\n");
+        goto cleanup;
+    }
+
+    const str_t rn_base = get_basename(g_state.root_namespace);
+
+    // prepend our prefix to each namespace
+    for (i = 0; i < g_state.namespaces_count; i++) {
+        int len =
+            snprintf(NULL, 0, "%s/%s/%s", g_state.root_namespace.data, MARFS_SUBSPACES_NAME, config_namespaces[i]);
+        if (len < 0) {
+            fprintf(stderr, "Error: snprintf failed for namespace[%zu]\n", i);
+            goto cleanup;
+        }
+
+        g_state.namespaces[i] = malloc((size_t)len + 1);
+        if (!g_state.namespaces[i]) {
+            fprintf(stderr, "Error: malloc failed for namespace[%zu]\n", i);
+            goto cleanup;
+        }
+
+        snprintf(g_state.namespaces[i], (size_t)len + 1, "%s/%s/%s", g_state.root_namespace.data, MARFS_SUBSPACES_NAME,
+                 config_namespaces[i]);
+
+        // printf("namespace: %s\n", g_state.namespaces[i]);
+
+        len = snprintf(NULL, 0, "%.*s/%.*s/%s/%s", (int)g_state.index_parent.len, g_state.index_parent.data,
+                       (int)rn_base.len, rn_base.data, MARFS_SUBSPACES_NAME, config_namespaces[i]);
+        if (len < 0) {
+            fprintf(stderr, "Error: snprintf failed for index_namespace[%zu]\n", i);
+            goto cleanup;
+        }
+
+        g_state.index_namespaces[i] = malloc((size_t)len + 1);
+        if (!g_state.index_namespaces[i]) {
+            fprintf(stderr, "Error: malloc failed for index_namespace[%zu]\n", i);
+            goto cleanup;
+        }
+
+        snprintf(g_state.index_namespaces[i], (size_t)len + 1, "%.*s/%.*s/%s/%s", (int)g_state.index_parent.len,
+                 g_state.index_parent.data, (int)rn_base.len, rn_base.data, MARFS_SUBSPACES_NAME, config_namespaces[i]);
+    }
+
+    sort_namespaces(g_state.namespaces, g_state.namespaces_count);
+    sort_namespaces(g_state.index_namespaces, g_state.namespaces_count);
+
+    if (!validate_sec_root()) {
+        fprintf(stderr, "Error: provided dir is not the root of the parent marfs namespace\n");
+        goto cleanup;
+    }
+
+    if (revert_marfs_index() != 0) {
+        fprintf(stderr, "Error: revert_marfs_index failed\n");
+        goto cleanup;
+    }
+
+    ret = 0;
+
+cleanup:
+    if (config_namespaces) {
+        for (size_t j = 0; j < config_index; j++) {
+            free(config_namespaces[j]);
+        }
+        free(config_namespaces);
+    }
+
+    if (ret != 0) {
+        marfs_plugin_cleanup();
+        exit(EXIT_FAILURE);
+    }
+}
+
+// simple check to determine if a provided file path is a namespace in the marfs config
+static int is_namespace(str_t path) {
+    if (!path.data) {
+        return 0;
+    }
+
+    for (size_t i = 0; i < g_state.namespaces_count; i++) {
+        const char* ns = g_state.namespaces[i];
+        if (!ns) {
+            continue;
+        }
+
+        size_t ns_len = strlen(ns);
+        if (ns_len != path.len) {
+            continue;
+        }
+
+        if (memcmp(ns, path.data, path.len) == 0) {
+            return 1;
+        }
+    }
+
+    return 0;
+}
+
+// marfs_pre_processing_dir checks if we're about to process a marfs specific directory (MDAL_reference, MDAL_subspaces)
+// or a namespace that is no longer active in the marfs config
+static process_action marfs_pre_processing_dir(void* ptr, void* user_data) {
+    PCS_t* pcs = (PCS_t*)ptr;
+    (void)user_data;
+
+    if (!pcs || !pcs->work || !pcs->work->name) {
+        fprintf(stderr, "Error: gufi pcs is NULL\n");
+        return PROCESS_DIR;
+    }
+
+    const str_t path = (str_t)REFSTR(pcs->work->name, strlen(pcs->work->name));
+    const str_t basename = get_basename(path);
+    const str_t parent = get_parent(path);
+
+    if (str_t_startswith(basename, MARFS_PREFIX)) {
+        // this directory starts with MDAL_
+
+        // determine if this is actual a marfs directory or a user dir
+        // cases for being a marfs dir:
+        // 1. directly under sec-root
+        // 2. directly under a namespace
+        if (g_state.root_namespace_level == pcs->work->level - 1 || is_namespace(parent)) {
+            if (str_t_eq_cstr(basename, MARFS_SUBSPACES_NAME)) {
+                // this is a subspaces dir. do not process, but still descend
+                return NO_PROCESS_DIR;
+            } else {
+                // this is any other marfs dir. do not process, do not descend
+                return NO_PROCESS_NO_DESCEND_DIR;
+            }
+        } else {
+            return PROCESS_DIR;
+        }
+    }
+
+    if (str_t_startswith(get_basename(parent), MARFS_PREFIX)) {
+        // parent directory starts with MDAL_
+        // check to see if it's even possible for this dir to be a marfs namespace
+        // cases for this being a marfs namespace:
+        // 1. grandparent is sec-root
+        // 2. grandparent is a namespace
+        const str_t grandparent = get_grandparent(path);
+        if (g_state.root_namespace_level == pcs->work->level - 2 || is_namespace(grandparent)) {
+            // it's possible for this to be a marfs namespace. check the marfs config to be sure that it is currently
+            // active
+            if (is_namespace(path)) {
+                return PROCESS_DIR;
+            } else {
+                // this dir is not listed in the marfs config so do not process it or descend
+                return NO_PROCESS_NO_DESCEND_DIR;
+            }
+        }
+    }
+
+    return PROCESS_DIR;
+}
+
+// marfs_ctx is used for database init and cleanup
+struct marfs_ctx {
+    sqlite3* db;
+    sqlite3_stmt* delete_entry;
+    sqlite3_stmt* decrement_nlink;
+    sqlite3_stmt* update_xattr_names;
+    sqlite3_stmt* update_summary_name;
+};
+
+static void marfs_ctx_exit(void* ptr, void* plugin_user_data) {
+    (void)ptr;
+
+    struct marfs_ctx* ctx = (struct marfs_ctx*)plugin_user_data;
+    if (!ctx) {
+        return;
+    }
+
+    if (ctx->delete_entry) {
+        sqlite3_finalize(ctx->delete_entry);
+    }
+
+    if (ctx->decrement_nlink) {
+        sqlite3_finalize(ctx->decrement_nlink);
+    }
+
+    if (ctx->update_xattr_names) {
+        sqlite3_finalize(ctx->update_xattr_names);
+    }
+
+    if (ctx->update_summary_name) {
+        sqlite3_finalize(ctx->update_summary_name);
+    }
+
+    free(ctx);
+}
+
+static void* marfs_ctx_init(void* ptr) {
+    PCS_t* pcs = (PCS_t*)ptr;
+    if (!pcs || !pcs->db) {
+        fprintf(stderr, "Error: marfs_ctx_init got invalid PCS/db\n");
+        return NULL;
+    }
+
+    sqlite3* db = pcs->db;
+
+    struct marfs_ctx* ctx = calloc(1, sizeof(*ctx));
+    if (!ctx) {
+        fprintf(stderr, "Error: could not allocate marfs ctx\n");
+        return NULL;
+    }
+
+    ctx->db = db;
+
+    int rc;
+
+    rc = sqlite3_prepare_v2(db, "DELETE FROM entries WHERE name = ?1;", -1, &ctx->delete_entry, NULL);
+    if (rc != SQLITE_OK) {
+        fprintf(stderr, "Error: prepare DELETE failed: %s\n", sqlite3_errmsg(db));
+        marfs_ctx_exit(ptr, ctx);
+        return NULL;
+    }
+
+    rc = sqlite3_prepare_v2(db,
+                            "UPDATE entries "
+                            "SET nlink = CASE WHEN nlink > 0 THEN nlink - 1 ELSE 0 END "
+                            "WHERE name = ?1;",
+                            -1, &ctx->decrement_nlink, NULL);
+    if (rc != SQLITE_OK) {
+        fprintf(stderr, "Error: prepare decrement nlink failed: %s\n", sqlite3_errmsg(db));
+        marfs_ctx_exit(ptr, ctx);
+        return NULL;
+    }
+
+    rc = sqlite3_prepare_v2(db,
+                            "UPDATE entries "
+                            "SET xattr_names = ?2 "
+                            "WHERE name = ?1;",
+                            -1, &ctx->update_xattr_names, NULL);
+    if (rc != SQLITE_OK) {
+        fprintf(stderr, "Error: prepare xattr update failed: %s\n", sqlite3_errmsg(db));
+        marfs_ctx_exit(ptr, ctx);
+        return NULL;
+    }
+
+    rc = sqlite3_prepare_v2(db,
+                            "UPDATE summary "
+                            "SET name = ?2 "
+                            "WHERE name = ?1;",
+                            -1, &ctx->update_summary_name, NULL);
+    if (rc != SQLITE_OK) {
+        fprintf(stderr, "Error: prepare summary update failed: %s\n", sqlite3_errmsg(db));
+        marfs_ctx_exit(ptr, ctx);
+        return NULL;
+    }
+
+    return ctx;
+}
+
+// filter out the marfs specific xattrs and rebuild the blob to update the gufi db
+static sqlite3_int64 build_xattr_names_filtered(struct entry_data* ed, const char* remove_name, char* out,
+                                                size_t out_sz) {
+    size_t w = 0;
+
+    for (size_t i = 0; i < ed->xattrs.count; i++) {
+        const struct xattr* x = &ed->xattrs.pairs[i];
+
+        if (strcmp(x->name, remove_name) == 0) {
+            continue;
+        }
+
+        const size_t nmlen = x->name_len;
+
+        // need space for name + delimiter
+        if (w + nmlen + 1 > out_sz) {
+            break;
+        }
+
+        memcpy(out + w, x->name, nmlen);
+        w += nmlen;
+
+        out[w++] = XATTRDELIM;
+    }
+
+    return (sqlite3_int64)w;
+}
+
+// marfs_process_file removes any marfs specific files from the gufi db, decrements every file nlink by 1, and removes
+// any marfs specific xattrs
+static void marfs_process_file(void* ptr, void* user_data) {
+    PCS_t* pcs = (PCS_t*)ptr;
+    struct entry_data* ed = pcs->ed;
+    struct marfs_ctx* ctx = (struct marfs_ctx*)user_data;
+
+    if (!pcs || !ctx || !ctx->db || !ed || !pcs->work || !pcs->work->name) {
+        return;
+    }
+
+    int rc;
+
+    const str_t path = (str_t)REFSTR(pcs->work->name, strlen(pcs->work->name));
+    const str_t basename = get_basename(path);
+
+    if (!basename.data || basename.len == 0) {
+        return;
+    }
+
+    // remove mdal specific files
+    if (basename.len >= strlen(MARFS_PREFIX) && str_t_startswith(basename, MARFS_PREFIX)) {
+        // this files starts with MDAL_
+
+        // determine if this is actual a marfs directory or a user dir
+        // cases for being a marfs dir:
+        // 1. directly under sec-root
+        // 2. directly under a namespace
+
+        const str_t parent = get_parent(path);
+
+        if (g_state.root_namespace_level == pcs->work->level - 1 || is_namespace(parent)) {
+            // this is a marfs file. remove it from the database
+
+            sqlite3_stmt* stmt = ctx->delete_entry;
+
+            sqlite3_reset(stmt);
+            sqlite3_clear_bindings(stmt);
+
+            rc = sqlite3_bind_text(stmt, 1, basename.data, (int)basename.len, SQLITE_TRANSIENT);
+            if (rc != SQLITE_OK) {
+                fprintf(stderr, "plugin: bind DELETE failed for %.*s: %s\n", (int)basename.len, basename.data,
+                        sqlite3_errmsg(ctx->db));
+                return;
+            }
+
+            rc = sqlite3_step(stmt);
+            if (rc != SQLITE_DONE) {
+                fprintf(stderr, "plugin: DELETE failed for %.*s: %s\n", (int)basename.len, basename.data,
+                        sqlite3_errmsg(ctx->db));
+            }
+
+            sqlite3_reset(stmt);
+            sqlite3_clear_bindings(stmt);
+            return;
+        }
+    }
+
+    // decrement nlink
+    {
+        sqlite3_stmt* stmt = ctx->decrement_nlink;
+
+        sqlite3_reset(stmt);
+        sqlite3_clear_bindings(stmt);
+
+        rc = sqlite3_bind_text(stmt, 1, basename.data, (int)basename.len, SQLITE_TRANSIENT);
+        if (rc != SQLITE_OK) {
+            fprintf(stderr, "plugin: bind nlink failed for %.*s: %s\n", (int)basename.len, basename.data,
+                    sqlite3_errmsg(ctx->db));
+            return;
+        }
+
+        rc = sqlite3_step(stmt);
+        if (rc != SQLITE_DONE) {
+            fprintf(stderr, "plugin: decrement nlink failed for %.*s: %s\n", (int)basename.len, basename.data,
+                    sqlite3_errmsg(ctx->db));
+        }
+
+        sqlite3_reset(stmt);
+        sqlite3_clear_bindings(stmt);
+    }
+
+    // remove marfs xattr
+    {
+        sqlite3_stmt* stmt = ctx->update_xattr_names;
+
+        char xattr_names[MAXXATTR];
+        sqlite3_int64 xlen = build_xattr_names_filtered(ed, MARFS_XATTR_NAME, xattr_names, sizeof(xattr_names));
+        if (xlen < 0) xlen = 0;
+
+        sqlite3_reset(stmt);
+        sqlite3_clear_bindings(stmt);
+
+        rc = sqlite3_bind_text(stmt, 1, basename.data, (int)basename.len, SQLITE_TRANSIENT);
+        if (rc != SQLITE_OK) {
+            fprintf(stderr, "plugin: bind xattr name failed for %.*s: %s\n", (int)basename.len, basename.data,
+                    sqlite3_errmsg(ctx->db));
+            return;
+        }
+
+        rc = sqlite3_bind_blob64(stmt, 2, xattr_names, (sqlite3_uint64)xlen, SQLITE_TRANSIENT);
+        if (rc != SQLITE_OK) {
+            fprintf(stderr, "plugin: bind xattr_names failed for %.*s: %s\n", (int)basename.len, basename.data,
+                    sqlite3_errmsg(ctx->db));
+            return;
+        }
+
+        rc = sqlite3_step(stmt);
+        if (rc != SQLITE_DONE) {
+            fprintf(stderr, "plugin: update xattr_names failed for %.*s: %s\n", (int)basename.len, basename.data,
+                    sqlite3_errmsg(ctx->db));
+        }
+
+        sqlite3_reset(stmt);
+        sqlite3_clear_bindings(stmt);
+    }
+}
+
+// marfs_process_dir renames the root namespace in the gufi db summary table to match the mountpoint in the marfs
+// config. The actual dir gets renamed in cleanup_marfs_index
+static void marfs_process_dir(void* ptr, void* user_data) {
+    PCS_t* pcs = (PCS_t*)ptr;
+    struct marfs_ctx* ctx = (struct marfs_ctx*)user_data;
+
+    if (!pcs || !pcs->work || !pcs->work->name || !ctx || !ctx->db) {
+        return;
+    }
+
+    // determine if this is the root namespace dir
+    if (g_state.root_namespace_level == pcs->work->level && str_t_eq_cstr(g_state.root_namespace, pcs->work->name)) {
+        // rename this to the marfs mountpoint in the database
+        const str_t path = (str_t)REFSTR(pcs->work->name, strlen(pcs->work->name));
+        const str_t basename = get_basename(path);
+        const str_t mountpoint = get_basename(g_state.marfs_mountpoint);
+
+        sqlite3_stmt* stmt = ctx->update_summary_name;
+        int rc;
+
+        sqlite3_reset(stmt);
+        sqlite3_clear_bindings(stmt);
+
+        // old name
+        rc = sqlite3_bind_text(stmt, 1, basename.data, (int)basename.len, SQLITE_TRANSIENT);
+        if (rc != SQLITE_OK) {
+            fprintf(stderr, "plugin: bind summary name failed for %.*s: %s\n", (int)basename.len, basename.data,
+                    sqlite3_errmsg(ctx->db));
+            sqlite3_reset(stmt);
+            sqlite3_clear_bindings(stmt);
+            return;
+        }
+
+        // new name
+        rc = sqlite3_bind_text(stmt, 2, mountpoint.data, (int)mountpoint.len, SQLITE_TRANSIENT);
+        if (rc != SQLITE_OK) {
+            fprintf(stderr, "plugin: bind new summary name failed for %.*s: %s\n", (int)mountpoint.len, mountpoint.data,
+                    sqlite3_errmsg(ctx->db));
+            sqlite3_reset(stmt);
+            sqlite3_clear_bindings(stmt);
+            return;
+        }
+
+        rc = sqlite3_step(stmt);
+        if (rc != SQLITE_DONE) {
+            fprintf(stderr, "plugin: update summary failed for %.*s: %s\n", (int)basename.len, basename.data,
+                    sqlite3_errmsg(ctx->db));
+        }
+
+        sqlite3_reset(stmt);
+        sqlite3_clear_bindings(stmt);
+    }
+}
+
+// marfs_indexing_global_exit cleans up the marfs index tree and cleans up the global state
+static void marfs_indexing_global_exit(void* global) {
+    (void)global;
+
+    if (cleanup_marfs_index() != 0) {
+        fprintf(stderr, "Warning: cleanup_marfs_index failed\n");
+    }
+    marfs_plugin_cleanup();
+}
+
+struct plugin_operations GUFI_PLUGIN_SYMBOL = {
+    .type = PLUGIN_INDEX,
+    .global_init = marfs_indexing_global_init,
+    .ctx_init = marfs_ctx_init,
+    .pre_process_dir = marfs_pre_processing_dir,
+    .process_dir = marfs_process_dir,
+    .process_file = marfs_process_file,
+    .ctx_exit = marfs_ctx_exit,
+    .global_exit = marfs_indexing_global_exit,
+};

--- a/contrib/plugins/marfs_plugin.c
+++ b/contrib/plugins/marfs_plugin.c
@@ -107,7 +107,7 @@ OF SUCH DAMAGE.
  *
  * mkdir build && cd build
  *
- * cmake .. -DMARFS_PREFIX=/path/to/marfs/install/ -DMARFS_SRC=/path/to/marfs/
+ * cmake .. -DMARFS_PREFIX=/path/to/marfs/install/
  *
  * make
  *
@@ -130,8 +130,7 @@ OF SUCH DAMAGE.
 #include <unistd.h>
 
 /* marfs */
-#include "config/config.h"
-#include "hash/hash.h"
+#include "include/config.h"
 
 #include "bf.h"
 #include "plugin.h"

--- a/contrib/plugins/marfs_plugin.c
+++ b/contrib/plugins/marfs_plugin.c
@@ -58,6 +58,9 @@ INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
 CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
 IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
 OF SUCH DAMAGE.
+*/
+
+
 
 /*
  * MarFS GUFI indexing plugin
@@ -102,28 +105,20 @@ OF SUCH DAMAGE.
  *
  * build instruction:
  *
- * cd contrib
+ * mkdir build && cd build
  *
- * gcc -g -c -fPIC plugins/marfs_plugin.c \
- *   -I../include \
- *   -I../build/deps/sqlite3/include \
- *   -I/path/to/marfs/install/include \
- *   -I/path/to/marfs/src/marfs/src \
- *   -I/usr/include/libxml2
+ * cmake .. -DMARFS_PREFIX=/path/to/marfs/install/ -DMARFS_SRC=/path/to/marfs/
  *
- * gcc -shared -o marfs_plugin.so marfs_plugin.o \
- *   ../build/src/libGUFI.a \
- *   -L/path/to/marfs/install/lib \
- *   -lmarfs \
- *   -lxml2 \
- *   -Wl,-rpath,/path/to/marfs/install/lib
+ * make
+ *
+ * (sudo) make install
  *
  * run example:
  * MARFS_CONFIG_PATH=/path/to/marfs/install/etc/marfs-config.xml \
- *   ./build/src/gufi_dir2index \
- *   --plugin ./contrib/marfs_plugin.so \
+ *   src/gufi_dir2index \
+ *   --plugin "GUFI_MARFS_PLUGIN:contrib/plugins/libmarfs_plugin.so" \
  *   /path/to/mdal-root/sec-root /home/$USER/gufi-index-dir
-*/
+ */
 
 #include <errno.h>
 #include <fcntl.h>
@@ -134,9 +129,11 @@ OF SUCH DAMAGE.
 #include <string.h>
 #include <unistd.h>
 
-#include "bf.h"
+/* marfs */
 #include "config/config.h"
 #include "hash/hash.h"
+
+#include "bf.h"
 #include "plugin.h"
 #include "str.h"
 #include "utils.h"
@@ -149,7 +146,8 @@ static const size_t MARFS_SUBSPACES_NAME_LEN = sizeof(MARFS_SUBSPACES_NAME) - 1;
 static const char MARFS_XATTR_NAME[] = "user.MDAL_MARFS-FILE";
 static const size_t MARFS_XATTR_NAME_LEN = sizeof(MARFS_XATTR_NAME) - 1;
 static const size_t ROOT_NAMESPACE_LEVEL = 0;
-static const mode_t MARFS_DIR_MODE = 0701;
+// marfs dir mode used for temporary additions of marfs specific directories during re-indexing
+static const mode_t MARFS_DIR_MODE = S_IRWXU | S_IXOTH;
 
 static const char* MARFS_CONFIG_ENV = "MARFS_CONFIG_PATH";
 
@@ -237,6 +235,8 @@ struct marfs_plugin {
     str_t index_parent;  // actual index is placed at <index parent>/$(basename <src>)
     str_t marfs_mountpoint;
     str_t root_namespace;
+
+    marfs_config* marfs_cfg;
 };
 
 static struct marfs_plugin g_state;
@@ -256,6 +256,10 @@ static void marfs_plugin_cleanup(void) {
 
     g_state.namespaces = NULL;
     g_state.namespaces_count = 0;
+
+    // cleanup marfs config
+    config_term(g_state.marfs_cfg);
+    g_state.marfs_cfg = NULL;
 }
 
 // count the number of namespace paths in the marfs config
@@ -382,9 +386,9 @@ cleanup:
     return ret;
 }
 
-// cleanup_marfs_index will go through each namesapce defined in the marfs config, move it up a directory, and delete
+// cleanup_marfs_index will go through each namespace defined in the marfs config, move it up a directory, and delete
 // the empty MDAL_subspaces that remains. It also removes any empty MDAL_subspaces that exist within the namespace as
-// well as renaming the root directory to the basename of the specified moutnpoint in the marfs config
+// well as renaming the root directory to the basename of the specified mountpoint in the marfs config
 static int cleanup_marfs_index(void) {
     int ret = 0;
 
@@ -518,7 +522,16 @@ static int revert_marfs_index(void) {
         return -1;
     }
 
-    rename(mm_path, rn_path);
+    if (rename(mm_path, rn_path) != 0) {
+        // if we failed to rename the root ns, then don't worry about the rest of the namespaces
+        if (errno != ENOENT) {
+            fprintf(stderr, "rename('%s' -> '%s') failed: %s\n", mm_path, rn_path, strerror(errno));
+            ret = -1;
+        }
+        free(mm_path);
+        free(rn_path);
+        return ret;
+    }
 
     free(mm_path);
     free(rn_path);
@@ -553,7 +566,8 @@ static int revert_marfs_index(void) {
         {
             // parent is a slice, so make a real C string before mkdir()
             if (parent.len > 1) {
-                parent_path = malloc(parent.len + 1);
+                size_t parent_path_size = parent.len + 1;
+                parent_path = malloc(parent_path_size);
                 if (!parent_path) {
                     fprintf(stderr, "malloc failed for parent_path\n");
                     free(indexed_path);
@@ -561,8 +575,7 @@ static int revert_marfs_index(void) {
                     continue;
                 }
 
-                memcpy(parent_path, parent.data, parent.len);
-                parent_path[parent.len] = '\0';
+                snprintf(parent_path, parent_path_size, "%.*s", (int)parent.len, parent.data);
 
                 if (mkdir(parent_path, MARFS_DIR_MODE) != 0) {
                     if (errno != ENOTEMPTY && errno != EEXIST) {
@@ -599,8 +612,7 @@ static int marfs_indexing_global_init(void* global) {
     size_t config_index = 0;
     int ret = -1;
 
-    // We can only allow for a single dir to be indexed at a time. this is because we have no way to taking in multiple
-    // marfs configs
+    // We can only allow for a single dir to be indexed at a time. this is because we do not read multiple marfs configs
     if (in->pos.argc != 2) {
         fprintf(stderr, "Error: Marfs plugin requires exactly 2 paths\n");
         return ret;
@@ -617,17 +629,17 @@ static int marfs_indexing_global_init(void* global) {
     }
 
     errno = 0;
-    marfs_config* cfg = config_init(marfs_config_path, &marfs_erasurelock);
-    if (!cfg) {
-        int e = errno;
-        fprintf(stderr, "marfs config_init returned NULL (errno=%d)\n", e);
+    g_state.marfs_cfg = config_init(marfs_config_path, &marfs_erasurelock);
+    if (!g_state.marfs_cfg) {
+        fprintf(stderr, "marfs config_init returned NULL (errno=%d: %s) (%s=%s)\n", errno, strerror(errno),
+                MARFS_CONFIG_ENV, marfs_config_path);
         goto cleanup;
     }
 
     // add marfs config mountpoint to global state
-    INSTALL_STR(&g_state.marfs_mountpoint, cfg->mountpoint);
+    INSTALL_STR(&g_state.marfs_mountpoint, g_state.marfs_cfg->mountpoint);
 
-    g_state.namespaces_count = count_ns_paths(cfg->rootns);
+    g_state.namespaces_count = count_ns_paths(g_state.marfs_cfg->rootns);
 
     if (g_state.namespaces_count == 0) {
         fprintf(stderr, "Error: no namespaces found in MarFS config\n");
@@ -644,8 +656,8 @@ static int marfs_indexing_global_init(void* global) {
         const str_t rn_base = get_basename(g_state.root_namespace);
         const str_t empty = REFSTR("", 0);
 
-        if (collect_ns_paths(cfg->rootns, empty, g_state.namespaces, &config_index, g_state.root_namespace,
-                             g_state.index_parent, rn_base) != 0) {
+        if (collect_ns_paths(g_state.marfs_cfg->rootns, empty, g_state.namespaces, &config_index,
+                             g_state.root_namespace, g_state.index_parent, rn_base) != 0) {
             fprintf(stderr, "Error: collect_ns_paths failed\n");
             goto cleanup;
         }
@@ -660,7 +672,9 @@ static int marfs_indexing_global_init(void* global) {
     sort_namespace_pairs(g_state.namespaces, g_state.namespaces_count);
 
     if (!validate_sec_root()) {
-        fprintf(stderr, "Error: provided dir is not the root of the parent marfs namespace\n");
+        fprintf(stderr,
+                "Error: provided dir (%s) is not the root of the parent marfs namespace or marfs_config is incorrect\n",
+                g_state.root_namespace.data);
         goto cleanup;
     }
 
@@ -697,7 +711,7 @@ static int is_namespace(str_t path) {
             continue;
         }
 
-        if (str_cmp(&ns, &path) == 0) {
+        if (strncmp(ns.data, path.data, ns.len) == 0) {
             return 1;
         }
     }
@@ -707,7 +721,7 @@ static int is_namespace(str_t path) {
 
 // marfs_pre_processing_dir checks if we're about to process a marfs specific directory (MDAL_reference, MDAL_subspaces)
 // or a namespace that is no longer active in the marfs config
-static plugin_process_action marfs_pre_processing_dir(void* ptr) {
+static plugin_dir_action marfs_dir_action(void* ptr) {
     PCS_t* pcs = (PCS_t*)ptr;
 
     if (!pcs || !pcs->work || !pcs->work->name) {
@@ -767,7 +781,9 @@ struct marfs_ctx {
     sqlite3_stmt* delete_entry;
     sqlite3_stmt* decrement_nlink;
     sqlite3_stmt* update_xattr_names;
+    sqlite3_stmt* remove_xattrs;
     sqlite3_stmt* update_summary_name;
+    sqlite3_stmt* update_summary_pinode;
 };
 
 static void marfs_ctx_exit(void* ptr, void* plugin_user_data) {
@@ -790,8 +806,16 @@ static void marfs_ctx_exit(void* ptr, void* plugin_user_data) {
         sqlite3_finalize(ctx->update_xattr_names);
     }
 
+    if (ctx->remove_xattrs) {
+        sqlite3_finalize(ctx->remove_xattrs);
+    }
+
     if (ctx->update_summary_name) {
         sqlite3_finalize(ctx->update_summary_name);
+    }
+
+    if (ctx->update_summary_pinode) {
+        sqlite3_finalize(ctx->update_summary_pinode);
     }
 
     free(ctx);
@@ -846,12 +870,33 @@ static void* marfs_ctx_init(void* ptr) {
     }
 
     rc = sqlite3_prepare_v2(db,
+                            "DELETE FROM xattrs_pwd "
+                            "WHERE inode = ?2 AND name = ?1;",
+                            -1, &ctx->remove_xattrs, NULL);
+    if (rc != SQLITE_OK) {
+        fprintf(stderr, "Error: remove xattrs failed: %s\n", sqlite3_errmsg(db));
+        marfs_ctx_exit(ptr, ctx);
+        return NULL;
+    }
+
+    rc = sqlite3_prepare_v2(db,
                             "UPDATE summary "
                             "SET name = ?2 "
                             "WHERE name = ?1;",
                             -1, &ctx->update_summary_name, NULL);
     if (rc != SQLITE_OK) {
         fprintf(stderr, "Error: prepare summary update failed: %s\n", sqlite3_errmsg(db));
+        marfs_ctx_exit(ptr, ctx);
+        return NULL;
+    }
+
+    rc = sqlite3_prepare_v2(db,
+                            "UPDATE summary "
+                            "SET pinode = ?1 "
+                            "WHERE name = ?2;",
+                            -1, &ctx->update_summary_pinode, NULL);
+    if (rc != SQLITE_OK) {
+        fprintf(stderr, "Error: prepare summary pinode update failed: %s\n", sqlite3_errmsg(db));
         marfs_ctx_exit(ptr, ctx);
         return NULL;
     }
@@ -890,7 +935,6 @@ static sqlite3_int64 build_xattr_names_filtered(struct entry_data* ed, char* out
 // any marfs specific xattrs
 static void marfs_process_file(void* ptr, void* user_data) {
     PCS_t* pcs = (PCS_t*)ptr;
-    sqlite3* db = pcs->db;
     struct entry_data* ed = pcs->ed;
     struct marfs_ctx* ctx = (struct marfs_ctx*)user_data;
 
@@ -968,7 +1012,7 @@ static void marfs_process_file(void* ptr, void* user_data) {
         sqlite3_clear_bindings(stmt);
     }
 
-    // remove marfs xattr
+    // remove marfs xattr name from entries
     {
         sqlite3_stmt* stmt = ctx->update_xattr_names;
 
@@ -1002,10 +1046,42 @@ static void marfs_process_file(void* ptr, void* user_data) {
         sqlite3_reset(stmt);
         sqlite3_clear_bindings(stmt);
     }
+
+    // remove marfs xattr from xattr_pwd
+    {
+        sqlite3_stmt* stmt = ctx->remove_xattrs;
+
+        sqlite3_reset(stmt);
+        sqlite3_clear_bindings(stmt);
+
+        rc = sqlite3_bind_blob(stmt, 1, MARFS_XATTR_NAME, (int)MARFS_XATTR_NAME_LEN, SQLITE_STATIC);
+        if (rc != SQLITE_OK) {
+            fprintf(stderr, "plugin: bind xattr remove name failed for %.*s: %s\n", (int)basename.len, basename.data,
+                    sqlite3_errmsg(ctx->db));
+            return;
+        }
+
+        rc = sqlite3_bind_int64(stmt, 2, (sqlite3_int64)pcs->work->statuso.st_ino);
+        if (rc != SQLITE_OK) {
+            fprintf(stderr, "plugin: bind xattr remove inode failed for %lu: %s\n", pcs->work->statuso.st_ino,
+                    sqlite3_errmsg(ctx->db));
+            return;
+        }
+
+        rc = sqlite3_step(stmt);
+        if (rc != SQLITE_DONE) {
+            fprintf(stderr, "plugin: remove xattrs_pwd failed for %.*s: %s\n", (int)basename.len, basename.data,
+                    sqlite3_errmsg(ctx->db));
+        }
+
+        sqlite3_reset(stmt);
+        sqlite3_clear_bindings(stmt);
+    }
 }
 
 // marfs_process_dir renames the root namespace in the gufi db summary table to match the mountpoint in the marfs
-// config. The actual dir gets renamed in cleanup_marfs_index
+// config. The actual dir gets renamed in cleanup_marfs_index. It also fixes pinode values for directories whose
+// parent is an MDAL_subspaces directory that will be removed from the final index.
 static void marfs_process_dir(void* ptr, void* user_data) {
     PCS_t* pcs = (PCS_t*)ptr;
     struct marfs_ctx* ctx = (struct marfs_ctx*)user_data;
@@ -1014,12 +1090,63 @@ static void marfs_process_dir(void* ptr, void* user_data) {
         return;
     }
 
+    const str_t path = (str_t)REFSTR(pcs->work->name, pcs->work->name_len);
+    const str_t basename = get_basename(path);
+    const str_t parent = get_parent(path);
+    const str_t parent_basename = get_basename(parent);
+
+    // Fix pinode for directories whose parent is MDAL_subspaces (which will be removed)
+    // The pinode currently points to the MDAL_subspaces inode, but should point to the grandparent
+    if (parent_basename.data && str_t_eq_cstr(parent_basename, MARFS_SUBSPACES_NAME, MARFS_SUBSPACES_NAME_LEN)) {
+        const str_t grandparent = get_parent(parent);
+
+        if (grandparent.data && grandparent.len > 0) {
+            size_t gp_path_size = grandparent.len + 1;
+            char* gp_path = malloc(gp_path_size);
+            if (gp_path) {
+                snprintf(gp_path, gp_path_size, "%.*s", (int)grandparent.len, grandparent.data);
+
+                struct stat st;
+                if (stat(gp_path, &st) == 0) {
+                    sqlite3_stmt* stmt = ctx->update_summary_pinode;
+                    int rc;
+
+                    sqlite3_reset(stmt);
+                    sqlite3_clear_bindings(stmt);
+
+                    rc = sqlite3_bind_int64(stmt, 1, (sqlite3_int64)st.st_ino);
+                    if (rc == SQLITE_OK) {
+                        rc = sqlite3_bind_text(stmt, 2, basename.data, (int)basename.len, SQLITE_STATIC);
+                    }
+
+                    if (rc == SQLITE_OK) {
+                        rc = sqlite3_step(stmt);
+                        if (rc != SQLITE_DONE) {
+                            fprintf(stderr, "plugin: update pinode failed for %.*s: %s\n", (int)basename.len,
+                                    basename.data, sqlite3_errmsg(ctx->db));
+                        }
+                    } else {
+                        fprintf(stderr, "plugin: bind pinode failed for %.*s: %s\n", (int)basename.len, basename.data,
+                                sqlite3_errmsg(ctx->db));
+                    }
+
+                    sqlite3_reset(stmt);
+                    sqlite3_clear_bindings(stmt);
+                } else {
+                    fprintf(stderr, "plugin: stat('%s') failed: %s\n", gp_path, strerror(errno));
+                }
+
+                free(gp_path);
+            } else {
+                fprintf(stderr, "malloc failed for gp_path\n");
+            }
+        }
+    }
+
     // determine if this is the root namespace dir
     if (ROOT_NAMESPACE_LEVEL == pcs->work->level &&
         str_t_eq_cstr(g_state.root_namespace, pcs->work->name, pcs->work->name_len)) {
-        // rename this to the marfs mountpoint in the database
-        const str_t path = (str_t)REFSTR(pcs->work->name, pcs->work->name_len);
-        const str_t basename = get_basename(path);
+        // Rename root namespace to mountpoint in database
         const str_t mountpoint = get_basename(g_state.marfs_mountpoint);
 
         sqlite3_stmt* stmt = ctx->update_summary_name;
@@ -1068,14 +1195,15 @@ static void marfs_indexing_global_exit(void* global) {
     if (cleanup_marfs_index() != 0) {
         fprintf(stderr, "Warning: cleanup_marfs_index failed\n");
     }
+
     marfs_plugin_cleanup();
 }
 
-struct plugin_operations GUFI_PLUGIN_SYMBOL = {
+struct plugin_operations GUFI_MARFS_PLUGIN = {
     .type = PLUGIN_INDEX,
     .global_init = marfs_indexing_global_init,
+    .dir_action = marfs_dir_action,
     .ctx_init = marfs_ctx_init,
-    .pre_process_dir = marfs_pre_processing_dir,
     .process_dir = marfs_process_dir,
     .process_file = marfs_process_file,
     .ctx_exit = marfs_ctx_exit,

--- a/include/plugin.h
+++ b/include/plugin.h
@@ -110,7 +110,7 @@ struct plugin_operations {
     int (*global_init)(void *global);
 
     /* Pre-process a directory */
-    plugin_process_action (*pre_process_dir)(void *ptr, void *user_data);
+    plugin_process_action (*pre_process_dir)(void *ptr);
 
     /*
      * Give the user an opportunity to initialize any state for the
@@ -187,12 +187,13 @@ size_t plugins_check_type(struct plugins *plugins, const plugin_type accepted);
  *         on error, stop, call plugins_global_exit() for previously
  *         successfully initialized plugins, and return error
  */
-size_t plugins_global_init (struct plugins *plugins, void *global);
-void   plugins_ctx_init    (struct plugins *plugins, void *ctx, const size_t tid);
-void   plugins_process_dir (struct plugins *plugins, void *ctx, const size_t tid);
-void   plugins_process_file(struct plugins *plugins, void *ctx, const size_t tid);
-void   plugins_ctx_exit    (struct plugins *plugins, void *ctx, const size_t tid);
-void   plugins_global_exit (struct plugins *plugins, void *global);
+size_t                plugins_global_init    (struct plugins* plugins, void* global);
+plugin_process_action plugins_pre_process_dir(struct plugins* plugins, void* ctx);
+void                  plugins_ctx_init       (struct plugins* plugins, void* ctx, const size_t tid);
+void                  plugins_process_dir    (struct plugins* plugins, void* ctx, const size_t tid);
+void                  plugins_process_file   (struct plugins* plugins, void* ctx, const size_t tid);
+void                  plugins_ctx_exit       (struct plugins* plugins, void* ctx, const size_t tid);
+void                  plugins_global_exit    (struct plugins* plugins, void* global);
 
 /* common plugin ptr struct (don't have to use; here to reduce duplicate struct definitions) */
 typedef struct PluginCommonStruct {

--- a/include/plugin.h
+++ b/include/plugin.h
@@ -82,6 +82,17 @@ typedef enum {
     PLUGIN_INCREMENTAL = 3,
 } plugin_type;
 
+typedef enum {
+    // No action specified / default value
+    PLUGIN_PROCESS_NONE = 0,
+    // Process this directory and allow normal traversal
+    PLUGIN_PROCESS_DIR = 1,
+    // Do not process this directory, but still allow traversal into subdirectories
+    PLUGIN_NO_PROCESS_DIR = 2,
+    // Do not process this directory and do not descend into its subdirectories
+    PLUGIN_NO_PROCESS_NO_DESCEND_DIR = 3,
+} plugin_process_action;
+
 /*
  * Operations for a user-defined plugin library, allowing the user to make custom
  * modifications to the databases as GUFI runs.
@@ -97,6 +108,9 @@ struct plugin_operations {
      * If the plugin does SQLite 3 operations, should call sqlite3_initialize()
      */
     int (*global_init)(void *global);
+
+    /* Pre-process a directory */
+    plugin_process_action (*pre_process_dir)(void *ptr, void *user_data);
 
     /*
      * Give the user an opportunity to initialize any state for the

--- a/include/plugin.h
+++ b/include/plugin.h
@@ -83,15 +83,13 @@ typedef enum {
 } plugin_type;
 
 typedef enum {
-    // No action specified / default value
-    PLUGIN_PROCESS_NONE = 0,
-    // Process this directory and allow normal traversal
-    PLUGIN_PROCESS_DIR = 1,
-    // Do not process this directory, but still allow traversal into subdirectories
-    PLUGIN_NO_PROCESS_DIR = 2,
     // Do not process this directory and do not descend into its subdirectories
-    PLUGIN_NO_PROCESS_NO_DESCEND_DIR = 3,
-} plugin_process_action;
+    PLUGIN_NO_PROCESS_NO_DESCEND_DIR = 0,
+    // Do not process this directory, but still allow traversal into subdirectories
+    PLUGIN_NO_PROCESS_DIR = 1,
+    // Process this directory and allow normal traversal
+    PLUGIN_PROCESS_DIR = 2,
+} plugin_dir_action;
 
 /*
  * Operations for a user-defined plugin library, allowing the user to make custom
@@ -109,8 +107,11 @@ struct plugin_operations {
      */
     int (*global_init)(void *global);
 
-    /* Pre-process a directory */
-    plugin_process_action (*pre_process_dir)(void *ptr);
+    /* 
+     * Returns whether a directory should be processed and/or 
+     * descended into
+     */
+    plugin_dir_action (*dir_action)(void *ptr);
 
     /*
      * Give the user an opportunity to initialize any state for the
@@ -187,13 +188,13 @@ size_t plugins_check_type(struct plugins *plugins, const plugin_type accepted);
  *         on error, stop, call plugins_global_exit() for previously
  *         successfully initialized plugins, and return error
  */
-size_t                plugins_global_init    (struct plugins* plugins, void* global);
-plugin_process_action plugins_pre_process_dir(struct plugins* plugins, void* ctx);
-void                  plugins_ctx_init       (struct plugins* plugins, void* ctx, const size_t tid);
-void                  plugins_process_dir    (struct plugins* plugins, void* ctx, const size_t tid);
-void                  plugins_process_file   (struct plugins* plugins, void* ctx, const size_t tid);
-void                  plugins_ctx_exit       (struct plugins* plugins, void* ctx, const size_t tid);
-void                  plugins_global_exit    (struct plugins* plugins, void* global);
+size_t            plugins_global_init (struct plugins* plugins, void* global);
+plugin_dir_action plugins_dir_action  (struct plugins* plugins, void* ctx);
+void              plugins_ctx_init    (struct plugins* plugins, void* ctx, const size_t tid);
+void              plugins_process_dir (struct plugins* plugins, void* ctx, const size_t tid);
+void              plugins_process_file(struct plugins* plugins, void* ctx, const size_t tid);
+void              plugins_ctx_exit    (struct plugins* plugins, void* ctx, const size_t tid);
+void              plugins_global_exit (struct plugins* plugins, void* global);
 
 /* common plugin ptr struct (don't have to use; here to reduce duplicate struct definitions) */
 typedef struct PluginCommonStruct {

--- a/src/gufi_dir2index.c
+++ b/src/gufi_dir2index.c
@@ -202,6 +202,15 @@ static int processdir(QPTPool_ctx_t *ctx, void *data) {
 
     decompress_work(&nda.work, data);
 
+    pcs.work = nda.work;
+
+    // if we're in the min-max range use the result of the plugins "dir_action" to determine process_dir
+    plugin_dir_action process_dir = PLUGIN_NO_PROCESS_DIR;
+
+    if (pa->in.min_level <= nda.work->level && nda.work->level <= pa->in.max_level) {
+        process_dir = plugins_dir_action(&pa->in.plugins, &pcs);
+    }
+
     dir = opendir_wrapper(nda.work->name, 1);
     if (!dir) {
         rc = 1;
@@ -212,15 +221,6 @@ static int processdir(QPTPool_ctx_t *ctx, void *data) {
                       &nda.work->stat_called, 1, 1) != 0) {
         rc = 1;
         goto close_dir;
-    }
-
-    pcs.work = nda.work;
-
-    // if we're in the min-max range use the result of the plugins "pre_process_dir" to determine process_dir
-    plugin_process_action process_dir = PLUGIN_NO_PROCESS_DIR;
-
-    if (pa->in.min_level <= nda.work->level && nda.work->level <= pa->in.max_level) {
-        process_dir = plugins_pre_process_dir(&pa->in.plugins, &pcs);
     }
 
     /* offset by work->root_len to remove prefix */

--- a/src/gufi_dir2index.c
+++ b/src/gufi_dir2index.c
@@ -220,11 +220,7 @@ static int processdir(QPTPool_ctx_t *ctx, void *data) {
     plugin_process_action process_dir = PLUGIN_NO_PROCESS_DIR;
 
     if (pa->in.min_level <= nda.work->level && nda.work->level <= pa->in.max_level) {
-        if (pa->in.plugin_ops->pre_process_dir) {
-            process_dir = pa->in.plugin_ops->pre_process_dir(&pcs, &nda.plugin_user_data);
-        } else {
-            process_dir = PLUGIN_PROCESS_DIR;
-        }
+        process_dir = plugins_pre_process_dir(&pa->in.plugins, &pcs);
     }
 
     /* offset by work->root_len to remove prefix */

--- a/src/gufi_dir2index.c
+++ b/src/gufi_dir2index.c
@@ -202,9 +202,6 @@ static int processdir(QPTPool_ctx_t *ctx, void *data) {
 
     decompress_work(&nda.work, data);
 
-    const int process_dir = ((pa->in.min_level <= nda.work->level) &&
-                             (nda.work->level <= pa->in.max_level));
-
     dir = opendir_wrapper(nda.work->name, 1);
     if (!dir) {
         rc = 1;
@@ -215,6 +212,19 @@ static int processdir(QPTPool_ctx_t *ctx, void *data) {
                       &nda.work->stat_called, 1, 1) != 0) {
         rc = 1;
         goto close_dir;
+    }
+
+    pcs.work = nda.work;
+
+    // if we're in the min-max range use the result of the plugins "pre_process_dir" to determine process_dir
+    plugin_process_action process_dir = PLUGIN_NO_PROCESS_DIR;
+
+    if (pa->in.min_level <= nda.work->level && nda.work->level <= pa->in.max_level) {
+        if (pa->in.plugin_ops->pre_process_dir) {
+            process_dir = pa->in.plugin_ops->pre_process_dir(&pcs, &nda.plugin_user_data);
+        } else {
+            process_dir = PLUGIN_PROCESS_DIR;
+        }
     }
 
     /* offset by work->root_len to remove prefix */
@@ -235,7 +245,7 @@ static int processdir(QPTPool_ctx_t *ctx, void *data) {
                "\0" DBNAME, (size_t) 1 + DBNAME_LEN);
 
     /* don't need recursion because parent is guaranteed to exist */
-    if (mkdir(nda.topath.data, S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH) < 0) {
+    if (process_dir != PLUGIN_NO_PROCESS_NO_DESCEND_DIR && mkdir(nda.topath.data, S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH) < 0) {
         const int err = errno;
         if (err != EEXIST) {
             fprintf(stderr, "mkdir %s failure: %d %s\n", nda.topath.data, err, strerror(err));
@@ -248,7 +258,7 @@ static int processdir(QPTPool_ctx_t *ctx, void *data) {
      * set up for processing, but keep to minimum to quickly hit
      * descend (and enqueue more work, keeping queues fed)
      */
-    if (process_dir) {
+    if (process_dir == PLUGIN_PROCESS_DIR) {
         /* restore "/db.db" */
         nda.topath.data[nda.topath.len] = '/';
 
@@ -293,14 +303,17 @@ static int processdir(QPTPool_ctx_t *ctx, void *data) {
    }
 
     struct descend_counters ctrs;
-    descend(ctx, nda.in, nda.work, dir, 1,
-            processdir, process_dir?process_nondir:NULL, &nda, &ctrs);
+
+    if (process_dir != PLUGIN_NO_PROCESS_NO_DESCEND_DIR){
+        descend(ctx, nda.in, nda.work, dir, 1,
+            processdir, process_dir == PLUGIN_PROCESS_DIR?process_nondir:NULL, &nda, &ctrs);
+    }
 
     /*
      * now that subdirectories have been enqueued,
      * do slower processing on this directory
      */
-    if (process_dir) {
+    if (process_dir == PLUGIN_PROCESS_DIR) {
         stopdb(nda.db);
 
         /* entries and xattrs have been inserted */
@@ -348,7 +361,7 @@ static int processdir(QPTPool_ctx_t *ctx, void *data) {
     closedir(dir);
 
   cleanup:
-    if (process_dir) {
+    if (process_dir == PLUGIN_PROCESS_DIR) {
         const size_t id = QPTPool_get_id(ctx);
         pa->total_dirs[id]++;
         pa->total_nondirs[id] += ctrs.nondirs_processed;

--- a/src/plugin.c
+++ b/src/plugin.c
@@ -228,16 +228,16 @@ size_t plugins_global_init(struct plugins *plugins, void *global) {
     return plugins->initialized;
 }
 
-plugin_process_action plugins_pre_process_dir(struct plugins* plugins, void* ctx) {
-    plugin_process_action ret = PLUGIN_PROCESS_DIR;
+plugin_dir_action plugins_dir_action(struct plugins* plugins, void* ctx) {
+    plugin_dir_action ret = PLUGIN_PROCESS_DIR;
 
     for (size_t i = 0; i < plugins->count; i++) {
-        if (plugins->plugins[i]->ops->pre_process_dir) {
-            plugin_process_action ppa = plugins->plugins[i]->ops->pre_process_dir(ctx);
+        if (plugins->plugins[i]->ops->dir_action) {
+            plugin_dir_action pda = plugins->plugins[i]->ops->dir_action(ctx);
 
             // choose the most restrictive action returned by any plugin
-            if (ppa > ret) {
-                ret = ppa;
+            if (pda < ret) {
+                ret = pda;
             }
         }
     }

--- a/src/plugin.c
+++ b/src/plugin.c
@@ -228,6 +228,23 @@ size_t plugins_global_init(struct plugins *plugins, void *global) {
     return plugins->initialized;
 }
 
+plugin_process_action plugins_pre_process_dir(struct plugins* plugins, void* ctx) {
+    plugin_process_action ret = PLUGIN_PROCESS_DIR;
+
+    for (size_t i = 0; i < plugins->count; i++) {
+        if (plugins->plugins[i]->ops->pre_process_dir) {
+            plugin_process_action ppa = plugins->plugins[i]->ops->pre_process_dir(ctx);
+
+            // choose the most restrictive action returned by any plugin
+            if (ppa > ret) {
+                ret = ppa;
+            }
+        }
+    }
+
+    return ret;
+}
+
 void plugins_ctx_init(struct plugins *plugins, void *ctx, const size_t tid) {
     /* Not checking arguments */
 

--- a/test/regression/CMakeLists.txt
+++ b/test/regression/CMakeLists.txt
@@ -177,6 +177,7 @@ set(OTHERS
   gufi_jail
   gufi_plugin
   longitudinal_snapshot
+  marfs_plugin
   parallel_cpr
   parallel_find
   parallel_rmr
@@ -252,6 +253,9 @@ endif()
 foreach(NAME ${EXAMPLES})
   set_property(TEST "${NAME}" APPEND PROPERTY LABELS "examples")
 endforeach()
+
+set_property(TEST "dsi_plugins" APPEND PROPERTY LABELS "gufi_vt;binary;plugin")
+set_property(TEST "marfs_plugin" APPEND PROPERTY LABELS "binary;plugin")
 
 foreach(NAME ${PYTHON})
   set_property(TEST "${NAME}" APPEND PROPERTY LABELS "python")

--- a/test/regression/CMakeLists.txt
+++ b/test/regression/CMakeLists.txt
@@ -177,7 +177,6 @@ set(OTHERS
   gufi_jail
   gufi_plugin
   longitudinal_snapshot
-  marfs_plugin
   parallel_cpr
   parallel_find
   parallel_rmr
@@ -209,6 +208,19 @@ configure_file(gufi_tool.py.in gufi_tool.py @ONLY)
 
 # gufi_vt.common is always required by gufi_vt test
 configure_file(gufi_vt.common gufi_vt.common @ONLY)
+
+if (TARGET marfs_plugin)
+  # marfs_plugin test config
+  configure_file(
+    marfs_plugin_config.xml.in
+    marfs_plugin_config.xml
+    @ONLY
+  )
+
+  list(APPEND OTHERS
+    marfs_plugin
+  )
+endif()
 
 # .sh and .expected
 function(sh_and_expected)
@@ -254,9 +266,6 @@ foreach(NAME ${EXAMPLES})
   set_property(TEST "${NAME}" APPEND PROPERTY LABELS "examples")
 endforeach()
 
-set_property(TEST "dsi_plugins" APPEND PROPERTY LABELS "gufi_vt;binary;plugin")
-set_property(TEST "marfs_plugin" APPEND PROPERTY LABELS "binary;plugin")
-
 foreach(NAME ${PYTHON})
   set_property(TEST "${NAME}" APPEND PROPERTY LABELS "python")
 endforeach()
@@ -265,6 +274,9 @@ set_property(TEST "gufi_query_multiple_remotes" APPEND PROPERTY LABELS "gufi_vt"
 # OTHERS
 set_property(TEST "dsi_plugins" APPEND PROPERTY LABELS "gufi_vt;binary;plugin")
 set_property(TEST "gufi_plugin" APPEND PROPERTY LABELS "plugin")
+if (TARGET marfs_plugin)
+  set_property(TEST "marfs_plugin" APPEND PROPERTY LABELS "binary;plugin")
+endif()
 
 find_program(SUDO sudo)
 if (SUDO)

--- a/test/regression/marfs_plugin.expected
+++ b/test/regression/marfs_plugin.expected
@@ -1,0 +1,171 @@
+# create mock MarFS namespace structure
+$ find "prefix/var/marfs/mdal-root/sec-root" -type f -o -type d | sort
+prefix/var/marfs/mdal-root/sec-root
+prefix/var/marfs/mdal-root/sec-root/MDAL_reference
+prefix/var/marfs/mdal-root/sec-root/MDAL_subspaces
+prefix/var/marfs/mdal-root/sec-root/MDAL_subspaces/namespace1
+prefix/var/marfs/mdal-root/sec-root/MDAL_subspaces/namespace1/MDAL_reference
+prefix/var/marfs/mdal-root/sec-root/MDAL_subspaces/namespace1/MDAL_subspaces
+prefix/var/marfs/mdal-root/sec-root/MDAL_subspaces/namespace1/MDAL_subspaces/namespace2
+prefix/var/marfs/mdal-root/sec-root/MDAL_subspaces/namespace1/MDAL_subspaces/namespace2/MDAL_reference
+prefix/var/marfs/mdal-root/sec-root/MDAL_subspaces/namespace1/MDAL_subspaces/namespace2/nestedfile1.txt
+prefix/var/marfs/mdal-root/sec-root/MDAL_subspaces/namespace1/MDAL_subspaces/namespace2/nestedfile2.txt
+prefix/var/marfs/mdal-root/sec-root/MDAL_subspaces/namespace1/userdir
+prefix/var/marfs/mdal-root/sec-root/MDAL_subspaces/namespace1/userdir/userfile3.txt
+prefix/var/marfs/mdal-root/sec-root/MDAL_subspaces/namespace1/userfile1.txt
+prefix/var/marfs/mdal-root/sec-root/MDAL_subspaces/namespace1/userfile2.txt
+
+
+# create MarFS config XML
+Created MarFS config at marfs_test_config.xml
+
+# test: index MarFS structure with plugin
+# This should:
+#   - Filter out MDAL_reference files
+#   - Filter out MDAL_MARFS-FILE xattrs
+#   - Preserve MDAL_subspaces structure during indexing
+#   - Rename root namespace to mountpoint in final index
+$ gufi_dir2index -x --plugin "GUFI_MARFS_PLUGIN:marfs_indexing_plugin" "prefix/var/marfs/mdal-root/sec-root" "search"
+Creating GUFI tree search with 1 threads
+Total Dirs:          4
+Total Non-Dirs:      8
+
+
+# verify index structure
+# Root should be renamed from 'sec-root' to 'marfs' (mountpoint basename)
+# MDAL_subspaces directories should be removed from final structure
+$ find "search" -type d | sort
+search
+search/marfs
+search/marfs/namespace1
+search/marfs/namespace1/namespace2
+search/marfs/namespace1/userdir
+
+
+# query indexed files
+# MarFS internal files (MDAL_reference) should not appear in results
+$ gufi_query -d "|" -S "SELECT rpath(sname, sroll) || '/' || name FROM vrsummary;" -E "SELECT rpath(sname, sroll, name) FROM vrpentries;" "search"
+search/marfs/marfs
+search/marfs/namespace1/namespace1
+search/marfs/namespace1/namespace2/namespace2
+search/marfs/namespace1/namespace2/nestedfile1.txt
+search/marfs/namespace1/namespace2/nestedfile2.txt
+search/marfs/namespace1/userdir/userdir
+search/marfs/namespace1/userdir/userfile3.txt
+search/marfs/namespace1/userfile1.txt
+search/marfs/namespace1/userfile2.txt
+
+
+# query file counts per directory
+$ gufi_query -d "|" -S "SELECT rpath(sname, sroll) || '/' || name, totfiles FROM vrsummary WHERE totfiles > 0 ORDER BY name;" "search"
+search/marfs/marfs|1
+search/marfs/namespace1/namespace1|3
+search/marfs/namespace1/namespace2/namespace2|3
+search/marfs/namespace1/userdir/userdir|1
+
+
+# verify xattrs
+# MarFS xattrs (user.MDAL_MARFS-FILE) should be filtered out
+# User xattrs (user.myattr) should be preserved
+$ gufi_query -d "|" -x -E "SELECT rpath(sname, sroll, name), xattr_name FROM vrxpentries WHERE xattr_name != '' ORDER BY name;" "search" 2>/dev/null
+search/marfs/namespace1/userfile1.txt|user.myattr
+
+
+# verify nlink decrement
+# All file nlink counts should be decremented by 1 (MarFS metadata link removed)
+$ gufi_query -d "|" -E "SELECT rpath(sname, sroll, name), nlink FROM vrpentries WHERE type == 'f' ORDER BY name;" "search"
+search/marfs/namespace1/namespace2/nestedfile1.txt|0
+search/marfs/namespace1/namespace2/nestedfile2.txt|0
+search/marfs/namespace1/userdir/userfile3.txt|0
+search/marfs/namespace1/userfile1.txt|0
+search/marfs/namespace1/userfile2.txt|0
+
+
+# test: verify root namespace rename in summary table
+$ gufi_query -d "|" -S "SELECT name FROM summary WHERE name == 'marfs';" "search"
+marfs
+
+
+# test: re-index over existing index
+# Plugin should handle existing index structure correctly
+$ gufi_dir2index -x --plugin "GUFI_MARFS_PLUGIN:marfs_indexing_plugin" "prefix/var/marfs/mdal-root/sec-root" "search"
+"search" Already exists!
+Creating GUFI tree search with 1 threads
+Total Dirs:          4
+Total Non-Dirs:      8
+
+
+# verify structure after re-indexing
+$ find "search" -type d | sort
+search
+search/marfs
+search/marfs/namespace1
+search/marfs/namespace1/namespace2
+search/marfs/namespace1/userdir
+
+
+# test: error handling - missing config
+# Should fail with appropriate error message
+$ gufi_dir2index -x --plugin "GUFI_MARFS_PLUGIN:marfs_indexing_plugin" "prefix/var/marfs/mdal-root/sec-root" "search_fail" 2>&1 | head -n 1
+Error: MARFS_CONFIG_PATH is not set
+
+
+# test: error handling - invalid path
+# Should fail when path is not a MarFS sec-root
+$ gufi_dir2index -x --plugin "GUFI_MARFS_PLUGIN:marfs_indexing_plugin" "/tmp" "search_fail2" 2>&1 | grep -i 'error' | head -n 1
+Error: provided dir (/tmp) is not the root of the parent marfs namespace or marfs_config is incorrect
+
+
+# test: verify inode/pinode relationships
+# Check that all child directories have pinode matching parent's inode
+# This ensures the plugin correctly maintains parent-child relationships
+$ gufi_query \
+        -n 1 \
+        -d '|' \
+        -I "CREATE TABLE intermediate(
+               dir        TEXT,
+               parent_dir TEXT,
+               inode      TEXT,
+               pinode     TEXT
+            );" \
+        -S "INSERT INTO intermediate
+            SELECT
+                path() AS dir,
+                CASE
+                    WHEN level() = 0 THEN NULL
+                    WHEN level() = 1 THEN ''
+                    ELSE substr(path(), 1, length(path()) - length(epath()) - 1)
+                END AS parent_dir,
+                inode,
+                pinode
+            FROM vrsummary;" \
+        -K "CREATE TABLE aggregate(
+               dir            TEXT,
+               parent_dir     TEXT,
+               inode          TEXT,
+               pinode         TEXT,
+               expected_inode TEXT
+            );" \
+        -J "INSERT INTO aggregate
+            SELECT
+                child.dir,
+                child.parent_dir,
+                child.inode,
+                child.pinode,
+                parent.inode AS expected_inode
+            FROM intermediate AS child
+            LEFT JOIN intermediate AS parent
+              ON child.parent_dir = parent.dir;" \
+        -G "SELECT
+                dir,
+                parent_dir,
+                inode,
+                pinode,
+                expected_inode
+            FROM aggregate
+            WHERE parent_dir != ''
+              AND (expected_inode IS NULL OR pinode != expected_inode)
+            ORDER BY dir;" \
+        "search"
+
+# If above query returns no results, all inode/pinode relationships are correct

--- a/test/regression/marfs_plugin.expected
+++ b/test/regression/marfs_plugin.expected
@@ -1,5 +1,5 @@
 # create mock MarFS namespace structure
-$ find "prefix/var/marfs/mdal-root/sec-root" -type f -o -type d | sort
+$ find "prefix/var/marfs/mdal-root/sec-root" -type f -o -type d
 prefix/var/marfs/mdal-root/sec-root
 prefix/var/marfs/mdal-root/sec-root/MDAL_reference
 prefix/var/marfs/mdal-root/sec-root/MDAL_subspaces
@@ -34,7 +34,7 @@ Total Non-Dirs:      8
 # verify index structure
 # Root should be renamed from 'sec-root' to 'marfs' (mountpoint basename)
 # MDAL_subspaces directories should be removed from final structure
-$ find "search" -type d | sort
+$ find "search" -type d
 search
 search/marfs
 search/marfs/namespace1
@@ -44,24 +44,24 @@ search/marfs/namespace1/userdir
 
 # query indexed files
 # MarFS internal files (MDAL_reference) should not appear in results
-$ gufi_query -d "|" -S "SELECT rpath(sname, sroll) || '/' || name FROM vrsummary;" -E "SELECT rpath(sname, sroll, name) FROM vrpentries;" "search"
-search/marfs/marfs
-search/marfs/namespace1/namespace1
-search/marfs/namespace1/namespace2/namespace2
+$ gufi_query -d "|" -S "SELECT rpath(sname, sroll) FROM vrsummary;" -E "SELECT rpath(sname, sroll, name) FROM vrpentries;" "search"
+search/marfs
+search/marfs/namespace1
+search/marfs/namespace1/namespace2
 search/marfs/namespace1/namespace2/nestedfile1.txt
 search/marfs/namespace1/namespace2/nestedfile2.txt
-search/marfs/namespace1/userdir/userdir
+search/marfs/namespace1/userdir
 search/marfs/namespace1/userdir/userfile3.txt
 search/marfs/namespace1/userfile1.txt
 search/marfs/namespace1/userfile2.txt
 
 
 # query file counts per directory
-$ gufi_query -d "|" -S "SELECT rpath(sname, sroll) || '/' || name, totfiles FROM vrsummary WHERE totfiles > 0 ORDER BY name;" "search"
-search/marfs/marfs|1
-search/marfs/namespace1/namespace1|3
-search/marfs/namespace1/namespace2/namespace2|3
-search/marfs/namespace1/userdir/userdir|1
+$ gufi_query -d "|" -S "SELECT rpath(sname, sroll) AS name, totfiles FROM vrsummary WHERE totfiles > 0 ORDER BY name;" "search"
+search/marfs/namespace1/namespace2|3
+search/marfs/namespace1/userdir|1
+search/marfs/namespace1|3
+search/marfs|1
 
 
 # verify xattrs
@@ -73,16 +73,20 @@ search/marfs/namespace1/userfile1.txt|user.myattr
 
 # verify nlink decrement
 # All file nlink counts should be decremented by 1 (MarFS metadata link removed)
-$ gufi_query -d "|" -E "SELECT rpath(sname, sroll, name), nlink FROM vrpentries WHERE type == 'f' ORDER BY name;" "search"
+$ gufi_query -d "|" -S "SELECT rpath(sname, sroll), nlink FROM vrsummary;" -E "SELECT rpath(sname, sroll, name), nlink FROM vrpentries WHERE type == 'f' ORDER BY name;" "search"
 search/marfs/namespace1/namespace2/nestedfile1.txt|0
 search/marfs/namespace1/namespace2/nestedfile2.txt|0
+search/marfs/namespace1/namespace2|2
 search/marfs/namespace1/userdir/userfile3.txt|0
+search/marfs/namespace1/userdir|2
 search/marfs/namespace1/userfile1.txt|0
 search/marfs/namespace1/userfile2.txt|0
+search/marfs/namespace1|4
+search/marfs|3
 
 
 # test: verify root namespace rename in summary table
-$ gufi_query -d "|" -S "SELECT name FROM summary WHERE name == 'marfs';" "search"
+$ sqlite3 "search/marfs/db.db" "SELECT name FROM summary;"
 marfs
 
 
@@ -96,7 +100,7 @@ Total Non-Dirs:      8
 
 
 # verify structure after re-indexing
-$ find "search" -type d | sort
+$ find "search" -type d
 search
 search/marfs
 search/marfs/namespace1

--- a/test/regression/marfs_plugin.sh.in
+++ b/test/regression/marfs_plugin.sh.in
@@ -1,0 +1,263 @@
+#!/usr/bin/env bash
+# This file is part of GUFI, which is part of MarFS, which is released
+# under the BSD license.
+#
+#
+# Copyright (c) 2017, Los Alamos National Security (LANS), LLC
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without modification,
+# are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+# list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation and/or
+# other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its contributors
+# may be used to endorse or promote products derived from this software without
+# specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+# IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+# INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+# LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+# OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+# ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+#
+# From Los Alamos National Security, LLC:
+# LA-CC-15-039
+#
+# Copyright (c) 2017, Los Alamos National Security, LLC All rights reserved.
+# Copyright 2017. Los Alamos National Security, LLC. This software was produced
+# under U.S. Government contract DE-AC52-06NA25396 for Los Alamos National
+# Laboratory (LANL), which is operated by Los Alamos National Security, LLC for
+# the U.S. Department of Energy. The U.S. Government has rights to use,
+# reproduce, and distribute this software.  NEITHER THE GOVERNMENT NOR LOS
+# ALAMOS NATIONAL SECURITY, LLC MAKES ANY WARRANTY, EXPRESS OR IMPLIED, OR
+# ASSUMES ANY LIABILITY FOR THE USE OF THIS SOFTWARE.  If software is
+# modified to produce derivative works, such modified software should be
+# clearly marked, so as not to confuse it with the version available from
+# LANL.
+#
+# THIS SOFTWARE IS PROVIDED BY LOS ALAMOS NATIONAL SECURITY, LLC AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL LOS ALAMOS NATIONAL SECURITY, LLC OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+# OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+# IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+# OF SUCH DAMAGE.
+
+
+
+set -e
+. @CMAKE_CURRENT_BINARY_DIR@/setup.sh 0
+
+OUTPUT="marfs_plugin.out"
+
+# Check if MarFS plugin is available
+if [[ ! -f "${MARFS_INDEXING_PLUGIN}" ]]; then
+    echo "MarFS plugin not found at ${MARFS_INDEXING_PLUGIN}, skipping test"
+    exit 0
+fi
+
+MARFS_CONFIG="marfs_test_config.xml"
+MARFS_MOUNTPOINT="/marfs"
+
+MARFS_BASE="${SRCDIR}/var/marfs"
+MARFS_DAL_ROOT="${MARFS_BASE}/dal-root"
+MARFS_MDAL_ROOT="${MARFS_BASE}/mdal-root"
+MARFS_SEC_ROOT="${MARFS_MDAL_ROOT}/sec-root"
+
+cleanup() {
+    rm -rf "${MARFS_BASE}" "${SEARCH}" "${MARFS_CONFIG}"
+}
+
+cleanup_exit() {
+    cleanup
+    setup_cleanup
+}
+
+trap cleanup_exit EXIT
+
+cleanup
+
+(
+    echo "# create mock MarFS namespace structure"
+    
+    # Create dal-root (data abstraction layer - empty but must exist)
+    mkdir -p "${MARFS_DAL_ROOT}"
+    
+    # Create mdal-root and sec-root (metadata abstraction layer)
+    mkdir -p "${MARFS_SEC_ROOT}"
+    mkdir -p "${MARFS_SEC_ROOT}/MDAL_subspaces"
+    mkdir -p "${MARFS_SEC_ROOT}/MDAL_subspaces/namespace1"
+    mkdir -p "${MARFS_SEC_ROOT}/MDAL_subspaces/namespace1/MDAL_subspaces"
+    mkdir -p "${MARFS_SEC_ROOT}/MDAL_subspaces/namespace1/MDAL_subspaces/namespace2"
+    
+    # Create user files in namespaces
+    echo "user file 1" > "${MARFS_SEC_ROOT}/MDAL_subspaces/namespace1/userfile1.txt"
+    echo "user file 2" > "${MARFS_SEC_ROOT}/MDAL_subspaces/namespace1/userfile2.txt"
+    mkdir -p "${MARFS_SEC_ROOT}/MDAL_subspaces/namespace1/userdir"
+    echo "user file 3" > "${MARFS_SEC_ROOT}/MDAL_subspaces/namespace1/userdir/userfile3.txt"
+    
+    echo "nested file 1" > "${MARFS_SEC_ROOT}/MDAL_subspaces/namespace1/MDAL_subspaces/namespace2/nestedfile1.txt"
+    echo "nested file 2" > "${MARFS_SEC_ROOT}/MDAL_subspaces/namespace1/MDAL_subspaces/namespace2/nestedfile2.txt"
+    
+    # Create MarFS internal files (these should be filtered out)
+    echo "reference" > "${MARFS_SEC_ROOT}/MDAL_reference"
+    echo "reference ns1" > "${MARFS_SEC_ROOT}/MDAL_subspaces/namespace1/MDAL_reference"
+    echo "reference ns2" > "${MARFS_SEC_ROOT}/MDAL_subspaces/namespace1/MDAL_subspaces/namespace2/MDAL_reference"
+    
+    # Add MarFS xattrs to files (these should be filtered out)
+    if command -v setfattr &> /dev/null; then
+        setfattr -n user.MDAL_MARFS-FILE -v "marfs_metadata" "${MARFS_SEC_ROOT}/MDAL_subspaces/namespace1/userfile1.txt" 2>/dev/null || true
+        setfattr -n user.MDAL_MARFS-FILE -v "marfs_metadata" "${MARFS_SEC_ROOT}/MDAL_subspaces/namespace1/MDAL_subspaces/namespace2/nestedfile1.txt" 2>/dev/null || true
+    fi
+    
+    # Add user xattrs (these should be preserved)
+    if command -v setfattr &> /dev/null; then
+        setfattr -n user.myattr -v "myvalue" "${MARFS_SEC_ROOT}/MDAL_subspaces/namespace1/userfile1.txt" 2>/dev/null || true
+    fi
+    
+    run_no_sort "find \"${MARFS_SEC_ROOT}\" -type f -o -type d | sort"
+    
+    echo
+    echo "# create MarFS config XML"
+    cp "@CMAKE_CURRENT_SOURCE_DIR@/marfs_plugin_config.xml.in" "${MARFS_CONFIG}"
+        
+    # Replace placeholders with actual paths
+    @SED@ -i "s|DAL_ROOT_PLACEHOLDER|${MARFS_DAL_ROOT}|g" "${MARFS_CONFIG}"
+    @SED@ -i "s|NS_ROOT_PLACEHOLDER|${MARFS_SEC_ROOT}|g" "${MARFS_CONFIG}"
+    
+    echo "Created MarFS config at ${MARFS_CONFIG}"
+    
+    echo
+    echo "# test: index MarFS structure with plugin"
+    echo "# This should:"
+    echo "#   - Filter out MDAL_reference files"
+    echo "#   - Filter out MDAL_MARFS-FILE xattrs"
+    echo "#   - Preserve MDAL_subspaces structure during indexing"
+    echo "#   - Rename root namespace to mountpoint in final index"
+    MARFS_CONFIG_PATH="${MARFS_CONFIG}" run_no_sort "${GUFI_DIR2INDEX} -x --plugin \"GUFI_MARFS_PLUGIN:${MARFS_INDEXING_PLUGIN}\" \"${MARFS_SEC_ROOT}\" \"${SEARCH}\"" 2>&1 | remove_indexing_time
+    
+    echo
+    echo "# verify index structure"
+    echo "# Root should be renamed from 'sec-root' to 'marfs' (mountpoint basename)"
+    echo "# MDAL_subspaces directories should be removed from final structure"
+    run_no_sort "find \"${SEARCH}\" -type d | sort"
+    
+    echo
+    echo "# query indexed files"
+    echo "# MarFS internal files (MDAL_reference) should not appear in results"
+    run_sort "${GUFI_QUERY} -d \"${DELIM}\" -S \"SELECT rpath(sname, sroll) || '/' || name FROM vrsummary;\" -E \"SELECT rpath(sname, sroll, name) FROM vrpentries;\" \"${SEARCH}\""
+    
+    echo
+    echo "# query file counts per directory"
+    run_sort "${GUFI_QUERY} -d \"${DELIM}\" -S \"SELECT rpath(sname, sroll) || '/' || name, totfiles FROM vrsummary WHERE totfiles > 0 ORDER BY name;\" \"${SEARCH}\""
+    
+    echo
+    echo "# verify xattrs"
+    echo "# MarFS xattrs (user.MDAL_MARFS-FILE) should be filtered out"
+    echo "# User xattrs (user.myattr) should be preserved"
+    run_sort "${GUFI_QUERY} -d \"${DELIM}\" -x -E \"SELECT rpath(sname, sroll, name), xattr_name FROM vrxpentries WHERE xattr_name != '' ORDER BY name;\" \"${SEARCH}\" 2>/dev/null" || echo "No xattrs found"
+    
+    echo
+    echo "# verify nlink decrement"
+    echo "# All file nlink counts should be decremented by 1 (MarFS metadata link removed)"
+    run_sort "${GUFI_QUERY} -d \"${DELIM}\" -E \"SELECT rpath(sname, sroll, name), nlink FROM vrpentries WHERE type == 'f' ORDER BY name;\" \"${SEARCH}\""
+    
+    echo
+    echo "# test: verify root namespace rename in summary table"
+    run_sort "${GUFI_QUERY} -d \"${DELIM}\" -S \"SELECT name FROM summary WHERE name == 'marfs';\" \"${SEARCH}\""
+    
+    echo
+    echo "# test: re-index over existing index"
+    echo "# Plugin should handle existing index structure correctly"
+    MARFS_CONFIG_PATH="${MARFS_CONFIG}" run_no_sort "${GUFI_DIR2INDEX} -x --plugin \"GUFI_MARFS_PLUGIN:${MARFS_INDEXING_PLUGIN}\" \"${MARFS_SEC_ROOT}\" \"${SEARCH}\"" 2>&1 | remove_indexing_time
+    
+    echo
+    echo "# verify structure after re-indexing"
+    run_no_sort "find \"${SEARCH}\" -type d | sort"
+    
+    echo
+    echo "# test: error handling - missing config"
+    echo "# Should fail with appropriate error message"
+    unset MARFS_CONFIG_PATH
+    run_no_sort "${GUFI_DIR2INDEX} -x --plugin \"GUFI_MARFS_PLUGIN:${MARFS_INDEXING_PLUGIN}\" \"${MARFS_SEC_ROOT}\" \"${SEARCH}_fail\" 2>&1 | head -n 1" || true
+    
+    echo
+    echo "# test: error handling - invalid path"
+    echo "# Should fail when path is not a MarFS sec-root"
+    MARFS_CONFIG_PATH="${MARFS_CONFIG}" run_no_sort "${GUFI_DIR2INDEX} -x --plugin \"GUFI_MARFS_PLUGIN:${MARFS_INDEXING_PLUGIN}\" \"/tmp\" \"${SEARCH}_fail2\" 2>&1 | @GREP@ -i 'error' | head -n 1" || true
+    
+    echo
+    echo "# test: verify inode/pinode relationships"
+    echo "# Check that all child directories have pinode matching parent's inode"
+    echo "# This ensures the plugin correctly maintains parent-child relationships"
+    run_no_sort "${GUFI_QUERY} \\
+        -n 1 \\
+        -d '|' \\
+        -I \"CREATE TABLE intermediate(
+               dir        TEXT,
+               parent_dir TEXT,
+               inode      TEXT,
+               pinode     TEXT
+            );\" \\
+        -S \"INSERT INTO intermediate
+            SELECT
+                path() AS dir,
+                CASE
+                    WHEN level() = 0 THEN NULL
+                    WHEN level() = 1 THEN ''
+                    ELSE substr(path(), 1, length(path()) - length(epath()) - 1)
+                END AS parent_dir,
+                inode,
+                pinode
+            FROM vrsummary;\" \\
+        -K \"CREATE TABLE aggregate(
+               dir            TEXT,
+               parent_dir     TEXT,
+               inode          TEXT,
+               pinode         TEXT,
+               expected_inode TEXT
+            );\" \\
+        -J \"INSERT INTO aggregate
+            SELECT
+                child.dir,
+                child.parent_dir,
+                child.inode,
+                child.pinode,
+                parent.inode AS expected_inode
+            FROM intermediate AS child
+            LEFT JOIN intermediate AS parent
+              ON child.parent_dir = parent.dir;\" \\
+        -G \"SELECT
+                dir,
+                parent_dir,
+                inode,
+                pinode,
+                expected_inode
+            FROM aggregate
+            WHERE parent_dir != ''
+              AND (expected_inode IS NULL OR pinode != expected_inode)
+            ORDER BY dir;\" \\
+        \"${SEARCH}\""
+    
+    echo "# If above query returns no results, all inode/pinode relationships are correct"
+    
+) | tee "${OUTPUT}"
+
+@DIFF@ @CMAKE_CURRENT_BINARY_DIR@/marfs_plugin.expected "${OUTPUT}"
+rm "${OUTPUT}"

--- a/test/regression/marfs_plugin.sh.in
+++ b/test/regression/marfs_plugin.sh.in
@@ -66,14 +66,7 @@ set -e
 
 OUTPUT="marfs_plugin.out"
 
-# Check if MarFS plugin is available
-if [[ ! -f "${MARFS_INDEXING_PLUGIN}" ]]; then
-    echo "MarFS plugin not found at ${MARFS_INDEXING_PLUGIN}, skipping test"
-    exit 0
-fi
-
 MARFS_CONFIG="marfs_test_config.xml"
-MARFS_MOUNTPOINT="/marfs"
 
 MARFS_BASE="${SRCDIR}/var/marfs"
 MARFS_DAL_ROOT="${MARFS_BASE}/dal-root"
@@ -81,7 +74,7 @@ MARFS_MDAL_ROOT="${MARFS_BASE}/mdal-root"
 MARFS_SEC_ROOT="${MARFS_MDAL_ROOT}/sec-root"
 
 cleanup() {
-    rm -rf "${MARFS_BASE}" "${SEARCH}" "${MARFS_CONFIG}"
+    rm -rf "${MARFS_BASE}" "${MARFS_CONFIG}"
 }
 
 cleanup_exit() {
@@ -100,10 +93,6 @@ cleanup
     mkdir -p "${MARFS_DAL_ROOT}"
     
     # Create mdal-root and sec-root (metadata abstraction layer)
-    mkdir -p "${MARFS_SEC_ROOT}"
-    mkdir -p "${MARFS_SEC_ROOT}/MDAL_subspaces"
-    mkdir -p "${MARFS_SEC_ROOT}/MDAL_subspaces/namespace1"
-    mkdir -p "${MARFS_SEC_ROOT}/MDAL_subspaces/namespace1/MDAL_subspaces"
     mkdir -p "${MARFS_SEC_ROOT}/MDAL_subspaces/namespace1/MDAL_subspaces/namespace2"
     
     # Create user files in namespaces
@@ -121,22 +110,18 @@ cleanup
     echo "reference ns2" > "${MARFS_SEC_ROOT}/MDAL_subspaces/namespace1/MDAL_subspaces/namespace2/MDAL_reference"
     
     # Add MarFS xattrs to files (these should be filtered out)
-    if command -v setfattr &> /dev/null; then
-        setfattr -n user.MDAL_MARFS-FILE -v "marfs_metadata" "${MARFS_SEC_ROOT}/MDAL_subspaces/namespace1/userfile1.txt" 2>/dev/null || true
-        setfattr -n user.MDAL_MARFS-FILE -v "marfs_metadata" "${MARFS_SEC_ROOT}/MDAL_subspaces/namespace1/MDAL_subspaces/namespace2/nestedfile1.txt" 2>/dev/null || true
-    fi
+    os_setfattr user.MDAL_MARFS-FILE "marfs_metadata" "${MARFS_SEC_ROOT}/MDAL_subspaces/namespace1/userfile1.txt" 2>/dev/null || true
+    os_setfattr user.MDAL_MARFS-FILE "marfs_metadata" "${MARFS_SEC_ROOT}/MDAL_subspaces/namespace1/MDAL_subspaces/namespace2/nestedfile1.txt" 2>/dev/null || true
     
     # Add user xattrs (these should be preserved)
-    if command -v setfattr &> /dev/null; then
-        setfattr -n user.myattr -v "myvalue" "${MARFS_SEC_ROOT}/MDAL_subspaces/namespace1/userfile1.txt" 2>/dev/null || true
-    fi
+    os_setfattr user.myattr "myvalue" "${MARFS_SEC_ROOT}/MDAL_subspaces/namespace1/userfile1.txt" 2>/dev/null || true
     
-    run_no_sort "find \"${MARFS_SEC_ROOT}\" -type f -o -type d | sort"
+    run_sort "find \"${MARFS_SEC_ROOT}\" -type f -o -type d"
     
     echo
     echo "# create MarFS config XML"
-    cp "@CMAKE_CURRENT_SOURCE_DIR@/marfs_plugin_config.xml.in" "${MARFS_CONFIG}"
-        
+    cp "@CMAKE_CURRENT_BINARY_DIR@/marfs_plugin_config.xml" "${MARFS_CONFIG}"
+
     # Replace placeholders with actual paths
     @SED@ -i "s|DAL_ROOT_PLACEHOLDER|${MARFS_DAL_ROOT}|g" "${MARFS_CONFIG}"
     @SED@ -i "s|NS_ROOT_PLACEHOLDER|${MARFS_SEC_ROOT}|g" "${MARFS_CONFIG}"
@@ -156,16 +141,16 @@ cleanup
     echo "# verify index structure"
     echo "# Root should be renamed from 'sec-root' to 'marfs' (mountpoint basename)"
     echo "# MDAL_subspaces directories should be removed from final structure"
-    run_no_sort "find \"${SEARCH}\" -type d | sort"
+    run_sort "find \"${SEARCH}\" -type d"
     
     echo
     echo "# query indexed files"
     echo "# MarFS internal files (MDAL_reference) should not appear in results"
-    run_sort "${GUFI_QUERY} -d \"${DELIM}\" -S \"SELECT rpath(sname, sroll) || '/' || name FROM vrsummary;\" -E \"SELECT rpath(sname, sroll, name) FROM vrpentries;\" \"${SEARCH}\""
-    
+    run_sort "${GUFI_QUERY} -d \"${DELIM}\" -S \"SELECT rpath(sname, sroll) FROM vrsummary;\" -E \"SELECT rpath(sname, sroll, name) FROM vrpentries;\" \"${SEARCH}\""
+
     echo
     echo "# query file counts per directory"
-    run_sort "${GUFI_QUERY} -d \"${DELIM}\" -S \"SELECT rpath(sname, sroll) || '/' || name, totfiles FROM vrsummary WHERE totfiles > 0 ORDER BY name;\" \"${SEARCH}\""
+    run_sort "${GUFI_QUERY} -d \"${DELIM}\" -S \"SELECT rpath(sname, sroll) AS name, totfiles FROM vrsummary WHERE totfiles > 0 ORDER BY name;\" \"${SEARCH}\""
     
     echo
     echo "# verify xattrs"
@@ -176,11 +161,11 @@ cleanup
     echo
     echo "# verify nlink decrement"
     echo "# All file nlink counts should be decremented by 1 (MarFS metadata link removed)"
-    run_sort "${GUFI_QUERY} -d \"${DELIM}\" -E \"SELECT rpath(sname, sroll, name), nlink FROM vrpentries WHERE type == 'f' ORDER BY name;\" \"${SEARCH}\""
+    run_sort "${GUFI_QUERY} -d \"${DELIM}\" -S \"SELECT rpath(sname, sroll), nlink FROM vrsummary;\" -E \"SELECT rpath(sname, sroll, name), nlink FROM vrpentries WHERE type == 'f' ORDER BY name;\" \"${SEARCH}\""
     
     echo
     echo "# test: verify root namespace rename in summary table"
-    run_sort "${GUFI_QUERY} -d \"${DELIM}\" -S \"SELECT name FROM summary WHERE name == 'marfs';\" \"${SEARCH}\""
+    run_sort "${SQLITE3} \"${SEARCH}/marfs/db.db\" \"SELECT name FROM summary;\""
     
     echo
     echo "# test: re-index over existing index"
@@ -189,7 +174,7 @@ cleanup
     
     echo
     echo "# verify structure after re-indexing"
-    run_no_sort "find \"${SEARCH}\" -type d | sort"
+    run_sort "find \"${SEARCH}\" -type d"
     
     echo
     echo "# test: error handling - missing config"

--- a/test/regression/marfs_plugin_config.xml.in
+++ b/test/regression/marfs_plugin_config.xml.in
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- MarFS Test Configuration -->
+<marfs_config version="2025-09-25">
+   <!-- Mount Point -->
+   <mnt_top>/marfs</mnt_top>
+
+   <!-- Test Repo Definition -->
+   <repo name="TestRepo">
+
+      <!-- Per-Repo Data Scheme -->
+      <data>
+
+         <!-- Erasure Protection -->
+         <protection>
+            <N>3</N>
+            <E>1</E>
+            <PSZ>1048572</PSZ>
+         </protection>
+
+         <!-- Packing -->
+         <packing enabled="yes">
+            <max_files>4096</max_files>
+         </packing>
+
+         <!-- Chunking -->
+         <chunking enabled="yes">
+            <max_size>4G</max_size>
+         </chunking>
+
+         <!-- Object Distribution -->
+         <distribution>
+            <pods cnt="1"/>
+            <caps cnt="1"/>
+            <scatters cnt="1024"/>
+         </distribution>
+
+         <!-- DAL Definition -->
+         <DAL type="posix">
+            <dir_template>pod{p}/block{b}/cap{c}/scat{s}/</dir_template>
+            <sec_root>DAL_ROOT_PLACEHOLDER</sec_root>
+         </DAL>
+
+      </data>
+
+      <!-- Per-Repo Metadata Scheme -->
+      <meta>
+
+         <!-- Direct Data -->
+         <direct read="yes"/>
+
+         <!-- MDAL Definition -->
+         <MDAL type="posix">
+            <ns_root>NS_ROOT_PLACEHOLDER</ns_root>
+         </MDAL>
+
+         <!-- Namespace Definitions -->
+         <namespaces rbreadth="40" rdepth="3" rdigits="3">
+
+            <!-- Root Namespace -->
+            <ns name="root">
+
+               <!-- Quota Limits for this NS -->
+               <quotas>
+                  <data>10T</data>
+               </quotas>
+
+               <!-- Permission Settings for this NS -->
+               <perms>
+                  <interactive>RM,RD</interactive>
+                  <batch>RM,RD</batch>
+               </perms>
+
+               <!-- Test Subspace -->
+               <ns name="namespace1">
+                  <quotas>
+                     <data>5T</data>
+                  </quotas>
+                  <perms>
+                     <interactive>RM,WM,RD</interactive>
+                     <batch>RM,WM,RD,WD</batch>
+                  </perms>
+                  
+                  <!-- Nested Subspace -->
+                  <ns name="namespace2">
+                     <quotas>
+                        <data>2T</data>
+                     </quotas>
+                     <perms>
+                        <interactive>RM,WM,RD</interactive>
+                        <batch>RM,WM,RD,WD</batch>
+                     </perms>
+                  </ns>
+               </ns>
+
+            </ns>
+
+         </namespaces>
+
+      </meta>
+
+   </repo>
+
+</marfs_config>

--- a/test/regression/marfs_plugin_config.xml.in
+++ b/test/regression/marfs_plugin_config.xml.in
@@ -1,4 +1,67 @@
 <?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+This file is part of GUFI, which is part of MarFS, which is released
+under the BSD license.
+
+
+Copyright (c) 2017, Los Alamos National Security (LANS), LLC
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation and/or
+other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors
+may be used to endorse or promote products derived from this software without
+specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+From Los Alamos National Security, LLC:
+LA-CC-15-039
+
+Copyright (c) 2017, Los Alamos National Security, LLC All rights reserved.
+Copyright 2017. Los Alamos National Security, LLC. This software was produced
+under U.S. Government contract DE-AC52-06NA25396 for Los Alamos National
+Laboratory (LANL), which is operated by Los Alamos National Security, LLC for
+the U.S. Department of Energy. The U.S. Government has rights to use,
+reproduce, and distribute this software.  NEITHER THE GOVERNMENT NOR LOS
+ALAMOS NATIONAL SECURITY, LLC MAKES ANY WARRANTY, EXPRESS OR IMPLIED, OR
+ASSUMES ANY LIABILITY FOR THE USE OF THIS SOFTWARE.  If software is
+modified to produce derivative works, such modified software should be
+clearly marked, so as not to confuse it with the version available from
+LANL.
+
+THIS SOFTWARE IS PROVIDED BY LOS ALAMOS NATIONAL SECURITY, LLC AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL LOS ALAMOS NATIONAL SECURITY, LLC OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+OF SUCH DAMAGE.
+-->
+
 <!-- MarFS Test Configuration -->
 <marfs_config version="2025-09-25">
    <!-- Mount Point -->

--- a/test/regression/os_specific.sh.in
+++ b/test/regression/os_specific.sh.in
@@ -80,6 +80,8 @@ case "@CMAKE_SYSTEM_NAME@" in
         DSI_INDEXING_PLUGIN="@CMAKE_BINARY_DIR@/contrib/plugins/libdsi_indexing.dylib"
         DSI_QUERYING_PLUGIN="@CMAKE_BINARY_DIR@/contrib/plugins/libdsi_querying.dylib"
 
+        MARFS_INDEXING_PLUGIN="@CMAKE_BINARY_DIR@/contrib/plugins/libmarfs_plugin.dylib"
+
         os_setfattr() {
             @XATTR@ -w "$1" "$2" "$3"
         }
@@ -125,6 +127,8 @@ case "@CMAKE_SYSTEM_NAME@" in
 
         DSI_INDEXING_PLUGIN="@CMAKE_BINARY_DIR@/contrib/plugins/libdsi_indexing.so"
         DSI_QUERYING_PLUGIN="@CMAKE_BINARY_DIR@/contrib/plugins/libdsi_querying.so"
+
+        MARFS_INDEXING_PLUGIN="@CMAKE_BINARY_DIR@/contrib/plugins/libmarfs_plugin.so"
 
         os_setfattr() {
             @SETFATTR@ -n "$1" -v "$2" "$3"

--- a/test/regression/setup.sh.in
+++ b/test/regression/setup.sh.in
@@ -358,6 +358,8 @@ replace() {
     s%${DSI_INDEXING_PLUGIN}%dsi_indexing_plugin%g;
     s%${DSI_QUERYING_PLUGIN}%dsi_querying_plugin%g;
 
+    s%${MARFS_INDEXING_PLUGIN}%marfs_indexing_plugin%g;
+
     s%${TEST_GUFI_JAIL}%gufi_jail%g;
 
     s%&vfs=.* as % as %g;


### PR DESCRIPTION
# Marfs Plugin
Add MarFS indexing plugin for GUFI


# Summary

This PR introduces a new GUFI indexing plugin that enables GUFI to correctly index MarFS namespaces. The plugin removes MarFS specific metadata entries from the index and normalizes directory structures so that the resulting GUFI index represents user visible filesystem structure rather than internal MDAL layout.

# Motivation

MarFS stores metadata internally using MDAL directories and files (e.g. `MDAL_*` directories and `MDAL_subspaces`). When GUFI indexes a MarFS namespace directly, these internal structures appear in the resulting index and interfere with normal filesystem queries.

This plugin adjusts indexing behavior to:

* remove MDAL internal files
* filter MDAL xattrs
* normalize namespace paths
* present the index as a standard hierarchical filesystem view

This allows GUFI to operate directly on MarFS namespaces without requiring post-processing.

# Design Overview

The plugin performs the following steps:

### 1. Global Initialization

During `global_init` the plugin:

* reads the MarFS configuration (`MARFS_CONFIG_PATH`)
* discovers all namespaces in the MarFS configuration
* validates that the provided directory is a MarFS namespace root

### 2. Directory Action

`dir_action`:

* prevents traversal into internal MDAL directories
* identifies active namespaces
* skips inactive namespaces

### 3. File Processing

`process_file`:

* removes MDAL metadata files from the index
* decrements link counts for remaining files
* removes MarFS specific xattrs from the indexed metadata

### 4. Directory Processing

`process_dir`:

* renames the root namespace entry in the index to match the MarFS mountpoint.

# Usage

Compile the plugin:

```bash
 mkdir build && cd build
 
 cmake .. -DMARFS_PREFIX=/path/to/marfs/install/ -DMARFS_SRC=/path/to/marfs/
 
 make
 
 (sudo) make install

```

Run with GUFI:

```bash
MARFS_CONFIG_PATH=/path/to/marfs/install/etc/marfs-config.xml \
   src/gufi_dir2index \
   --plugin "GUFI_MARFS_PLUGIN:contrib/plugins/libmarfs_plugin.so" \
   /path/to/mdal-root/sec-root /home/$USER/gufi-index-dir
 ```

# Dependencies

The plugin depends on:

* MarFS libraries (`libmarfs`)
* MarFS source (`hash.h` & `config.h`)
* libxml2