### PR TITLE
WIP / Proof of concept: Filehandle based incremental updates for Lustre

### DIFF
--- a/docs/file_handle_based_incrementals.md
+++ b/docs/file_handle_based_incrementals.md
@@ -1,0 +1,80 @@
+# GUFI Incrementals based on on File Handles
+
+This describes the implementation of file handle based incremental updates for Lustre.
+
+## Motivation
+
+The challenge with performing incremental updates for GUFI is that the GUFI index
+mimics the tree-structure of the source filesystem, but changelog records from source filesystems
+like Lustre only provide node IDs (i.e., FIDs), not paths.
+
+Given a change record like: "Node with name `child` and id `456` was created under Node with id `123`",
+how do you locate node `123` in the index to apply the update there?
+
+Various proposed solutions are either expensive (e.g., require walking the entire source
+and index filesystems to resolve node IDs to paths), or vulnerable to race conditions
+(e.g., using `lfs fid2path` or analogous operations to resolve a path at some later time when
+the node may have been moved to a different location).
+
+Using file handles--the opaque structures returned by the system call `name_to_handle_at(2)`--allows
+filesystem nodes to be accessed directly, given their handles, bypassing the need for path resolution.
+
+## File Handle Index
+
+An index needs to be created that maps *source* file handles (e.g., Lustre FIDs) to *index* file handles
+in the GUFI tree.
+Currently, this is a sqlite database called `filehandles.db` created at the root of the GUFI tree.
+
+`gufi_dir2index` inserts a row into this database each time it creates a directory in the index tree.
+The row maps the file handle of the source FS directory to the file handle of the newly created index directory.
+
+## Performing Updates
+
+A program at `src/lustre_changelog_updater.c` consumes Lustre changelogs.
+For each changelog record it receives, it records the relevant information and
+performs an update to the index tree that mimics the update to the source.
+
+### new or modified files
+
+Updates that do not modify the shape of the tree include file creation, file modification, etc.
+These kinds of updates simply trigger the sqlite database at that index node to be recreated.
+
+### mkdir, rmdir
+
+`mkdir` and `rmdir` operations are similar: the changelog record includes the FID
+of the parent directory, the name of the affected child, and the FID of the child.
+
+The file handle of the parent directory is looked up in the file handle index.
+The parent directory is opened using `open_by_handle_at(2)`, and then the either
+`mkdirat(2)` or `unlinkat(2)` is performed.
+
+Then a row is either inserted (for `mkdir`) or deleted (for `rmdir`) from the file handle index.
+
+### rename
+
+`rename` is a little more complicated because there are two parent directories involved.
+The changelog record has the FID for each directory, so both the old parent and the
+new parent are resolved to index file handles. Both file handles are opened with
+`open_by_handle_at(2)`.
+
+Then, `renameat(2)` is performed.
+
+A further complication with `rename` is that rename can fail if the kernel cannot determine
+if the rename will not introduce a filesystem loop. The kernel checks this by making sure
+that neither parent directory is an ancestor of the other. This check can fail, however,
+if the parent directories are in disconnected subtrees of the dentry cache tree.
+
+Normally, the dentry cache tree (or really, forest) does not contain any disconnected subtrees
+because files are opened via paths, so any node's parent will already be in memory before
+the node itself is opened.
+
+However, opening nodes via their handle instead of their path opens up the possibility that
+the node's parent is not cached in the dentry cache. This situation can result in `renameat(2)`
+spuriously failing.
+
+In order to resolve this *connectable* file handles must be used.
+Connectable file handles ensure that when a node is opened via its handle, the node's
+parent is loaded into memory and connected to the child node, and so on recursively
+until the node is connected to the main subtree that contains the root.
+
+See https://lwn.net/Articles/993810/ for more details on connectable file handles.

