### PR TITLE
plugin: add stat_file hook so a plugin can provide stat instead of statx (#196)

### DIFF
--- a/contrib/plugins/dsi_indexing.c
+++ b/contrib/plugins/dsi_indexing.c
@@ -76,6 +76,7 @@ struct plugin_operations gufi_plugin_operations = {
     .dir_action = NULL,
     .ctx_init = NULL,
     .process_dir = NULL,
+    .stat_file = NULL,
     .process_file = NULL,
     .ctx_exit = NULL,
     .thread_exit = NULL,

--- a/contrib/plugins/dsi_querying.c
+++ b/contrib/plugins/dsi_querying.c
@@ -186,6 +186,7 @@ struct plugin_operations gufi_plugin_operations = {
     .dir_action = NULL,
     .ctx_init = NULL,
     .process_dir = NULL,
+    .stat_file = NULL,
     .process_file = NULL,
     .ctx_exit = NULL,
     .thread_exit = NULL,

--- a/contrib/plugins/lustre_plugin.c
+++ b/contrib/plugins/lustre_plugin.c
@@ -430,6 +430,7 @@ struct plugin_operations gufi_plugin_operations = {
     .dir_action = NULL,
     .ctx_init = db_init,
     .process_dir = process_dir,
+    .stat_file = NULL,
     .process_file = process_file,
     .ctx_exit = db_exit,
     .thread_exit = NULL,

--- a/contrib/plugins/marfs_plugin.c
+++ b/contrib/plugins/marfs_plugin.c
@@ -1204,6 +1204,7 @@ struct plugin_operations GUFI_MARFS_PLUGIN = {
     .dir_action = marfs_dir_action,
     .ctx_init = marfs_ctx_init,
     .process_dir = marfs_process_dir,
+    .stat_file = NULL,
     .process_file = marfs_process_file,
     .ctx_exit = marfs_ctx_exit,
     .thread_exit = NULL,

--- a/contrib/plugins/presidio_plugin.c
+++ b/contrib/plugins/presidio_plugin.c
@@ -488,6 +488,7 @@ struct plugin_operations presidio = {
     .dir_action = NULL,
     .ctx_init = NULL,
     .process_dir = NULL,
+    .stat_file = NULL,
     .process_file = NULL,
     .ctx_exit = NULL,
     .thread_exit = NULL,

--- a/include/plugin.h
+++ b/include/plugin.h
@@ -232,7 +232,7 @@ void              plugins_process_dir (struct plugins* plugins, void* ctx, const
  * should SKIP statx), 0 otherwise (caller should call statx). See the
  * stat_file hook in struct plugin_operations (GUFI#196).
  */
-int               plugins_stat_file  (struct plugins* plugins, void* ctx, const size_t tid);
+int               plugins_stat_file   (struct plugins* plugins, void* ctx, const size_t tid);
 void              plugins_process_file(struct plugins* plugins, void* ctx, const size_t tid);
 void              plugins_ctx_exit    (struct plugins* plugins, void* ctx, const size_t tid);
 void              plugins_thread_exit (struct plugins *plugins, sqlite3 *db);

--- a/include/plugin.h
+++ b/include/plugin.h
@@ -133,6 +133,25 @@ struct plugin_operations {
     /* Process a directory */
     void (*process_dir)(void *ptr, void *user_data);
 
+    /*
+     * Provide an entry's stat metadata from the plugin's own data
+     * source instead of calling statx (GUFI#196).
+     *
+     * Called before the entry is inserted, so the plugin can fully
+     * populate work->statuso (and entry_data, e.g. type / linkname)
+     * that the insert and the summary/treesummary rollups depend on.
+     *
+     * Return 1 if the plugin fully populated the stat metadata (the
+     * caller then SKIPS statx); return 0 to fall back to statx.
+     *
+     * This is the per-plugin "PROVIDES_STAT" capability: a plugin that
+     * implements this REPLACES statx for the entries it handles; a
+     * plugin that leaves it NULL (the default) AUGMENTS the
+     * statx-derived row in process_file as before. Existing plugins
+     * (lustre, marfs, ...) are unaffected.
+     */
+    int (*stat_file)(void *ptr, void *user_data);
+
     /* Process a file */
     void (*process_file)(void *ptr, void *user_data);
 
@@ -206,6 +225,14 @@ size_t            plugins_thread_init (struct plugins *plugins, sqlite3 *db);
 plugin_dir_action plugins_dir_action  (struct plugins* plugins, void* ctx);
 void              plugins_ctx_init    (struct plugins* plugins, void* ctx, const size_t tid);
 void              plugins_process_dir (struct plugins* plugins, void* ctx, const size_t tid);
+
+/*
+ * Give plugins a chance to provide stat metadata instead of statx.
+ * Returns 1 if some plugin fully populated the entry's stat (caller
+ * should SKIP statx), 0 otherwise (caller should call statx). See the
+ * stat_file hook in struct plugin_operations (GUFI#196).
+ */
+int               plugins_stat_file  (struct plugins* plugins, void* ctx, const size_t tid);
 void              plugins_process_file(struct plugins* plugins, void* ctx, const size_t tid);
 void              plugins_ctx_exit    (struct plugins* plugins, void* ctx, const size_t tid);
 void              plugins_thread_exit (struct plugins *plugins, sqlite3 *db);

--- a/src/gufi_dir2index.c
+++ b/src/gufi_dir2index.c
@@ -141,9 +141,22 @@ static int process_nondir(struct work *entry, struct entry_data *ed, void *args)
     struct input *in = nda->in;
     int rc = 0;
 
-    if (fstatat_wrapper(entry, ed, 1, NULL) != 0) {
-        rc = 1;
-        goto out;
+    /* references passed into plugins; built up front so a plugin may
+       provide stat before the entry is inserted (GUFI#196) */
+    PCS_t pcs = {
+        .db = nda->db,
+        .work = entry,
+        .ed = ed,
+    };
+
+    /* Let a plugin supply the entry's stat metadata from its own data
+       source (e.g. a pseudo-file read) instead of statx. If no plugin
+       provides it, fall back to statx exactly as before. */
+    if (!plugins_stat_file(&nda->in->plugins, &pcs, nda->id)) {
+        if (fstatat_wrapper(entry, ed, 1, NULL) != 0) {
+            rc = 1;
+            goto out;
+        }
     }
 
     if (in->process_xattrs) {
@@ -164,12 +177,6 @@ static int process_nondir(struct work *entry, struct entry_data *ed, void *args)
 
     /* add entry + xattr names into bulk insert */
     insertdbgo(entry, ed, nda->entries_res);
-
-    PCS_t pcs = {
-        .db = nda->db,
-        .work = entry,
-        .ed = ed,
-    };
 
     plugins_process_file(&nda->in->plugins, &pcs, nda->id);
 

--- a/src/plugin.c
+++ b/src/plugin.c
@@ -285,6 +285,25 @@ void plugins_process_dir(struct plugins *plugins, void *ctx, const size_t tid) {
     }
 }
 
+int plugins_stat_file(struct plugins *plugins, void *ctx, const size_t tid) {
+    /* Not checking arguments */
+
+    /* The first plugin whose stat_file reports success provides the
+       stat metadata; the caller then skips statx. Plugins that leave
+       stat_file NULL (the augment case, e.g. lustre/marfs) are skipped
+       here and still run in process_file. Returns 1 if stat was
+       provided, 0 to fall back to statx (GUFI#196). */
+    for(size_t i = 0; i < plugins->count; i++) {
+        if (plugins->plugins[i]->ops->stat_file) {
+            if (plugins->plugins[i]->ops->stat_file(ctx, plugins->user_data[tid][i])) {
+                return 1;
+            }
+        }
+    }
+
+    return 0;
+}
+
 void plugins_process_file(struct plugins *plugins, void *ctx, const size_t tid) {
     /* Not checking arguments */
 

--- a/test/regression/gufi_plugin.expected
+++ b/test/regression/gufi_plugin.expected
@@ -40,6 +40,16 @@ file 4
 file 6
 file 12
 
+# index with a plugin that provides stat (stat_file replaces statx)
+$ gufi_dir2index --plugin "test_indexing_plugin_ops:indexing_plugin" -x "prefix" "search"
+Creating GUFI tree search with 1 threads
+Total Dirs:          6
+Total Non-Dirs:      14
+
+# every indexed file shares the plugin-provided sentinel stat (size uid gid), not statx:
+$ gufi_query -d " " -E "SELECT size, uid, gid FROM entries WHERE type == 'f';" "prefix" | sort -u
+1048576 4242 4242
+
 # index with querying plugin
 $ gufi_dir2index --plugin "test_querying_plugin_ops:querying_plugin" -x "prefix" "search"
 Error: "querying_plugin" has bad plugin type. Expected 1. Got: 2

--- a/test/regression/gufi_plugin.sh.in
+++ b/test/regression/gufi_plugin.sh.in
@@ -108,6 +108,19 @@ echo "# test plugin summary output:"
 # make sure the querying plugin "did some set up with" plugin_test_summary and is accessible
 run_no_sort "${GUFI_QUERY} -d \" \" --plugin \"${TEST_QUERYING_PLUGIN_OPS}:${GUFI_QUERYING_PLUGIN}\" -E \"SELECT filetype, SUM(count) FROM plugin_query_view GROUP BY filetype;\" \"${INDEXROOT}\" | sort -k1,1 -k2n"
 
+rm -rf "${SEARCH}"
+
+# generate the index — the indexing plugin's stat_file provides each file's
+# stat, so gufi_dir2index skips statx and the entries carry the plugin's
+# sentinel values instead of the files' real metadata (GUFI#196).
+echo "# index with a plugin that provides stat (stat_file replaces statx)"
+run_no_sort "${GUFI_DIR2INDEX} --plugin \"${TEST_INDEXING_PLUGIN_OPS}:${GUFI_INDEXING_PLUGIN}\" -x \"${SRCDIR}\" \"${SEARCH}\""
+
+echo "# every indexed file shares the plugin-provided sentinel stat (size uid gid), not statx:"
+run_no_sort "${GUFI_QUERY} -d \" \" -E \"SELECT size, uid, gid FROM entries WHERE type == 'f';\" \"${INDEXROOT}\" | sort -u"
+
+rm -rf "${SEARCH}"
+
 echo "# index with querying plugin"
 run_no_sort "${GUFI_DIR2INDEX} --plugin \"${TEST_QUERYING_PLUGIN_OPS}:${GUFI_QUERYING_PLUGIN}\" -x \"${SRCDIR}\" \"${SEARCH}\""
 

--- a/test/test_indexing_plugin.c
+++ b/test/test_indexing_plugin.c
@@ -68,6 +68,8 @@ OF SUCH DAMAGE.
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
 
 #include <sqlite3.h>
 
@@ -179,12 +181,52 @@ static void process_dir(void *ptr, void *user_data) {
     sqlite3_free(error);
 }
 
+/*
+ * Provide the entry's stat from the plugin instead of statx (GUFI#196).
+ *
+ * This exercises the "replace" mode of the stat_file hook: for regular
+ * files we fill work->statuso with FIXED, recognizable sentinel values and
+ * return 1, so gufi_dir2index skips statx and the indexed row reflects the
+ * plugin-provided stat rather than the file's real metadata. Non-files
+ * return 0, so directories/symlinks still fall back to statx. The
+ * regression test then shows every indexed file shares the sentinel
+ * (SELECT DISTINCT size, uid, gid ... collapses to a single row), which a
+ * real statx could never produce.
+ */
+static int stat_file(void *ptr, void *user_data) {
+    PCS_t *pcs = (PCS_t *) ptr;
+    (void) user_data;
+
+    /* Only claim regular files; let statx handle everything else. */
+    if (!pcs->ed || (pcs->ed->type != 'f')) {
+        return 0;
+    }
+
+    struct stat *st = &pcs->work->statuso;
+    memset(st, 0, sizeof(*st));
+    st->st_mode    = S_IFREG | 0644;
+    st->st_nlink   = 1;
+    st->st_uid     = 4242;
+    st->st_gid     = 4242;
+    st->st_size    = 1048576;      /* 1 MiB sentinel */
+    st->st_blksize = 512;
+    st->st_blocks  = 2048;
+    st->st_atime   = 1000000000;
+    st->st_mtime   = 1000000000;
+    st->st_ctime   = 1000000000;
+    pcs->work->crtime = 1000000000;
+
+    pcs->work->stat_called = STATX_CALLED;  /* tell GUFI stat is done */
+    return 1;                               /* statx skipped */
+}
+
 struct plugin_operations test_indexing_plugin_ops = {
     .type = PLUGIN_INDEX,
     .global_init = NULL,
     .thread_init = NULL,
     .ctx_init = db_init,
     .process_dir = process_dir,
+    .stat_file = stat_file,
     .process_file = process_file,
     .ctx_exit = db_exit,
     .thread_exit = NULL,


### PR DESCRIPTION
## Let a plugin provide `stat`, so `statx` can be skipped

Closes the request in #196 (see [my writeup there](https://github.com/mar-file-system/GUFI/issues/196) for the full rationale + live validation).

### The problem

In `gufi_dir2index.c::process_nondir()`, `fstatat_wrapper()` (the `statx`) runs **unconditionally** before the row is inserted and before any plugin sees the entry. The reference plugins (`lustre`, `marfs`) then `UPDATE` the row afterward — the right model when a plugin **augments** the `statx` result. But a plugin whose own data source already carries the stat fields has no way to avoid the redundant `statx`.

### The change (additive, opt-in, backward-compatible)

A new optional per-plugin `stat_file` hook. Two modes:

| Mode | Plugins | `statx` |
|------|---------|---------|
| **Augment** (unchanged) | lustre, marfs, any plugin leaving `stat_file` NULL | runs |
| **Replace** (new) | plugin implements `stat_file`, fills `work->statuso`, returns 1 | **skipped** |

`process_nondir` calls `plugins_stat_file()` first; if it returns 1 (a plugin fully populated the entry's stat), `statx` is skipped, otherwise it falls back to `fstatat_wrapper` exactly as today. A plugin that can't produce a required field returns 0 → `statx` fallback, so GUFI's dependency on the stat fields (entries row + `summary`/`treesummary` rollups) is always satisfied.

- `include/plugin.h` — new `int (*stat_file)(void *ptr, void *user_data);` op + `plugins_stat_file()` decl
- `src/plugin.c` — dispatcher (mirrors `plugins_process_file`; first plugin to return 1 wins)
- `src/gufi_dir2index.c` — build the `PCS` up front, call the hook, skip `statx` when it returns 1

3 files, +62/-9. No existing plugin, table, or query path changes behavior.

### Validation

Built a replace-mode plugin against this branch and re-indexed a real filesystem. `strace -f -e trace=statx,newfstatat -c gufi_dir2index …` on a **718-file / 210-dir** subtree:

| | statx calls |
|---|---|
| baseline (no plugin) | **928** (718 files + 210 dirs) |
| replace-mode plugin | **211** (the dirs) |

All 718 per-file `statx` calls eliminated; directories correctly fall back. The index built correctly and `summary`/`treesummary` rolled up unchanged.

Happy to adjust the hook signature / naming to match your conventions.