--- a/include/incremental_non_path.h
+++ b/include/incremental_non_path.h
@@ -1,0 +1,94 @@
+/*
+This file is part of GUFI, which is part of MarFS, which is released
+under the BSD license.
+
+
+Copyright (c) 2017, Los Alamos National Security (LANS), LLC
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation and/or
+other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors
+may be used to endorse or promote products derived from this software without
+specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+From Los Alamos National Security, LLC:
+LA-CC-15-039
+
+Copyright (c) 2017, Los Alamos National Security, LLC All rights reserved.
+Copyright 2017. Los Alamos National Security, LLC. This software was produced
+under U.S. Government contract DE-AC52-06NA25396 for Los Alamos National
+Laboratory (LANL), which is operated by Los Alamos National Security, LLC for
+the U.S. Department of Energy. The U.S. Government has rights to use,
+reproduce, and distribute this software.  NEITHER THE GOVERNMENT NOR LOS
+ALAMOS NATIONAL SECURITY, LLC MAKES ANY WARRANTY, EXPRESS OR IMPLIED, OR
+ASSUMES ANY LIABILITY FOR THE USE OF THIS SOFTWARE.  If software is
+modified to produce derivative works, such modified software should be
+clearly marked, so as not to confuse it with the version available from
+LANL.
+
+THIS SOFTWARE IS PROVIDED BY LOS ALAMOS NATIONAL SECURITY, LLC AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL LOS ALAMOS NATIONAL SECURITY, LLC OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+OF SUCH DAMAGE.
+*/
+
+
+
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+
+#include <sqlite3.h>
+
+struct fh_incremental_state {
+    sqlite3 *fh_db;
+    int fh_mount_fd;
+};
+
+struct fh_incremental_state open_incremental_state(const char *path);
+
+void close_incremental_state(struct fh_incremental_state s);
+
+sqlite3 *create_filehandle_db(const char *path);
+
+struct file_handle *fh_lookup(sqlite3 *db, void *src_fh, size_t src_fh_len);
+
+int fh_db_insert_by_path(sqlite3 *db, char *src, char *dst);
+
+int do_rename(struct fh_incremental_state *s, void *old_parent, size_t old_parent_len,
+              void *new_parent, size_t new_parent_len,
+              const char *oldpath, const char *newpath);
+
+int do_mkdir(struct fh_incremental_state *s, void *parent, size_t parent_len,
+             void *child, size_t child_len, const char *name);
+
+int do_rmdir(struct fh_incremental_state *s, void *parent, size_t parent_len,
+             void *child, size_t child_len, const char *name);

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -79,6 +79,7 @@ set(GUFI_SOURCES
   external_copy.c
   gufi_vt.c
   histogram.c
+  incremental_non_path.c
   outfiles.c
   path_list.c
   plugin.c

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -340,3 +340,17 @@ if (DB2_FOUND AND DB2_BUILD)
   string(REPLACE ";" " " DB2_CFLAGS "${DB2_CFLAGS}")
   string(REPLACE ";" " " DB2_LDFLAGS "${DB2_LDFLAGS}")
 endif()
+
+# lustre changelog reader...
+add_executable(lustre_changelog_updater lustre_changelog_updater.c)
+target_include_directories(lustre_changelog_updater
+    PRIVATE /home/bertschinger/git/lustre-release/lustre/include/
+    /home/bertschinger/git/lustre-release/lustre/include/uapi
+)
+target_link_directories(lustre_changelog_updater
+    PRIVATE /home/bertschinger/git/lustre-release/lustre/utils/.libs
+)
+target_link_libraries(lustre_changelog_updater
+    lustreapi
+    ${COMMON_LIBRARIES}
+)

--- a/src/gufi_dir2index.c
+++ b/src/gufi_dir2index.c
@@ -84,6 +84,8 @@ OF SUCH DAMAGE.
 #include "str.h"
 #include "utils.h"
 
+#include "incremental_non_path.h"
+
 struct PoolArgs {
     struct input in;
     str_t index_parent; /* actual index is placed at <index parent>/$(basename <src>) */
@@ -93,6 +95,8 @@ struct PoolArgs {
 
     uint64_t *total_dirs;
     uint64_t *total_nondirs;
+
+    sqlite3 *filehandle_db;
 };
 
 /*
@@ -243,6 +247,9 @@ static int processdir(QPTPool_ctx_t *ctx, void *data) {
             goto close_dir;
         }
     }
+
+    // printf("from dir: %s, to dir: %s\n", nda.work->name, nda.topath.data);
+    fh_db_insert_by_path(pa->filehandle_db, nda.work->name, nda.topath.data);
 
     /*
      * set up for processing, but keep to minimum to quickly hit
@@ -579,6 +586,14 @@ int main(int argc, char *argv[]) {
         rc = EXIT_FAILURE;
         goto free_db;
     }
+
+    sqlite3 *db = create_filehandle_db(pa.index_parent.data);
+    if (!db) {
+        fprintf(stderr, "Could not create filehandle database\n");
+        rc = EXIT_FAILURE;
+        goto free_db;
+    }
+    pa.filehandle_db = db;
 
     const uint64_t queue_limit = get_queue_limit(pa.in.target_memory, pa.in.maxthreads);
     QPTPool_ctx_t *ctx = QPTPool_init_with_props(pa.in.maxthreads, &pa, NULL, NULL, queue_limit, pa.in.swap_prefix.data, 1, 2, 1);

--- a/src/incremental_non_path.c
+++ b/src/incremental_non_path.c
@@ -1,0 +1,519 @@
+/*
+This file is part of GUFI, which is part of MarFS, which is released
+under the BSD license.
+
+
+Copyright (c) 2017, Los Alamos National Security (LANS), LLC
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation and/or
+other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors
+may be used to endorse or promote products derived from this software without
+specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+From Los Alamos National Security, LLC:
+LA-CC-15-039
+
+Copyright (c) 2017, Los Alamos National Security, LLC All rights reserved.
+Copyright 2017. Los Alamos National Security, LLC. This software was produced
+under U.S. Government contract DE-AC52-06NA25396 for Los Alamos National
+Laboratory (LANL), which is operated by Los Alamos National Security, LLC for
+the U.S. Department of Energy. The U.S. Government has rights to use,
+reproduce, and distribute this software.  NEITHER THE GOVERNMENT NOR LOS
+ALAMOS NATIONAL SECURITY, LLC MAKES ANY WARRANTY, EXPRESS OR IMPLIED, OR
+ASSUMES ANY LIABILITY FOR THE USE OF THIS SOFTWARE.  If software is
+modified to produce derivative works, such modified software should be
+clearly marked, so as not to confuse it with the version available from
+LANL.
+
+THIS SOFTWARE IS PROVIDED BY LOS ALAMOS NATIONAL SECURITY, LLC AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL LOS ALAMOS NATIONAL SECURITY, LLC OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+OF SUCH DAMAGE.
+*/
+
+
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include "incremental_non_path.h"
+
+#define FILEID_LUSTRE  0x97
+
+static int file_handle_size(struct file_handle *fh) {
+    /*
+     * Hack for Lustre specifically: the filehandle is twice as large as a FID because it
+     * can optionally encode the parent FID next to the FID of this object. This functionality
+     * is not used for GUFI; in this use case, the second half of the FID is always all 0s.
+     *
+     * (Storing the parent FID is useful when the target object is a file, not a directory,
+     *  but this database only stores directory FIDs.)
+     *
+     * In order to save space, and make comparisons with FIDs easier when later querying the
+     * database, only store the first half of the filehandle.
+     */
+    if (fh->handle_type == FILEID_LUSTRE && fh->handle_bytes == 32) {
+        return 16;
+    }
+
+    return sizeof *fh + fh->handle_bytes;
+}
+
+static void *file_handle_data(struct file_handle *fh) {
+    if (fh->handle_type == FILEID_LUSTRE && fh->handle_bytes == 32) {
+        return fh->f_handle;
+    }
+
+    return fh;
+}
+
+static struct file_handle *alloc_fh(void) {
+    struct file_handle *fh = calloc(1, sizeof *fh + MAX_HANDLE_SZ);
+    if (!fh)
+        return NULL;
+
+    fh->handle_bytes = MAX_HANDLE_SZ;
+
+    return fh;
+}
+
+static sqlite3 *open_filehandle_db(const char *parent_dir) {
+    sqlite3 *db = NULL;
+
+    char path[4096];
+    snprintf(path, 4096, "%s/filehandles.db", parent_dir);
+
+    if (sqlite3_open(path, &db) != SQLITE_OK) {
+        fprintf(stderr, "sqlite3_open() failed: %s\n", db ? sqlite3_errmsg(db) : "out of memory");
+        if (db) {
+            sqlite3_close(db);
+        }
+        return NULL;
+    }
+
+    return db;
+}
+
+struct fh_incremental_state open_incremental_state(const char *path) {
+    struct fh_incremental_state new;
+
+    new.fh_mount_fd = open(path, O_RDONLY|O_DIRECTORY);
+    if (new.fh_mount_fd < 0) {
+        fprintf(stderr, "Could not open GUFI root '%s': %s\n", path, strerror(errno));
+        exit(1);
+    }
+
+    new.fh_db = open_filehandle_db(path);
+    if (!new.fh_db) {
+        fprintf(stderr, "Could not open filehandle database.\n");
+        exit(1);
+    }
+
+    return new;
+}
+
+/*
+ * Closes the incremental updates database. Exits the program with an error if
+ * any sqlite3 object leaks were detected.
+ *
+ * Also closes the GUFI tree file descriptor.
+ */
+void close_incremental_state(struct fh_incremental_state s) {
+    if (close(s.fh_mount_fd)) {
+        fprintf(stderr, "Warning: closing GUFI tree file descriptor failed: %s\n", strerror(errno));
+    }
+
+    if (sqlite3_close(s.fh_db) != SQLITE_OK) {
+        fprintf(stderr, "Closing the filehandle database failed. Check for leaked sqlite3 objects.\n");
+        exit(1);
+    }
+}
+
+/*
+ * Create the filehandle database in the given parent_dir. The database will be named
+ * "filehandles.db".
+ *
+ * The database has one table which just stores key/value pairs.
+ *   - The key is a filehandle in the source filesystem (the FS being indexed)
+ *   - The value is a filehandle for the equivalent directory in the index itself
+ */
+sqlite3 *create_filehandle_db(const char *parent_dir) {
+    sqlite3 *db = NULL;
+
+    char path[4096];
+    snprintf(path, 4096, "%s/filehandles.db", parent_dir);
+
+    printf("creating FH db at %s\n", path);
+
+    if (sqlite3_open(path, &db) != SQLITE_OK) {
+        fprintf(stderr, "sqlite3_open() failed: %s\n", db ? sqlite3_errmsg(db) : "out of memory");
+        if (db) {
+            sqlite3_close(db);
+        }
+        return NULL;
+    }
+
+    const char *sql =
+        "CREATE TABLE IF NOT EXISTS filehandles ("
+        "  src_fh BLOB NOT NULL PRIMARY KEY,"
+        "  dst_fh BLOB NOT NULL"
+        ") WITHOUT ROWID;";
+
+    char *errmsg = NULL;
+    if (sqlite3_exec(db, sql, NULL, NULL, &errmsg) != SQLITE_OK) {
+        fprintf(stderr, "sqlite3_exec() failed: %s\n", errmsg ? errmsg : sqlite3_errmsg(db));
+        sqlite3_free(errmsg);
+        return NULL;
+    }
+
+    return db;
+}
+
+/*
+ * Inserts the source and target filehandles into the database.
+ *
+ * The target filehandle is stored in its entirety, but for the source filehandle only
+ * the handle bytes are stored, not the metadata. This is convenient for two reasons:
+ *
+ *   1) Since only the f_handle field is needed to adequately distinguish a file,
+ *      this saves a few bytes and makes the database file smaller.
+ *
+ *   2) When indexing Lustre, files are identified by Lustre FIDs which are
+ *      equal to the f_handle of a Lustre file handle. By only storing f_handle, a later
+ *      comparison with a Lustre FID will work as expected without needing to trim
+ *      the file handle metadata away.
+ *
+ * In order for it to be safe to strip the metadata out of the source filehandle,
+ * the handle_bytes and handle_type field must be identical for all files in the
+ * source filesystem.
+ * That assumption holds for the filesystems we are interested in indexing.
+ */
+static int fh_insert(sqlite3 *db, void *src_fh, size_t src_len, struct file_handle *dst_fh) {
+    int ret = 0;
+
+    const char *sql = "INSERT INTO filehandles(src_fh, dst_fh) VALUES(?, ?);";
+
+    sqlite3_stmt *stmt = NULL;
+
+    // printf("source fid size: %d, dest fid size: %d\n", src_len, dst_fh->handle_bytes);
+
+    if (sqlite3_prepare_v2(db, sql, -1, &stmt, NULL) != SQLITE_OK) {
+        fprintf(stderr, "fh_insert(): sqlite3_prepare_v2() failed: %s\n", sqlite3_errmsg(db));
+        return 1;
+    }
+
+    if (sqlite3_bind_blob(stmt, 1, src_fh, src_len, SQLITE_STATIC) != SQLITE_OK) {
+        fprintf(stderr, "fh_insert(): bind source FH failed: %s\n", sqlite3_errmsg(db));
+        ret = 1;
+        goto out;
+    }
+
+    if (sqlite3_bind_blob(stmt, 2, (void *) file_handle_data(dst_fh),
+                          file_handle_size(dst_fh), SQLITE_STATIC) != SQLITE_OK) {
+        fprintf(stderr, "fh_insert(): bind dest FH failed: %s\n", sqlite3_errmsg(db));
+        ret = 1;
+        goto out;
+    }
+
+    if (sqlite3_step(stmt) != SQLITE_DONE) {
+        fprintf(stderr, "fh_insert(): statement failed: %s\n", sqlite3_errmsg(db));
+        ret = 1;
+    }
+
+out:
+    sqlite3_finalize(stmt);
+
+    return ret;
+}
+
+static int fh_delete(sqlite3 *db, void *src_fh, size_t src_len) {
+    int ret = 0;
+
+    const char *sql = "DELETE FROM filehandles WHERE src_fh = ?;";
+
+    sqlite3_stmt *stmt = NULL;
+
+    if (sqlite3_prepare_v2(db, sql, -1, &stmt, NULL) != SQLITE_OK) {
+        fprintf(stderr, "fh_delete(): sqlite3_prepare_v2() failed: %s\n", sqlite3_errmsg(db));
+        return 1;
+    }
+
+    if (sqlite3_bind_blob(stmt, 1, src_fh, src_len, SQLITE_STATIC) != SQLITE_OK) {
+        fprintf(stderr, "fh_delete(): bind source FH failed: %s\n", sqlite3_errmsg(db));
+        ret = 1;
+        goto out;
+    }
+
+    if (sqlite3_step(stmt) != SQLITE_DONE) {
+        fprintf(stderr, "fh_delete(): statement failed: %s\n", sqlite3_errmsg(db));
+        ret = 1;
+    }
+
+out:
+    sqlite3_finalize(stmt);
+
+    return ret;
+}
+
+/*
+ * Returns either an allocated file handle or NULL if an error occurred.
+ */
+struct file_handle *fh_lookup(sqlite3 *db, void *src_fh, size_t src_fh_len) {
+    struct file_handle *dst_fh = NULL;
+
+    const char *sql = "SELECT dst_fh FROM filehandles WHERE src_fh = ?";
+    sqlite3_stmt *stmt = NULL;
+
+    if (sqlite3_prepare_v2(db, sql, -1, &stmt, NULL) != SQLITE_OK) {
+        fprintf(stderr, "sqlite3_prepare_v2() failed: %s\n", sqlite3_errmsg(db));
+        return NULL;
+    }
+
+    if (sqlite3_bind_blob(stmt, 1, src_fh, src_fh_len, SQLITE_STATIC) != SQLITE_OK) {
+        fprintf(stderr, "bind src FH failed: %s\n", sqlite3_errmsg(db));
+        goto out;
+    }
+
+    int rc = sqlite3_step(stmt);
+    if (rc == SQLITE_ROW) {
+        const void *data = sqlite3_column_blob(stmt, 0);
+        int n = sqlite3_column_bytes(stmt, 0);
+
+        if (n < 0 || n > sizeof(struct file_handle) + MAX_HANDLE_SZ) {
+            fprintf(stderr, "invalid size of dest filehandle: %d\n", n);
+            goto out;
+        }
+
+        dst_fh = malloc(n);
+        if (!dst_fh) {
+            fprintf(stderr, "out of memory");
+            goto out;
+        }
+
+        memcpy(dst_fh, data, n);
+
+        if (dst_fh->handle_bytes > MAX_HANDLE_SZ) {
+            fprintf(stderr, "invalid file handle returned: size too large: %u\n", dst_fh->handle_bytes);
+            free(dst_fh);
+            dst_fh = NULL;
+            goto out;
+        }
+    } else {
+        fprintf(stderr, "expected to get a row.\n");
+        goto out;
+    }
+
+out:
+    sqlite3_finalize(stmt);
+
+    return dst_fh;
+}
+
+static struct file_handle *get_fh(int dirfd, const char *path) {
+    int mount_id;
+
+    struct file_handle *fh = alloc_fh();
+    if (!fh)
+        return NULL;
+
+    int rc = name_to_handle_at(dirfd, path, fh, &mount_id, 0);
+    if (rc) {
+        fprintf(stderr, "name_to_handle_at() failed: %s\n", strerror(errno));
+        free(fh);
+        return NULL;
+    }
+
+    return fh;
+}
+
+int fh_db_insert_by_path(sqlite3 *db, char *src, char *dst) {
+    int ret = 0;
+    struct file_handle *src_fh = get_fh(AT_FDCWD, src);
+    struct file_handle *dst_fh = get_fh(AT_FDCWD, dst);
+
+    if (!src_fh || !dst_fh) {
+        ret = 1;
+        goto out;
+    }
+
+    if (fh_insert(db, file_handle_data(src_fh), file_handle_size(src_fh), dst_fh)) {
+        ret = 1;
+    }
+
+out:
+    free(src_fh);
+    free(dst_fh);
+
+    return ret;
+}
+
+/*
+ * Perform a rename in the index given the following information about a rename
+ * that occurred in the source FS:
+ *   - filehandles of old parent and new parent directory
+ *   - old name and new name
+ *
+ *  gufi_fd must be a file descriptor to a file in the GUFI index tree, most likely
+ *  the index root.
+ */
+int do_rename(struct fh_incremental_state *s, void *old_parent, size_t old_parent_len,
+              void *new_parent, size_t new_parent_len,
+              const char *oldpath, const char *newpath) {
+    int ret = 0;
+
+    struct file_handle *index_old = fh_lookup(s->fh_db, old_parent, old_parent_len);
+    if (!index_old) {
+        fprintf(stderr, "Could not look up old parent's handle in filehandle database.\n");
+        ret = 1;
+        goto out_free;
+    }
+    struct file_handle *index_new = fh_lookup(s->fh_db, new_parent, new_parent_len);
+    if (!index_new) {
+        fprintf(stderr, "Could not look up new parent's handle in filehandle database.\n");
+        ret = 1;
+        goto out_free;
+    }
+
+    int old_fd = open_by_handle_at(s->fh_mount_fd, index_old, O_PATH|O_DIRECTORY);
+    if (old_fd < 0) {
+        fprintf(stderr, "Could not open old parent file in index tree: %s\n", strerror(errno));
+        ret = 1;
+        goto out_free;
+    }
+
+    int new_fd = open_by_handle_at(s->fh_mount_fd, index_new, O_PATH|O_DIRECTORY);
+    if (new_fd < 0) {
+        fprintf(stderr, "Could not open new parent file in index tree: %s\n", strerror(errno));
+        ret = 1;
+        goto out_close;
+    }
+
+    if (renameat(old_fd, oldpath, new_fd, newpath)) {
+        fprintf(stderr, "Could not perform rename in index tree: %s\n", strerror(errno));
+        ret = 1;
+    }
+
+    close(new_fd);
+out_close:
+    close(old_fd);
+
+out_free:
+    free(index_old);
+    free(index_new);
+
+    return ret;
+}
+
+int do_mkdir(struct fh_incremental_state *s, void *parent, size_t parent_len,
+             void *child, size_t child_len, const char *name) {
+    int ret = 0;
+
+    struct file_handle *index_parent = fh_lookup(s->fh_db, parent, parent_len);
+    if (!index_parent) {
+        fprintf(stderr, "Could not look up parent directory's handle in filehandle database.\n");
+        return 1;
+    }
+
+    int fd = open_by_handle_at(s->fh_mount_fd, index_parent, O_PATH|O_DIRECTORY);
+    if (fd < 0) {
+        fprintf(stderr, "Could not open parent directory in index tree: %s\n", strerror(errno));
+        ret = 1;
+        goto out_free;
+    }
+
+    // TODO: need to fix up mode, ownership of new directory...
+    if (mkdirat(fd, name, 0644)) {
+        fprintf(stderr, "Could not perform mkdir in index tree: %s\n", strerror(errno));
+        ret = 1;
+        goto out;
+    }
+
+    // Update file handle index
+    struct file_handle *new_fh = get_fh(fd, name);
+    if (!new_fh) {
+        ret = 1;
+        goto out;
+    }
+
+    int rc = fh_insert(s->fh_db, child, child_len, new_fh);
+    if (rc) {
+        ret = 1;
+    }
+
+    free(new_fh);
+
+out:
+    close(fd);
+
+out_free:
+    free(index_parent);
+
+    return ret;
+}
+
+int do_rmdir(struct fh_incremental_state *s, void *parent, size_t parent_len,
+             void *child, size_t child_len, const char *name) {
+    int ret = 0;
+
+    struct file_handle *index_parent = fh_lookup(s->fh_db, parent, parent_len);
+    if (!index_parent) {
+        fprintf(stderr, "Could not look up parent directory's handle in filehandle database.\n");
+        return 1;
+    }
+
+    int fd = open_by_handle_at(s->fh_mount_fd, index_parent, O_PATH|O_DIRECTORY);
+    if (fd < 0) {
+        fprintf(stderr, "Could not open parent directory in index tree: %s\n", strerror(errno));
+        ret = 1;
+        goto out_free;
+    }
+
+    if (unlinkat(fd, name, AT_REMOVEDIR)) {
+        fprintf(stderr, "Could not perform rmdir in index tree: %s\n", strerror(errno));
+        ret = 1;
+        goto out;
+    }
+
+    ret = fh_delete(s->fh_db, child, child_len);
+
+out:
+    close(fd);
+
+out_free:
+    free(index_parent);
+
+    return ret;
+}

--- a/src/lustre_changelog_updater.c
+++ b/src/lustre_changelog_updater.c
@@ -1,0 +1,470 @@
+/*
+ * To build:
+ *
+ *     export LUSTRE_LIBRARY_DIR=/home/$USER/git/lustre-release/lustre/utils/.libs
+ *     export LUSTRE_INCLUDE_DIR=/home/$USER/git/lustre-release/lustre/include/
+ *     gcc -D_GNU_SOURCE -I$LUSTRE_INCLUDE_DIR -I$LUSTRE_INCLUDE_DIR/uapi/ -L$LUSTRE_LIBRARY_DIR -llustreapi changelog_reader.c
+ *
+ * To run:
+ *
+ *     export LD_LIBRARY_PATH=$LUSTRE_LIBRARY_DIR
+ *     ./a.out
+ *
+ */
+
+#include <stdio.h>
+#include <getopt.h>
+#include <pthread.h>
+
+#include "lustre/lustreapi.h"
+
+#include "incremental_non_path.h"
+
+static void usage(const char *prog_name) {
+    fprintf(stderr, "Usage: %s --gufi-root GUFI_ROOT --consumer CONSUMER...\n", prog_name);
+    fprintf(stderr, "\t\tCONSUMER format: \"<MDT_NAME>:<CONSUMER_ID>\". Example: \"lustre-MDT0000:cl1\"\n");
+
+    exit(1);
+}
+
+/* Halt the program if malloc() fails. */
+static void oom(void) {
+    fprintf(stderr, "Out of memory.");
+    exit(1);
+}
+
+/*
+ * This holds the information needed to consume changelog records from a single MDT.
+ */
+struct changelog_client {
+    char *mdt_name;         /* e.g., 'lustre-MDT0000' */
+    char *consumer_name;    /* e.g., 'cl1' */
+};
+
+#define MAX_MDTS 64     /* Hardcoded limit; increase if this runs on an FS with more. */
+
+/*
+ * Expects a string with the lustre MDT name and changelog consumer name
+ * separated by a colon.
+ *
+ * For example: "lustre-MDT0000:cl1" -> { "lustre-MDT0000", "cl1" }
+ */
+static struct changelog_client parse_changelog_client(char *s, const char *prog_name) {
+    char *sep = strchr(s, ':');
+
+    if (!sep) {
+        fprintf(stderr, "Could not parse changelog consumer '%s'.\n", s);
+        usage(prog_name);
+    }
+
+    *sep = '\0';
+
+    struct changelog_client new = { NULL };
+
+    new.mdt_name = strdup(s);
+    sep++;
+    new.consumer_name = strdup(sep);
+
+    return new;
+}
+
+static struct {
+    /*
+     * An array of changelog clients, one for each MDT that this program should query.
+     */
+    int num_clients;    /* Number of entries in the changelog_clients array. */
+    struct changelog_client changelog_clients[MAX_MDTS];
+
+    char *gufi_root;    /* Root of the GUFI index tree. */
+
+    /* State used by FH incremental API. */
+    struct fh_incremental_state incremental_state;
+} args = { 0 };
+
+int parse_args(int argc, char *argv[])
+{
+    int opt;
+
+    static struct option long_options[] = {
+        {"consumer", required_argument, 0, 'c'},
+        {"gufi-root", required_argument, 0, 1},
+        {"help",     no_argument,       0, 'h'},
+        {0, 0, 0, 0}
+    };
+
+    while ((opt = getopt_long(argc, argv, "c:h", long_options, NULL)) != -1) {
+        switch (opt) {
+            case 'c':
+                if (args.num_clients >= MAX_MDTS) {
+                    fprintf(stderr, "Too many changelog consumers specified. (Max: %d)\n", MAX_MDTS);
+                    usage(argv[0]);
+                }
+                args.changelog_clients[args.num_clients++] = parse_changelog_client(optarg, argv[0]);
+                break;
+            case 1:
+                args.gufi_root = optarg;
+                break;
+            case 'h':
+                usage(argv[0]);
+            default:
+                usage(argv[0]);
+        }
+    }
+
+    if (args.num_clients == 0) {
+        fprintf(stderr, "Specify at least one changelog consumer.\n");
+        usage(argv[0]);
+    }
+
+    if (!args.gufi_root) {
+        fprintf(stderr, "Must specify root of GUFI index tree.\n");
+        usage(argv[0]);
+    }
+
+    return 0;
+}
+
+enum record_type {
+    REC_PARENT,     /* Any change that simply requires recreating a directory's index. */
+    REC_MKDIR,      /* Creation of a new node in the index tree. */
+    REC_RENAME,     /* Moving a node in the index tree. */
+    REC_RMDIR,      /* Remove a node in the index tree. */
+};
+
+struct record {
+    uint8_t type;               /* enum record_type */
+
+    uint64_t timestamp;         /* Record timestamp in Lustre "packed" format. */
+
+    struct lu_fid parent;       /* Parent directory of the object modified */
+    char *name;                 /* Name of the object that was created or deleted */
+
+    union {
+        struct lu_fid old_parent;   /* For rename - this is the OLD parent */
+        struct lu_fid child;        /* for mkdir, rmdir records - the FID of the target object */
+    };
+
+    char *old_name;             /* Only set for rename: OLD name of object */
+};
+
+/*
+ * Extract the seconds from a Lustre packed timestamp.
+ * See man 3 llapi_changelog_recv for details on the format.
+ * The seconds are stored in the top 34 bits, nanoseconds in the bottom 30 bits.
+ */
+static uint64_t get_seconds(uint64_t lustre_packed_timestamp) {
+    return lustre_packed_timestamp >> 30;
+}
+
+static uint64_t get_nanoseconds(uint64_t lustre_packed_timestamp) {
+    const uint64_t nanoseconds_mask = (1ULL << 30) - 1;
+
+    return lustre_packed_timestamp & nanoseconds_mask;
+}
+
+/* NB: Not thread safe due to static buf... */
+static char *format_fid_as_bytes(struct lu_fid *fid) {
+#define BUF_SIZE 4096
+    static char buf[BUF_SIZE];
+
+    memset(buf, 0, sizeof buf);
+
+    size_t s = 0;
+    s += snprintf(buf, BUF_SIZE, "0x");
+
+    unsigned char *p = (unsigned char *) fid;
+
+    for (size_t i = 0; i < sizeof(*fid); i++) {
+        s += snprintf(&buf[s], BUF_SIZE, "%x", p[i]);
+    }
+
+    return buf;
+}
+
+static void dump_record(struct record *rec) {
+    char *type;
+    switch (rec->type) {
+    case REC_PARENT:
+        type = "PARENT";
+        break;
+    case REC_MKDIR:
+        type = "MKDIR";
+        break;
+    case REC_RENAME:
+        type = "RENAME";
+        break;
+    case REC_RMDIR:
+        type = "RMDIR";
+    }
+
+    printf("%llu.%llu: %s\tpfid=%s\tname='%s', old_name='%s'\n",
+            get_seconds(rec->timestamp), get_nanoseconds(rec->timestamp),
+            type, format_fid_as_bytes(&rec->parent),
+            rec->name ? rec->name : "",
+            rec->old_name ? rec->old_name : "");
+}
+
+struct record_array {
+    size_t len;                 /* Index of the last used slot. */
+    size_t capacity;            /* Available slots. */
+    struct record *records;     /* Pointer to the records. */
+};
+
+/*
+ * Initialize a struct record_array, giving it a reasonably sized initial capacity.
+ */
+static void record_array_initialize(struct record_array *recs) {
+    const size_t initial_capacity = 1024;
+
+    recs->records = calloc(initial_capacity, sizeof *(recs->records));
+    if (!recs->records)
+        oom();
+
+    recs->len = 0;
+    recs->capacity = initial_capacity;
+}
+
+/*
+ * Push a new record to the end of a record_array.
+ * Doubles the capacity if there are no more empty slots at the end.
+ */
+static void record_array_push(struct record_array *recs, struct record new) {
+    if (recs->len >= recs->capacity) {
+        struct record *new = reallocarray(recs->records, recs->capacity * 2, sizeof *(recs->records));
+        if (!new)
+            oom();
+
+        recs->records = new;
+        recs->capacity *= 2;
+    }
+
+    recs->records[recs->len] = new;
+    recs->len++;
+}
+
+/*
+ * Look up a record in a record_array.
+ */
+struct record *record_array_get(struct record_array *recs, size_t index) {
+    if (index > recs->capacity || index > recs->len) {
+        fprintf(stderr, "BUG: invalid index %llu (cap: %llu, len: %llu)\n",
+                index, recs->capacity, recs->len);
+        exit(1);
+    }
+
+    return &recs->records[index];
+}
+
+/*
+ * Re-initialize a record_array, but without re-allocating the underlying memory.
+ */
+static void record_array_reset(struct record_array *recs) {
+    recs->len = 0;
+    memset(recs->records, 0, sizeof *(recs->records) * recs->capacity);
+}
+
+/* The state of a consumer of one MDT. */
+struct one_mdt_state {
+    struct changelog_client *client;    /* The consumer identity for this MDT. */
+    struct record_array records;        /* Changelog records that this consumer has read. */
+    void *changelog_priv;               /* Private data passed to the lustre changelog functions. */
+};
+
+/*
+ * Read the changelog records from a single MDT.
+ * Store the ones we care about in a `struct record_array`.
+ */
+void *get_records_one_mdt(void *data) {
+    struct one_mdt_state *state = (struct one_mdt_state *) data;
+    int rc;
+
+    struct changelog_rec *received;
+    while ((rc = llapi_changelog_recv(state->changelog_priv, &received)) == 0) {
+        struct record my_rec = { 0 };
+
+        __u32 type = received->cr_type;
+
+        my_rec.parent = received->cr_pfid;
+        my_rec.timestamp = received->cr_time;
+
+        switch (received->cr_type) {
+        case CL_MKDIR:
+            my_rec.type = REC_MKDIR;
+            my_rec.name = strdup(changelog_rec_name(received));
+            my_rec.child = received->cr_tfid;
+            break;
+        case CL_RENAME:
+            my_rec.type = REC_RENAME;
+            my_rec.name = strdup(changelog_rec_name(received));
+            my_rec.old_name = strdup(changelog_rec_sname(received));
+            struct changelog_ext_rename *rename_metadata = changelog_rec_rename(received);
+            my_rec.old_parent = rename_metadata->cr_spfid;
+            break;
+        case CL_RMDIR:
+            my_rec.type = REC_RMDIR;
+            my_rec.name = strdup(changelog_rec_name(received));
+            my_rec.child = received->cr_tfid;
+            break;
+        case CL_CREATE:
+        case CL_MKNOD:
+            my_rec.type = REC_PARENT;
+            break;
+        default:
+            /* Don't care about any other record types that we might receive... */
+            goto skip;
+        }
+
+        record_array_push(&state->records, my_rec);
+skip:
+        ; /* Continue on to next loop iteration. */
+    }
+
+    printf("done receiving records, rc = %d\n", rc);
+    // TODO: return an error status somehow, if llapi_changelog_recv() failed?
+    return NULL;
+}
+
+/*
+ * Get the earliest record from the collection of records in `state`.
+ * `indexes` points to the next unconsumed record in each array in `state`.
+ *
+ * Returns NULL if there are no more unconsumed records.
+ */
+struct record *get_next_record(size_t indexes[], struct one_mdt_state state[MAX_MDTS]) {
+    struct record *p = NULL;
+    size_t increment_index = 0;
+
+    for (int i = 0; i < args.num_clients; i++) {
+        /* If we've already consumed every record from this array, skip it: */
+        if (indexes[i] >= state[i].records.len)
+            continue;
+
+        /* If this is the first array with an un-consumed record, initialize p: */
+        if (!p) {
+            p = record_array_get(&state[i].records, indexes[i]);
+            increment_index = i;
+            continue;
+        }
+
+        /* Otherwise, compare this un-consumed record with a previously-checked record: */
+        struct record *q = record_array_get(&state[i].records, indexes[i]);
+        if (q->timestamp < p->timestamp) {
+            p = q;
+            increment_index = i;
+        }
+    }
+
+    if (p) {
+        indexes[increment_index]++;
+    }
+
+    return p;
+}
+
+void process_records(struct one_mdt_state state[MAX_MDTS]) {
+    size_t indexes[MAX_MDTS] = { 0 };
+
+    struct record *rec;
+    int rc;
+    while (rec = get_next_record(indexes, state)) {
+        dump_record(rec);
+
+        switch (rec->type) {
+        case REC_MKDIR:
+            rc = do_mkdir(&args.incremental_state, (void *) &rec->parent, sizeof rec->parent,
+                          (void *) &rec->child, sizeof rec->child, rec->name);
+            if (rc) {
+                return;
+            }
+            break;
+        case REC_RENAME:
+            rc = do_rename(&args.incremental_state, (void *) &rec->old_parent, sizeof rec->old_parent,
+                           (void *) &rec->parent, sizeof rec->parent, rec->old_name, rec->name);
+            if (rc) {
+                return;
+            }
+            break;
+        case REC_RMDIR:
+            rc = do_rmdir(&args.incremental_state, (void *) &rec->parent, sizeof rec->parent,
+                          (void *) &rec->child, sizeof rec->child, rec->name);
+            if (rc) {
+                return;
+            }
+            break;
+        default:
+            break;
+        }
+    }
+}
+
+void main_loop(void) {
+    long long startrec = 0;
+    int rc;
+
+    pthread_t threads[MAX_MDTS] = { 0 };
+    struct one_mdt_state state[MAX_MDTS] = { 0 };
+
+    /* Initialize each MDT consumer's per-consumer state: */
+    for (int i = 0; i < args.num_clients; i++) {
+        state[i].client = &args.changelog_clients[i];
+
+        record_array_initialize(&state[i].records);
+
+        rc = llapi_changelog_start(&state[i].changelog_priv,
+                       CHANGELOG_FLAG_JOBID |
+                       CHANGELOG_FLAG_EXTRA_FLAGS,
+                       args.changelog_clients[i].mdt_name, startrec);
+        if (rc < 0) {
+            fprintf(stderr, "error starting changelog: %s\n", strerror(-rc));
+            return;
+        }
+    }
+
+    /*
+     * Main loop logic:
+     *   - launch a thread for each consumer
+     *   - wait for them to collect a number of records
+     *   - join each thread
+     *   - process all of the collected records together in chronological order
+     */
+    while (1) {
+        for (int i = 0; i < args.num_clients; i++) {
+            record_array_reset(&state[i].records);
+            pthread_create(&threads[i], NULL, get_records_one_mdt, &state[i]);
+        }
+
+        for (int i = 0; i < args.num_clients; i++) {
+            int rc = pthread_join(threads[i], NULL);
+            // TODO: handle error joining? check for errors that occurred in get_records_one_mdt()?
+        }
+
+        process_records(state);
+
+        break;
+    }
+
+    for (int i = 0; i < args.num_clients; i++) {
+        llapi_changelog_fini(&state[i].changelog_priv);
+    }
+}
+
+int main(int argc, char *argv[])
+{
+    void *changelog_priv;
+    long long startrec = 0;
+
+    if (parse_args(argc, argv)) {
+        return EXIT_FAILURE;
+    }
+
+    sqlite3_initialize();
+
+    args.incremental_state = open_incremental_state(args.gufi_root);
+
+    main_loop();
+
+    close_incremental_state(args.incremental_state);
+
+    /* main_loop() is never supposed to exit unless an error occurs... */
+    return EXIT_FAILURE;
+}


### PR DESCRIPTION
This implements file-handle based incremental updates for GUFI using Lustre changleogs. The principle is to use the FIDs in the changelog record to do a targeted update to the GUFI tree without requiring treewalks or reverse-pathname-resolution to turn the FID into a path. This is accomplished by mapping Lustre FIDs to GUFI filehandles in a sqlite3 database.

See `docs/file_handle_based_incrementals.md` for a full explanation.

This is just a proof of concept at this point. I'm uploading it for the sake of getting early feedback.

Required features that still need to be implemented:

- [ ] Create/update the GUFI `db.db` files in new / modified directories. (So far this just does the tree / namespace modifications, which is the "hard part". It doesn't actually update the GUFI sqlite indexes, the "easy part").
- [ ] Clear Lustre changelog entries after they are processed. Currently this doesn't do this so when testing this code, you have to manually clear the Lustre changelog entries
- [ ] Create some way of storing persistent information on which changelog entries have been processed so that if this process crashes, it can pick up where it left off without missing changes or duplicating changes
- [ ] Use connectable filehandles to make rename more reliable (see docs for details)
- [ ] Test cross-MDS updates to see if ordering issues happen in practice. If so, implement an algorithm to try re-ordering changelog records in cases where out-of-order records result in problems. (I really hope this doesn't end up being a problem in practice as long as MDS clocks are kept closely synchronized)
- [ ] Test this on other source filesystems besides Lustre? The API presented here works for Lustre but might need modifications to be suitable for other FS types, like scoutFS for example