### PR TITLE
Marfs indexing from non-sec-root

### DIFF
--- a/contrib/plugins/marfs_plugin.c
+++ b/contrib/plugins/marfs_plugin.c
@@ -425,13 +425,15 @@ static int validate_sec_root(void) {
     if (!g_state.namespaces || g_state.namespaces_count == 0) goto cleanup;
 
     // check if MDAL_subspaces exists under the target dir
-    len = snprintf(NULL, 0, "%s/%s", g_state.root_namespace.data, MARFS_SUBSPACES_NAME);
+    len = snprintf(NULL, 0, "%.*s/%s", (int)g_state.root_namespace.len, g_state.root_namespace.data,
+                   MARFS_SUBSPACES_NAME);
     if (len < 0) goto cleanup;
 
     path = malloc((size_t)len + 1);
     if (!path) goto cleanup;
 
-    snprintf(path, (size_t)len + 1, "%s/%s", g_state.root_namespace.data, MARFS_SUBSPACES_NAME);
+    snprintf(path, (size_t)len + 1, "%.*s/%s", (int)g_state.root_namespace.len, g_state.root_namespace.data,
+             MARFS_SUBSPACES_NAME);
 
     if (stat(path, &st) != 0 || !S_ISDIR(st.st_mode)) goto cleanup;
 
@@ -934,7 +936,7 @@ static plugin_file_action marfs_pre_process_file(void* ptr, void* user_data) {
     }
 
     // remove mdal specific files
-    if (basename.len >= MARFS_PREFIX_LEN && starts_with_mdal(basename)) {
+    if (starts_with_mdal(basename)) {
         // this files starts with MDAL_
 
         const str_t parent = get_parent(path);
@@ -1002,7 +1004,6 @@ static void marfs_post_process_dir(void* ptr, void* user_data) {
         return;
     }
 
-    const str_t path = REFSTR(pcs->work->name, pcs->work->name_len);
     const str_t basename =
         REFSTR(pcs->work->name + pcs->work->name_len - pcs->work->basename_len, pcs->work->basename_len);
     const str_t mountpoint = get_basename(g_state.marfs_mountpoint);

--- a/contrib/plugins/marfs_plugin.c
+++ b/contrib/plugins/marfs_plugin.c
@@ -669,7 +669,6 @@ static int revert_marfs_index(void) {
     // loop through our index namespaces and add a subspaces into them. then move them down into each subspace
     for (size_t i = 0; i < g_state.namespaces_count; i++) {
         const str_t old = g_state.namespaces[i].index_namespace;
-        if (!old.data || old.len == 0) continue;
 
         const str_t basename = get_basename(old);
         const str_t parent = get_parent(old);
@@ -863,18 +862,6 @@ static int is_namespace(str_t path) {
 // sec-root and configured namespaces are the directories that own MDAL metadata
 static int is_mdal_owner(str_t path) { return path_eq(path, g_state.root_namespace) || is_namespace(path); }
 
-// check whether a namespace will be moved out of MDAL_subspaces in this index
-static int namespace_is_rewritten(str_t path) {
-    for (size_t i = 0; i < g_state.namespaces_count; i++) {
-        namespace_pair* pair = &g_state.namespaces[i];
-        if (path_eq(pair->namespace, path)) {
-            return pair->index_namespace.data && pair->index_namespace.len > 0;
-        }
-    }
-
-    return 0;
-}
-
 // marfs_pre_processing_dir checks if we're about to process a marfs specific directory (MDAL_reference, MDAL_subspaces)
 // or a namespace that is no longer active in the marfs config
 static plugin_dir_action marfs_dir_action(void* ptr) {
@@ -1037,8 +1024,8 @@ static void marfs_pre_process_dir(void* ptr, void* user_data) {
 
     // Fix pinode for directories whose parent is MDAL_subspaces (which will be removed)
     // The pinode currently points to the MDAL_subspaces inode, but should point to the grandparent
-    if (parent_basename.data && str_t_eq_cstr(parent_basename, MARFS_SUBSPACES_NAME, MARFS_SUBSPACES_NAME_LEN) &&
-        namespace_is_rewritten(path)) {
+    if (str_t_eq_cstr(parent_basename, MARFS_SUBSPACES_NAME, MARFS_SUBSPACES_NAME_LEN) && is_namespace(path) &&
+        !path_eq(path, g_state.source)) {
         const str_t grandparent = get_parent(parent);
 
         if (grandparent.data && grandparent.len > 0) {

--- a/contrib/plugins/marfs_plugin.c
+++ b/contrib/plugins/marfs_plugin.c
@@ -275,15 +275,6 @@ static str_t get_relative_path(str_t path, str_t root) {
     return (str_t)REFSTR(path.data + root.len + 1, path.len - root.len - 1);
 }
 
-static str_t get_first_component(str_t path) {
-    if (!path.data || path.len == 0) return (str_t)REFSTR(NULL, 0);
-
-    size_t len = 0;
-    while (len < path.len && path.data[len] != '/') len++;
-
-    return (str_t)REFSTR(path.data, len);
-}
-
 struct marfs_plugin {
     namespace_pair* namespaces;
     size_t namespaces_count;
@@ -491,7 +482,7 @@ static int validate_source(void) {
 
     if (!path_eq(g_state.source, owner)) {
         const str_t relative = get_relative_path(g_state.source, owner);
-        if (starts_with_mdal(get_first_component(relative))) {
+        if (starts_with_mdal(relative)) {
             fprintf(stderr, "Error: source (%s) is inside a MarFS internal directory\n", g_state.source.data);
             return 0;
         }
@@ -509,7 +500,6 @@ static int cleanup_marfs_index(void) {
     // loop through our index namespaces and move them up a directory and delete the unecessary MDAL_subspaces
     for (size_t i = g_state.namespaces_count; i-- > 0;) {
         const str_t old = g_state.namespaces[i].index_namespace;
-        if (!str_exists(&old)) continue;
 
         const str_t basename = get_basename(old);
         const str_t parent = get_parent(old);

--- a/contrib/plugins/marfs_plugin.c
+++ b/contrib/plugins/marfs_plugin.c
@@ -279,6 +279,8 @@ struct marfs_plugin {
     str_t root_namespace;
     str_t source;
 
+    int source_is_root;
+
     marfs_config* marfs_cfg;
 };
 
@@ -578,7 +580,7 @@ static int cleanup_marfs_index(void) {
     }
 
     // rename the root namespace to the marfs mountpoint from the marfs config
-    if (path_eq(g_state.source, g_state.root_namespace)) {
+    if (g_state.source_is_root) {
         const str_t rn_base = get_basename(g_state.root_namespace);
         const str_t mm_base = get_basename(g_state.marfs_mountpoint);
 
@@ -612,7 +614,7 @@ static int revert_marfs_index(void) {
     int ret = 0;
 
     // rename the marfs mountpoint from the marfs config to the root namespace
-    if (path_eq(g_state.source, g_state.root_namespace)) {
+    if (g_state.source_is_root) {
         const str_t mm_base = get_basename(g_state.marfs_mountpoint);
         const str_t rn_base = get_basename(g_state.root_namespace);
 
@@ -758,6 +760,8 @@ static int marfs_indexing_global_init(struct input* in) {
 
     INSTALL_STR(&g_state.root_namespace, sec_root);
     g_state.root_namespace = trim_trailing_slashes(g_state.root_namespace);
+
+    g_state.source_is_root = path_eq(g_state.source, g_state.root_namespace);
 
     char* marfs_config_path = getenv(MARFS_CONFIG_ENV);
     if (!marfs_config_path || marfs_config_path[0] == '\0') {
@@ -994,7 +998,7 @@ static void marfs_post_process_dir(void* ptr, void* user_data) {
     (void)user_data;
 
     // determine if this is the root namespace dir
-    if (!path_eq(g_state.source, g_state.root_namespace) || pcs->work->level != ROOT_NAMESPACE_LEVEL) {
+    if (!g_state.source_is_root || pcs->work->level != ROOT_NAMESPACE_LEVEL) {
         return;
     }
 

--- a/contrib/plugins/marfs_plugin.c
+++ b/contrib/plugins/marfs_plugin.c
@@ -881,9 +881,7 @@ static int is_namespace(str_t path) {
 }
 
 // sec-root and configured namespaces are the directories that own MDAL metadata
-static int is_mdal_owner(str_t path) {
-    return str_t_eq(path, g_state.root_namespace) || is_namespace(path);
-}
+static int is_mdal_owner(str_t path) { return str_t_eq(path, g_state.root_namespace) || is_namespace(path); }
 
 // check whether a namespace will be moved out of MDAL_subspaces in this index
 static int namespace_is_rewritten(str_t path) {

--- a/contrib/plugins/marfs_plugin.c
+++ b/contrib/plugins/marfs_plugin.c
@@ -232,13 +232,6 @@ static int str_t_eq_cstr(str_t s, const char* cstr, size_t cstr_len) {
     return strncmp(s.data, cstr, cstr_len) == 0;
 }
 
-static void trim_trailing_slashes_in_place(str_t* path) {
-    while (path->len > 1 && path->data[path->len - 1] == '/') {
-        path->len--;
-        path->data[path->len] = '\0';
-    }
-}
-
 static int path_eq(str_t lhs, str_t rhs) {
     lhs = trim_trailing_slashes(lhs);
     rhs = trim_trailing_slashes(rhs);
@@ -754,9 +747,8 @@ static int marfs_indexing_global_init(struct input* in) {
     // add index parent, selected source, and root namespace to global state
     INSTALL_STR(&g_state.index_parent, in->pos.argv[in->pos.argc - 1]);
     INSTALL_STR(&g_state.source, in->pos.argv[0]);
-
-    trim_trailing_slashes_in_place(&g_state.index_parent);
-    trim_trailing_slashes_in_place(&g_state.source);
+    g_state.index_parent = trim_trailing_slashes(g_state.index_parent);
+    g_state.source = trim_trailing_slashes(g_state.source);
 
     char* sec_root = getenv(MARFS_SEC_ROOT_ENV);
     if (!sec_root || sec_root[0] == '\0') {
@@ -765,7 +757,7 @@ static int marfs_indexing_global_init(struct input* in) {
     }
 
     INSTALL_STR(&g_state.root_namespace, sec_root);
-    trim_trailing_slashes_in_place(&g_state.root_namespace);
+    g_state.root_namespace = trim_trailing_slashes(g_state.root_namespace);
 
     char* marfs_config_path = getenv(MARFS_CONFIG_ENV);
     if (!marfs_config_path || marfs_config_path[0] == '\0') {
@@ -872,7 +864,8 @@ static plugin_dir_action marfs_dir_action(void* ptr) {
     PCS_t* pcs = ptr;
 
     const str_t path = REFSTR(pcs->work->name, pcs->work->name_len);
-    const str_t basename = get_basename(path);
+    const str_t basename =
+        REFSTR(pcs->work->name + pcs->work->name_len - pcs->work->basename_len, pcs->work->basename_len);
     const str_t parent = get_parent(path);
 
     if (starts_with_mdal(basename)) {
@@ -917,67 +910,6 @@ static plugin_dir_action marfs_dir_action(void* ptr) {
     return PLUGIN_PROCESS_DIR;
 }
 
-// marfs_ctx is used for database init and cleanup
-struct marfs_ctx {
-    sqlite3* db;
-    sqlite3_stmt* delete_entry;
-    sqlite3_stmt* update_summary_name;
-};
-
-static void marfs_ctx_exit(void* ptr, void* plugin_user_data) {
-    (void)ptr;
-
-    struct marfs_ctx* ctx = plugin_user_data;
-    if (!ctx) {
-        return;
-    }
-
-    if (ctx->delete_entry) {
-        sqlite3_finalize(ctx->delete_entry);
-    }
-
-    if (ctx->update_summary_name) {
-        sqlite3_finalize(ctx->update_summary_name);
-    }
-
-    free(ctx);
-}
-
-static void* marfs_ctx_init(void* ptr) {
-    PCS_t* pcs = ptr;
-    sqlite3* db = pcs->db;
-
-    struct marfs_ctx* ctx = calloc(1, sizeof(*ctx));
-    if (!ctx) {
-        fprintf(stderr, "Error: could not allocate marfs ctx\n");
-        return NULL;
-    }
-
-    ctx->db = db;
-
-    int rc;
-
-    rc = sqlite3_prepare_v2(db, "DELETE FROM entries WHERE name = ?1;", -1, &ctx->delete_entry, NULL);
-    if (rc != SQLITE_OK) {
-        fprintf(stderr, "Error: prepare DELETE failed: %s\n", sqlite3_errmsg(db));
-        marfs_ctx_exit(ptr, ctx);
-        return NULL;
-    }
-
-    rc = sqlite3_prepare_v2(db,
-                            "UPDATE summary "
-                            "SET name = ?2 "
-                            "WHERE name = ?1;",
-                            -1, &ctx->update_summary_name, NULL);
-    if (rc != SQLITE_OK) {
-        fprintf(stderr, "Error: prepare summary update failed: %s\n", sqlite3_errmsg(db));
-        marfs_ctx_exit(ptr, ctx);
-        return NULL;
-    }
-
-    return ctx;
-}
-
 // marfs_pre_process_file removes any marfs specific files from the gufi db, decrements every file nlink by 1, and
 // removes any marfs specific xattrs
 static plugin_file_action marfs_pre_process_file(void* ptr, void* user_data) {
@@ -986,7 +918,8 @@ static plugin_file_action marfs_pre_process_file(void* ptr, void* user_data) {
     (void)user_data;
 
     const str_t path = REFSTR(pcs->work->name, pcs->work->name_len);
-    const str_t basename = get_basename(path);
+    const str_t basename =
+        REFSTR(pcs->work->name + pcs->work->name_len - pcs->work->basename_len, pcs->work->basename_len);
 
     // remove marfs xattr from entry
     const size_t removed = xattr_remove(&ed->xattrs, MARFS_XATTR_NAME, MARFS_XATTR_NAME_LEN);
@@ -1058,52 +991,47 @@ static void marfs_pre_process_dir(void* ptr, void* user_data) {
 // parent is an MDAL_subspaces directory that will be removed from the final index.
 static void marfs_post_process_dir(void* ptr, void* user_data) {
     PCS_t* pcs = ptr;
-    struct marfs_ctx* ctx = user_data;
-
-    const str_t path = REFSTR(pcs->work->name, pcs->work->name_len);
-    const str_t basename = get_basename(path);
+    (void)user_data;
 
     // determine if this is the root namespace dir
-    if (path_eq(g_state.source, g_state.root_namespace) && ROOT_NAMESPACE_LEVEL == pcs->work->level &&
-        str_t_eq_cstr(g_state.source, pcs->work->name, pcs->work->name_len)) {
-        // Rename root namespace to mountpoint in database
-        const str_t mountpoint = get_basename(g_state.marfs_mountpoint);
-
-        sqlite3_stmt* stmt = ctx->update_summary_name;
-        int rc;
-
-        sqlite3_reset(stmt);
-        sqlite3_clear_bindings(stmt);
-
-        // old name
-        rc = sqlite3_bind_text(stmt, 1, basename.data, (int)basename.len, SQLITE_STATIC);
-        if (rc != SQLITE_OK) {
-            fprintf(stderr, "plugin: bind summary name failed for %.*s: %s\n", (int)basename.len, basename.data,
-                    sqlite3_errmsg(ctx->db));
-            sqlite3_reset(stmt);
-            sqlite3_clear_bindings(stmt);
-            return;
-        }
-
-        // new name
-        rc = sqlite3_bind_text(stmt, 2, mountpoint.data, (int)mountpoint.len, SQLITE_STATIC);
-        if (rc != SQLITE_OK) {
-            fprintf(stderr, "plugin: bind new summary name failed for %.*s: %s\n", (int)mountpoint.len, mountpoint.data,
-                    sqlite3_errmsg(ctx->db));
-            sqlite3_reset(stmt);
-            sqlite3_clear_bindings(stmt);
-            return;
-        }
-
-        rc = sqlite3_step(stmt);
-        if (rc != SQLITE_DONE) {
-            fprintf(stderr, "plugin: update summary failed for %.*s: %s\n", (int)basename.len, basename.data,
-                    sqlite3_errmsg(ctx->db));
-        }
-
-        sqlite3_reset(stmt);
-        sqlite3_clear_bindings(stmt);
+    if (!path_eq(g_state.source, g_state.root_namespace) || pcs->work->level != ROOT_NAMESPACE_LEVEL) {
+        return;
     }
+
+    const str_t path = REFSTR(pcs->work->name, pcs->work->name_len);
+    const str_t basename =
+        REFSTR(pcs->work->name + pcs->work->name_len - pcs->work->basename_len, pcs->work->basename_len);
+    const str_t mountpoint = get_basename(g_state.marfs_mountpoint);
+
+    sqlite3_stmt* stmt = NULL;
+
+    int rc = sqlite3_prepare_v2(pcs->db, "UPDATE summary SET name = ?2 WHERE name = ?1;", -1, &stmt, NULL);
+    if (rc != SQLITE_OK) {
+        fprintf(stderr, "plugin: prepare summary update failed: %s\n", sqlite3_errmsg(pcs->db));
+        return;
+    }
+
+    // old name
+    rc = sqlite3_bind_text(stmt, 1, basename.data, (int)basename.len, SQLITE_STATIC);
+    if (rc != SQLITE_OK) {
+        fprintf(stderr, "plugin: bind summary name failed: %s\n", sqlite3_errmsg(pcs->db));
+        goto cleanup;
+    }
+
+    // new name
+    rc = sqlite3_bind_text(stmt, 2, mountpoint.data, (int)mountpoint.len, SQLITE_STATIC);
+    if (rc != SQLITE_OK) {
+        fprintf(stderr, "plugin: bind mountpoint name failed: %s\n", sqlite3_errmsg(pcs->db));
+        goto cleanup;
+    }
+
+    rc = sqlite3_step(stmt);
+    if (rc != SQLITE_DONE) {
+        fprintf(stderr, "plugin: update summary failed: %s\n", sqlite3_errmsg(pcs->db));
+    }
+
+cleanup:
+    sqlite3_finalize(stmt);
 }
 
 // marfs_indexing_global_exit cleans up the marfs index tree and cleans up the global state
@@ -1124,13 +1052,13 @@ struct plugin_operations GUFI_MARFS_PLUGIN = {
     .global_init = marfs_indexing_global_init,
     .thread_init = NULL,
     .dir_action = marfs_dir_action,
-    .ctx_init = marfs_ctx_init,
+    .ctx_init = NULL,
     .stat_file = NULL,
     .pre_process_dir = marfs_pre_process_dir,
     .post_process_dir = marfs_post_process_dir,
     .pre_process_file = marfs_pre_process_file,
     .post_process_file = NULL,
-    .ctx_exit = marfs_ctx_exit,
+    .ctx_exit = NULL,
     .thread_exit = NULL,
     .global_exit = marfs_indexing_global_exit,
 };

--- a/contrib/plugins/marfs_plugin.c
+++ b/contrib/plugins/marfs_plugin.c
@@ -173,38 +173,30 @@ static void sort_namespace_pairs(namespace_pair* namespace_list, size_t namespac
 
 // returns the basename of a path
 static str_t get_basename(str_t path) {
-    if (!path.data || path.len == 0) return (str_t)REFSTR(NULL, 0);
+    path = trim_trailing_slashes(path);
+    if (!str_exists(&path)) return (str_t)REFSTR(NULL, 0);
 
-    size_t len = path.len;
+    const size_t parent_len = dirname_len(path.data, path.len);
 
-    // trim trailing slashes except root
-    while (len > 1 && path.data[len - 1] == '/') len--;
-
-    size_t i = len;
-    while (i > 0 && path.data[i - 1] != '/') i--;
-
-    return (str_t)REFSTR(path.data + i, len - i);
+    return (str_t)REFSTR(path.data + parent_len, path.len - parent_len);
 }
 
 // returns the parent of a path
 static str_t get_parent(str_t path) {
-    if (!path.data || path.len == 0) return (str_t)REFSTR(NULL, 0);
+    path = trim_trailing_slashes(path);
+    if (!str_exists(&path)) return (str_t)REFSTR(NULL, 0);
 
-    size_t len = path.len;
+    if (path.len == 1 && path.data[0] == '/') {
+        return path;
+    }
 
-    // trim trailing slashes except root
-    while (len > 1 && path.data[len - 1] == '/') len--;
+    size_t len = dirname_len(path.data, path.len);
+    if (len == 0) return (str_t)REFSTR(NULL, 0);
 
-    // root stays root
-    if (len == 1 && path.data[0] == '/') return (str_t)REFSTR(path.data, 1);
+    // dirname_len includes the trailing '/'
+    if (len > 1) len--;
 
-    size_t i = len;
-    while (i > 0 && path.data[i - 1] != '/') i--;
-
-    if (i == 0) return (str_t)REFSTR(NULL, 0);
-
-    size_t parent_len = (i - 1 == 0) ? 1 : (i - 1);
-    return (str_t)REFSTR(path.data, parent_len);
+    return (str_t)REFSTR(path.data, len);
 }
 
 // join two str_t file paths together
@@ -247,13 +239,11 @@ static void trim_trailing_slashes_in_place(str_t* path) {
     }
 }
 
-static int str_t_eq(str_t lhs, str_t rhs) {
+static int path_eq(str_t lhs, str_t rhs) {
     lhs = trim_trailing_slashes(lhs);
     rhs = trim_trailing_slashes(rhs);
 
-    if (lhs.len != rhs.len) return 0;
-
-    return strncmp(lhs.data, rhs.data, lhs.len) == 0;
+    return str_cmp(&lhs, &rhs) == 0;
 }
 
 // check whether path is root itself or is below root on a path-component boundary
@@ -274,7 +264,7 @@ static str_t get_relative_path(str_t path, str_t root) {
     path = trim_trailing_slashes(path);
     root = trim_trailing_slashes(root);
 
-    if (!path_is_at_or_below(path, root) || str_t_eq(path, root)) {
+    if (!path_is_at_or_below(path, root) || str_cmp(&path, &root)) {
         return (str_t)REFSTR(NULL, 0);
     }
 
@@ -411,13 +401,13 @@ static int collect_ns_paths(marfs_ns* ns, str_t parent_path, namespace_pair* pat
 // build index paths only for configured namespaces below the selected source
 static int build_index_namespace_paths(void) {
     const str_t source_base = get_basename(g_state.source);
-    if (!source_base.data || source_base.len == 0) return -1;
+    if (!str_exists(&source_base)) return -1;
 
     for (size_t i = 0; i < g_state.namespaces_count; i++) {
         namespace_pair* pair = &g_state.namespaces[i];
 
         // the selected source is already the index root and does not need to be moved
-        if (str_t_eq(pair->namespace, g_state.source)) continue;
+        if (path_eq(pair->namespace, g_state.source)) continue;
 
         const str_t relative = get_relative_path(pair->namespace, g_state.source);
         if (!relative.data || relative.len == 0) continue;
@@ -499,7 +489,7 @@ static int validate_source(void) {
         if (ns.len > owner.len && path_is_at_or_below(g_state.source, ns)) owner = ns;
     }
 
-    if (!str_t_eq(g_state.source, owner)) {
+    if (!path_eq(g_state.source, owner)) {
         const str_t relative = get_relative_path(g_state.source, owner);
         if (starts_with_mdal(get_first_component(relative))) {
             fprintf(stderr, "Error: source (%s) is inside a MarFS internal directory\n", g_state.source.data);
@@ -519,7 +509,7 @@ static int cleanup_marfs_index(void) {
     // loop through our index namespaces and move them up a directory and delete the unecessary MDAL_subspaces
     for (size_t i = g_state.namespaces_count; i-- > 0;) {
         const str_t old = g_state.namespaces[i].index_namespace;
-        if (!old.data || old.len == 0) continue;
+        if (!str_exists(&old)) continue;
 
         const str_t basename = get_basename(old);
         const str_t parent = get_parent(old);
@@ -602,7 +592,7 @@ static int cleanup_marfs_index(void) {
     }
 
     // rename the root namespace to the marfs mountpoint from the marfs config
-    if (str_t_eq(g_state.source, g_state.root_namespace)) {
+    if (path_eq(g_state.source, g_state.root_namespace)) {
         const str_t rn_base = get_basename(g_state.root_namespace);
         const str_t mm_base = get_basename(g_state.marfs_mountpoint);
 
@@ -636,7 +626,7 @@ static int revert_marfs_index(void) {
     int ret = 0;
 
     // rename the marfs mountpoint from the marfs config to the root namespace
-    if (str_t_eq(g_state.source, g_state.root_namespace)) {
+    if (path_eq(g_state.source, g_state.root_namespace)) {
         const str_t mm_base = get_basename(g_state.marfs_mountpoint);
         const str_t rn_base = get_basename(g_state.root_namespace);
 
@@ -872,7 +862,7 @@ static int is_namespace(str_t path) {
             continue;
         }
 
-        if (str_t_eq(ns, path)) {
+        if (path_eq(ns, path)) {
             return 1;
         }
     }
@@ -881,13 +871,13 @@ static int is_namespace(str_t path) {
 }
 
 // sec-root and configured namespaces are the directories that own MDAL metadata
-static int is_mdal_owner(str_t path) { return str_t_eq(path, g_state.root_namespace) || is_namespace(path); }
+static int is_mdal_owner(str_t path) { return path_eq(path, g_state.root_namespace) || is_namespace(path); }
 
 // check whether a namespace will be moved out of MDAL_subspaces in this index
 static int namespace_is_rewritten(str_t path) {
     for (size_t i = 0; i < g_state.namespaces_count; i++) {
         namespace_pair* pair = &g_state.namespaces[i];
-        if (str_t_eq(pair->namespace, path)) {
+        if (path_eq(pair->namespace, path)) {
             return pair->index_namespace.data && pair->index_namespace.len > 0;
         }
     }
@@ -1093,7 +1083,7 @@ static void marfs_post_process_dir(void* ptr, void* user_data) {
     const str_t basename = get_basename(path);
 
     // determine if this is the root namespace dir
-    if (str_t_eq(g_state.source, g_state.root_namespace) && ROOT_NAMESPACE_LEVEL == pcs->work->level &&
+    if (path_eq(g_state.source, g_state.root_namespace) && ROOT_NAMESPACE_LEVEL == pcs->work->level &&
         str_t_eq_cstr(g_state.source, pcs->work->name, pcs->work->name_len)) {
         // Rename root namespace to mountpoint in database
         const str_t mountpoint = get_basename(g_state.marfs_mountpoint);

--- a/contrib/plugins/marfs_plugin.c
+++ b/contrib/plugins/marfs_plugin.c
@@ -60,6 +60,8 @@ IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
 OF SUCH DAMAGE.
 */
 
+
+
 /*
  * MarFS GUFI indexing plugin
  *
@@ -216,21 +218,7 @@ static int str_t_eq_cstr(str_t s, const char* cstr, size_t cstr_len) {
     return strncmp(s.data, cstr, cstr_len) == 0;
 }
 
-// install a path while removing trailing slashes, except for filesystem root
-static int install_path(str_t* dst, const char* path) {
-    if (!dst || !path || path[0] == '\0') return -1;
-
-    size_t len = strlen(path);
-    while (len > 1 && path[len - 1] == '/') len--;
-
-    if (!str_alloc_existing(dst, len)) return -1;
-
-    memcpy(dst->data, path, len);
-    dst->data[len] = '\0';
-    return 0;
-}
-
-static int path_eq(str_t lhs, str_t rhs) {
+static int str_t_eq(str_t lhs, str_t rhs) {
     if (!lhs.data || !rhs.data || lhs.len != rhs.len) return 0;
 
     return strncmp(lhs.data, rhs.data, lhs.len) == 0;
@@ -248,7 +236,7 @@ static int path_is_at_or_below(str_t path, str_t root) {
 }
 
 static str_t get_relative_path(str_t path, str_t root) {
-    if (!path_is_at_or_below(path, root) || path_eq(path, root)) {
+    if (!path_is_at_or_below(path, root) || str_t_eq(path, root)) {
         return (str_t)REFSTR(NULL, 0);
     }
 
@@ -356,14 +344,16 @@ static int is_namespace(str_t path) {
     if (!path.data) return 0;
 
     for (size_t i = 0; i < g_state.namespaces_count; i++) {
-        if (path_eq(g_state.namespaces[i].namespace, path)) return 1;
+        if (str_t_eq(g_state.namespaces[i].namespace, path)) return 1;
     }
 
     return 0;
 }
 
 // sec-root and configured namespaces are the directories that own MDAL metadata
-static int is_mdal_owner(str_t path) { return path_eq(path, g_state.sec_root) || is_namespace(path); }
+static int is_mdal_owner(str_t path) { 
+    return str_t_eq(path, g_state.sec_root) || is_namespace(path); 
+}
 
 static int is_mdal_subspaces_dir(str_t path) {
     if (!path.data) return 0;
@@ -377,7 +367,7 @@ static int is_mdal_subspaces_dir(str_t path) {
 static int namespace_is_rewritten(str_t path) {
     for (size_t i = 0; i < g_state.namespaces_count; i++) {
         namespace_pair* pair = &g_state.namespaces[i];
-        if (path_eq(pair->namespace, path)) {
+        if (str_t_eq(pair->namespace, path)) {
             return pair->index_namespace.data && pair->index_namespace.len > 0;
         }
     }
@@ -394,7 +384,7 @@ static int build_index_namespace_paths(void) {
         namespace_pair* pair = &g_state.namespaces[i];
 
         // the selected source is already the index root and does not need to be moved
-        if (path_eq(pair->namespace, g_state.source)) continue;
+        if (str_t_eq(pair->namespace, g_state.source)) continue;
 
         const str_t relative = get_relative_path(pair->namespace, g_state.source);
         if (!relative.data || relative.len == 0) continue;
@@ -467,7 +457,7 @@ static int validate_source(void) {
         if (ns.len > owner.len && path_is_at_or_below(g_state.source, ns)) owner = ns;
     }
 
-    if (!path_eq(g_state.source, owner)) {
+    if (!str_t_eq(g_state.source, owner)) {
         const str_t relative = get_relative_path(g_state.source, owner);
         const str_t first = get_first_component(relative);
 
@@ -720,8 +710,8 @@ static int marfs_indexing_global_init(struct input* in) {
         return ret;
     }
 
-    if (install_path(&g_state.index_parent, in->pos.argv[in->pos.argc - 1]) != 0 ||
-        install_path(&g_state.source, in->pos.argv[0]) != 0) {
+    if (INSTALL_STR(&g_state.index_parent, in->pos.argv[in->pos.argc - 1]) != 0 ||
+        INSTALL_STR(&g_state.source, in->pos.argv[0]) != 0) {
         fprintf(stderr, "Error: could not store GUFI source or index path\n");
         goto cleanup;
     }
@@ -732,7 +722,7 @@ static int marfs_indexing_global_init(struct input* in) {
         goto cleanup;
     }
 
-    if (install_path(&g_state.sec_root, sec_root) != 0) {
+    if (INSTALL_STR(&g_state.sec_root, sec_root) != 0) {
         fprintf(stderr, "Error: could not store %s\n", MARFS_SEC_ROOT_ENV);
         goto cleanup;
     }
@@ -780,7 +770,7 @@ static int marfs_indexing_global_init(struct input* in) {
 
     if (validate_source() != 0) goto cleanup;
 
-    g_state.source_is_sec_root = path_eq(g_state.source, g_state.sec_root);
+    g_state.source_is_sec_root = str_t_eq(g_state.source, g_state.sec_root);
 
     if (build_index_namespace_paths() != 0) {
         fprintf(stderr, "Error: build_index_namespace_paths failed\n");
@@ -960,7 +950,7 @@ static void marfs_post_process_dir(void* ptr, void* user_data) {
     const str_t basename = get_basename(path);
 
     // Only a sec-root index is renamed to the MarFS mountpoint.
-    if (g_state.source_is_sec_root && path_eq(path, g_state.source)) {
+    if (g_state.source_is_sec_root && str_t_eq(path, g_state.source)) {
         // Rename root namespace to mountpoint in database
         const str_t mountpoint = get_basename(g_state.marfs_mountpoint);
 

--- a/contrib/plugins/marfs_plugin.c
+++ b/contrib/plugins/marfs_plugin.c
@@ -208,6 +208,13 @@ static str_t get_parent(str_t path) {
     return (str_t)REFSTR(path.data, len);
 }
 
+static void trim_trailing_slashes_in_place(str_t* path) {
+    while (path->len > 1 && path->data[path->len - 1] == '/') {
+        path->len--;
+        path->data[path->len] = '\0';
+    }
+}
+
 // join two str_t file paths together
 static char* join_path(str_t lhs, str_t rhs) {
     size_t len = lhs.len + 1 + rhs.len + 1;
@@ -751,8 +758,8 @@ static int marfs_indexing_global_init(struct input* in) {
     // add index parent, selected source, and root namespace to global state
     INSTALL_STR(&g_state.index_parent, in->pos.argv[in->pos.argc - 1]);
     INSTALL_STR(&g_state.source, in->pos.argv[0]);
-    g_state.index_parent = trim_trailing_slashes(g_state.index_parent);
-    g_state.source = trim_trailing_slashes(g_state.source);
+    trim_trailing_slashes_in_place(&g_state.index_parent);
+    trim_trailing_slashes_in_place(&g_state.source);
 
     char* sec_root = getenv(MARFS_SEC_ROOT_ENV);
     if (!sec_root || sec_root[0] == '\0') {

--- a/contrib/plugins/marfs_plugin.c
+++ b/contrib/plugins/marfs_plugin.c
@@ -60,8 +60,6 @@ IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
 OF SUCH DAMAGE.
 */
 
-
-
 /*
  * MarFS GUFI indexing plugin
  *
@@ -71,37 +69,27 @@ OF SUCH DAMAGE.
  *
  * High level behavior:
  *
- * 1. Reads the MarFS config specified by MARFS_CONFIG_PATH and discovers all
- *    configured namespaces under the selected root namespace.
+ * 1. Reads the MarFS config specified by MARFS_CONFIG_PATH and the physical
+ *    MDAL sec-root specified by MARFS_SEC_ROOT. The GUFI source may be the
+ *    sec-root, a configured namespace, or a normal directory below one.
  *
- * 2. Builds a sorted list of namespace pairs:
- *      - namespace:        the real namespace path under sec-root
- *      - index_namespace:  the corresponding path GUFI will see in the
- *                          temporary index tree
+ * 2. Builds the full physical path of every configured namespace from the
+ *    configured sec-root. It separately builds temporary index paths only for
+ *    configured namespaces below the selected GUFI source.
  *
- * 3. Before indexing begins, rewrites the on-disk index layout to match the
- *    MarFS namespace structure expected by this plugin. In particular, it
- *    restores MDAL_subspaces directories and renames the indexed root from
- *    the MarFS mountpoint back to the configured root namespace so repeated
- *    indexing runs work correctly.
+ * 3. Before indexing begins, restores MDAL_subspaces directories in an
+ *    existing index so GUFI can update the physical traversal layout.
  *
- * 4. During traversal, filters out MarFS internal directories and files
- *    (such as MDAL_* entries) so GUFI does not index MarFS metadata as user
- *    content. It also skips namespaces that exist on disk but are no longer
- *    present in the current MarFS config.
+ * 4. During traversal, identifies MarFS metadata by checking whether its
+ *    parent is the configured sec-root or a configured namespace. This avoids
+ *    depending on GUFI traversal levels.
  *
- * 5. While processing files, removes MarFS specific database entries,
- *    decrements link counts to account for MarFS metadata links, and strips
- *    MarFS xattrs from the stored xattr list.
+ * 5. While processing files, removes MarFS xattrs, decrements link counts to
+ *    account for MarFS metadata links, and hides MarFS implementation files.
  *
- * 6. While processing directories, renames the indexed root namespace in the
- *    GUFI summary table so the final index presents the MarFS mountpoint name
- *    instead of the raw sec-root namespace name.
- *
- * 7. After indexing completes, restores the index tree into a cleaner final
- *    form by moving namespace directories up out of MDAL_subspaces, removing
- *    empty MDAL_subspaces directories, and renaming the indexed root back to
- *    the MarFS mountpoint basename.
+ * 6. After indexing completes, moves configured child namespaces out of
+ *    MDAL_subspaces in the generated index. The index root is renamed to the
+ *    MarFS mountpoint only when the selected source is the sec-root itself.
  *
  * build instruction:
  *
@@ -115,9 +103,10 @@ OF SUCH DAMAGE.
  *
  * run example:
  * MARFS_CONFIG_PATH=/path/to/marfs/install/etc/marfs-config.xml \
+ * MARFS_SEC_ROOT=/path/to/mdal-root/sec-root \
  *   src/gufi_dir2index \
  *   --plugin "GUFI_MARFS_PLUGIN:contrib/plugins/libmarfs_plugin.so" \
- *   /path/to/mdal-root/sec-root /home/$USER/gufi-index-dir
+ *   /path/to/mdal-root/sec-root/MDAL_subspaces/ns1/subdir /home/$USER/gufi-index-dir
  */
 
 #include <errno.h>
@@ -144,11 +133,11 @@ static const char MARFS_SUBSPACES_NAME[] = "MDAL_subspaces";
 static const size_t MARFS_SUBSPACES_NAME_LEN = sizeof(MARFS_SUBSPACES_NAME) - 1;
 static const char MARFS_XATTR_NAME[] = "user.MDAL_MARFS-FILE";
 static const size_t MARFS_XATTR_NAME_LEN = sizeof(MARFS_XATTR_NAME) - 1;
-static const size_t ROOT_NAMESPACE_LEVEL = 0;
 // marfs dir mode used for temporary additions of marfs specific directories during re-indexing
 static const mode_t MARFS_DIR_MODE = S_IRWXU | S_IXOTH;
 
 static const char* MARFS_CONFIG_ENV = "MARFS_CONFIG_PATH";
+static const char* MARFS_SEC_ROOT_ENV = "MARFS_SEC_ROOT";
 
 typedef struct {
     str_t namespace;
@@ -227,13 +216,68 @@ static int str_t_eq_cstr(str_t s, const char* cstr, size_t cstr_len) {
     return strncmp(s.data, cstr, cstr_len) == 0;
 }
 
+// install a path while removing trailing slashes, except for filesystem root
+static int install_path(str_t* dst, const char* path) {
+    if (!dst || !path || path[0] == '\0') return -1;
+
+    size_t len = strlen(path);
+    while (len > 1 && path[len - 1] == '/') len--;
+
+    if (!str_alloc_existing(dst, len)) return -1;
+
+    memcpy(dst->data, path, len);
+    dst->data[len] = '\0';
+    return 0;
+}
+
+static int path_eq(str_t lhs, str_t rhs) {
+    if (!lhs.data || !rhs.data || lhs.len != rhs.len) return 0;
+
+    return strncmp(lhs.data, rhs.data, lhs.len) == 0;
+}
+
+// check whether path is root itself or is below root on a path-component boundary
+static int path_is_at_or_below(str_t path, str_t root) {
+    if (!path.data || !root.data || path.len < root.len) return 0;
+    if (strncmp(path.data, root.data, root.len) != 0) return 0;
+    if (path.len == root.len) return 1;
+
+    if (root.len == 1 && root.data[0] == '/') return path.data[0] == '/';
+
+    return path.data[root.len] == '/';
+}
+
+static str_t get_relative_path(str_t path, str_t root) {
+    if (!path_is_at_or_below(path, root) || path_eq(path, root)) {
+        return (str_t)REFSTR(NULL, 0);
+    }
+
+    if (root.len == 1 && root.data[0] == '/') {
+        return (str_t)REFSTR(path.data + 1, path.len - 1);
+    }
+
+    return (str_t)REFSTR(path.data + root.len + 1, path.len - root.len - 1);
+}
+
+static str_t get_first_component(str_t path) {
+    if (!path.data || path.len == 0) return (str_t)REFSTR(NULL, 0);
+
+    size_t len = 0;
+    while (len < path.len && path.data[len] != '/') len++;
+
+    return (str_t)REFSTR(path.data, len);
+}
+
 struct marfs_plugin {
     namespace_pair* namespaces;
     size_t namespaces_count;
 
     str_t index_parent;  // actual index is placed at <index parent>/$(basename <src>)
     str_t marfs_mountpoint;
-    str_t root_namespace;
+    str_t source;
+    str_t sec_root;
+
+    int source_is_sec_root;
 
     marfs_config* marfs_cfg;
 };
@@ -251,10 +295,12 @@ static void marfs_plugin_cleanup(void) {
 
     str_free_existing(&g_state.index_parent);
     str_free_existing(&g_state.marfs_mountpoint);
-    str_free_existing(&g_state.root_namespace);
+    str_free_existing(&g_state.source);
+    str_free_existing(&g_state.sec_root);
 
     g_state.namespaces = NULL;
     g_state.namespaces_count = 0;
+    g_state.source_is_sec_root = 0;
 
     // cleanup marfs config
     config_term(g_state.marfs_cfg);
@@ -280,120 +326,171 @@ static size_t count_ns_paths(marfs_ns* ns) {
     return total;
 }
 
-// retrieve the namespace paths from the marfs config and build namespace pairs
-static int collect_ns_paths(marfs_ns* ns, str_t parent_path, namespace_pair* paths, size_t* index, str_t root_namespace,
-                            str_t index_parent, str_t rn_base) {
-    if (!ns || !paths || !index || !root_namespace.data || !index_parent.data || !rn_base.data) return -1;
-
+// retrieve the physical namespace paths from the marfs config
+static int collect_ns_paths(marfs_ns* ns, str_t parent_namespace, namespace_pair* paths, size_t* index) {
     for (size_t i = 0; i < ns->subnodecount; i++) {
         HASH_NODE* hn = &ns->subnodes[i];
         marfs_ns* child = (marfs_ns*)hn->content;
 
         if (!hn->name || !child) continue;
 
-        str_t path = {0};
+        namespace_pair* pair = &paths[*index];
         const size_t name_len = strlen(hn->name);
+        const size_t namespace_len = parent_namespace.len + 1 + MARFS_SUBSPACES_NAME_LEN + 1 + name_len;
 
-        if (parent_path.len == 0) {
-            const size_t path_len = name_len;
+        if (!str_alloc_existing(&pair->namespace, namespace_len)) return -1;
 
-            if (!str_alloc_existing(&path, path_len)) return -1;
-
-            snprintf(path.data, path_len + 1, "%s", hn->name);
-        } else {
-            // add an MDAL_subspaces dir into the path
-            const size_t path_len = parent_path.len + 1 + MARFS_SUBSPACES_NAME_LEN + 1 + name_len;
-
-            if (!str_alloc_existing(&path, path_len)) return -1;
-
-            snprintf(path.data, path_len + 1, "%.*s/%s/%s", (int)parent_path.len, parent_path.data,
-                     MARFS_SUBSPACES_NAME, hn->name);
-        }
-
-        // build namespace and index namespace paths
-        {
-            namespace_pair* pair = &paths[*index];
-            const size_t namespace_len = root_namespace.len + 1 + MARFS_SUBSPACES_NAME_LEN + 1 + path.len;
-            const size_t index_namespace_len =
-                index_parent.len + 1 + rn_base.len + 1 + MARFS_SUBSPACES_NAME_LEN + 1 + path.len;
-
-            if (!str_alloc_existing(&pair->namespace, namespace_len)) {
-                str_free_existing(&path);
-                return -1;
-            }
-
-            snprintf(pair->namespace.data, namespace_len + 1, "%.*s/%s/%.*s", (int)root_namespace.len,
-                     root_namespace.data, MARFS_SUBSPACES_NAME, (int)path.len, path.data);
-
-            if (!str_alloc_existing(&pair->index_namespace, index_namespace_len)) {
-                str_free_existing(&pair->namespace);
-                str_free_existing(&path);
-                return -1;
-            }
-
-            snprintf(pair->index_namespace.data, index_namespace_len + 1, "%.*s/%.*s/%s/%.*s", (int)index_parent.len,
-                     index_parent.data, (int)rn_base.len, rn_base.data, MARFS_SUBSPACES_NAME, (int)path.len, path.data);
-        }
+        snprintf(pair->namespace.data, namespace_len + 1, "%.*s/%s/%s", (int)parent_namespace.len,
+                 parent_namespace.data, MARFS_SUBSPACES_NAME, hn->name);
 
         (*index)++;
 
-        if (collect_ns_paths(child, path, paths, index, root_namespace, index_parent, rn_base) != 0) {
-            (*index)--;
-            str_free_existing(&paths[*index].namespace);
-            str_free_existing(&paths[*index].index_namespace);
-            str_free_existing(&path);
-            return -1;
-        }
-
-        str_free_existing(&path);
+        if (collect_ns_paths(child, pair->namespace, paths, index) != 0) return -1;
     }
 
     return 0;
 }
 
-// validate that we are actually pointed at the root namespace of a marfs-mdal (sec-root).
-// There should be an MDAL_subspaces directly under the root namespace
-// then there should be our first namespaces right under the MDAL_subspaces
-// NOTE: this requires that the namespaces be sorted beforehand
-static int validate_sec_root(void) {
-    struct stat st;
-    int ret = 0;
-    char* path = NULL;
-    int len;
+// simple check to determine if a provided file path is a namespace in the marfs config
+static int is_namespace(str_t path) {
+    if (!path.data) return 0;
 
-    if (!g_state.root_namespace.data || g_state.root_namespace.len == 0) goto cleanup;
-    if (!g_state.namespaces || g_state.namespaces_count == 0) goto cleanup;
+    for (size_t i = 0; i < g_state.namespaces_count; i++) {
+        if (path_eq(g_state.namespaces[i].namespace, path)) return 1;
+    }
 
-    // check if MDAL_subspaces exists under the target dir
-    len = snprintf(NULL, 0, "%s/%s", g_state.root_namespace.data, MARFS_SUBSPACES_NAME);
-    if (len < 0) goto cleanup;
-
-    path = malloc((size_t)len + 1);
-    if (!path) goto cleanup;
-
-    snprintf(path, (size_t)len + 1, "%s/%s", g_state.root_namespace.data, MARFS_SUBSPACES_NAME);
-
-    if (stat(path, &st) != 0 || !S_ISDIR(st.st_mode)) goto cleanup;
-
-    // check if one of the top namespaces is in the first MDAL_subspaces
-    if (stat(g_state.namespaces[0].namespace.data, &st) != 0 || !S_ISDIR(st.st_mode)) goto cleanup;
-
-    ret = 1;
-
-cleanup:
-    free(path);
-    return ret;
+    return 0;
 }
 
-// cleanup_marfs_index will go through each namespace defined in the marfs config, move it up a directory, and delete
-// the empty MDAL_subspaces that remains. It also removes any empty MDAL_subspaces that exist within the namespace as
-// well as renaming the root directory to the basename of the specified mountpoint in the marfs config
+// sec-root and configured namespaces are the directories that own MDAL metadata
+static int is_mdal_owner(str_t path) { return path_eq(path, g_state.sec_root) || is_namespace(path); }
+
+static int is_mdal_subspaces_dir(str_t path) {
+    if (!path.data) return 0;
+
+    const str_t basename = get_basename(path);
+    if (!str_t_eq_cstr(basename, MARFS_SUBSPACES_NAME, MARFS_SUBSPACES_NAME_LEN)) return 0;
+
+    return is_mdal_owner(get_parent(path));
+}
+
+static int namespace_is_rewritten(str_t path) {
+    for (size_t i = 0; i < g_state.namespaces_count; i++) {
+        namespace_pair* pair = &g_state.namespaces[i];
+        if (path_eq(pair->namespace, path)) {
+            return pair->index_namespace.data && pair->index_namespace.len > 0;
+        }
+    }
+
+    return 0;
+}
+
+// build only the index paths for configured namespaces that are below the selected source
+static int build_index_namespace_paths(void) {
+    const str_t source_base = get_basename(g_state.source);
+    if (!source_base.data || source_base.len == 0) return -1;
+
+    for (size_t i = 0; i < g_state.namespaces_count; i++) {
+        namespace_pair* pair = &g_state.namespaces[i];
+
+        // the selected source is already the index root and does not need to be moved
+        if (path_eq(pair->namespace, g_state.source)) continue;
+
+        const str_t relative = get_relative_path(pair->namespace, g_state.source);
+        if (!relative.data || relative.len == 0) continue;
+
+        const size_t index_namespace_len = g_state.index_parent.len + 1 + source_base.len + 1 + relative.len;
+
+        if (!str_alloc_existing(&pair->index_namespace, index_namespace_len)) return -1;
+
+        snprintf(pair->index_namespace.data, index_namespace_len + 1, "%.*s/%.*s/%.*s", (int)g_state.index_parent.len,
+                 g_state.index_parent.data, (int)source_base.len, source_base.data, (int)relative.len, relative.data);
+    }
+
+    return 0;
+}
+
+// validate the configured sec-root and ensure the selected source is a usable path inside it
+static int validate_source(void) {
+    struct stat st;
+
+    if (g_state.sec_root.data[0] != '/' || g_state.source.data[0] != '/') {
+        fprintf(stderr, "Error: source and %s must both be absolute paths\n", MARFS_SEC_ROOT_ENV);
+        return -1;
+    }
+
+    if (stat(g_state.sec_root.data, &st) != 0 || !S_ISDIR(st.st_mode)) {
+        fprintf(stderr, "Error: %s (%s) is not a directory\n", MARFS_SEC_ROOT_ENV, g_state.sec_root.data);
+        return -1;
+    }
+
+    {
+        const str_t subspaces_name = REFSTR(MARFS_SUBSPACES_NAME, MARFS_SUBSPACES_NAME_LEN);
+        char* subspaces = join_path(g_state.sec_root, subspaces_name);
+
+        if (!subspaces) {
+            fprintf(stderr, "Error: could not build sec-root MDAL_subspaces path\n");
+            return -1;
+        }
+
+        if (stat(subspaces, &st) != 0 || !S_ISDIR(st.st_mode)) {
+            fprintf(stderr, "Error: %s (%s) does not contain %s\n", MARFS_SEC_ROOT_ENV, g_state.sec_root.data,
+                    MARFS_SUBSPACES_NAME);
+            free(subspaces);
+            return -1;
+        }
+
+        free(subspaces);
+    }
+
+    if (stat(g_state.source.data, &st) != 0 || !S_ISDIR(st.st_mode)) {
+        fprintf(stderr, "Error: source (%s) is not a directory\n", g_state.source.data);
+        return -1;
+    }
+
+    if (!path_is_at_or_below(g_state.source, g_state.sec_root)) {
+        fprintf(stderr, "Error: source (%s) is not within %s (%s)\n", g_state.source.data, MARFS_SEC_ROOT_ENV,
+                g_state.sec_root.data);
+        return -1;
+    }
+
+    /*
+     * Find the deepest configured namespace containing the source. Relative
+     * to that owner, a leading MDAL_* component means the user selected an
+     * internal MarFS implementation directory. Selecting the namespace itself
+     * is valid because it becomes the root of the generated index.
+     */
+    str_t owner = g_state.sec_root;
+
+    for (size_t i = 0; i < g_state.namespaces_count; i++) {
+        const str_t ns = g_state.namespaces[i].namespace;
+        if (ns.len > owner.len && path_is_at_or_below(g_state.source, ns)) owner = ns;
+    }
+
+    if (!path_eq(g_state.source, owner)) {
+        const str_t relative = get_relative_path(g_state.source, owner);
+        const str_t first = get_first_component(relative);
+
+        if (starts_with_mdal(first)) {
+            fprintf(stderr, "Error: source (%s) is inside MarFS internal directory %.*s\n", g_state.source.data,
+                    (int)first.len, first.data);
+            return -1;
+        }
+    }
+
+    return 0;
+}
+
+// cleanup_marfs_index moves configured namespaces below the selected source out of
+// MDAL_subspaces directories. When indexing sec-root, it also renames the index root
+// to the basename of the MarFS mountpoint.
 static int cleanup_marfs_index(void) {
     int ret = 0;
 
-    // loop through our index namespaces and move them up a directory and delete the unecessary MDAL_subspaces
+    // deepest namespaces must be moved before their parents
     for (size_t i = g_state.namespaces_count; i-- > 0;) {
         const str_t old = g_state.namespaces[i].index_namespace;
+        if (!old.data || old.len == 0) continue;
 
         const str_t basename = get_basename(old);
         const str_t parent = get_parent(old);
@@ -403,10 +500,9 @@ static int cleanup_marfs_index(void) {
         char* parent_path = NULL;
         char* child_subspaces = NULL;
 
-        // check to see if there is an empty MDAL_subspaces within this namespace
+        // remove an empty MDAL_subspaces contained by this namespace
         {
-            size_t child_subspaces_len =
-                old.len + 1 + MARFS_SUBSPACES_NAME_LEN + 1;  // old + "/" + MDAL_subspaces + NUL
+            const size_t child_subspaces_len = old.len + 1 + MARFS_SUBSPACES_NAME_LEN + 1;
             child_subspaces = malloc(child_subspaces_len);
             if (!child_subspaces) {
                 fprintf(stderr, "malloc failed for child_subspaces\n");
@@ -415,18 +511,18 @@ static int cleanup_marfs_index(void) {
             }
 
             snprintf(child_subspaces, child_subspaces_len, "%.*s/%s", (int)old.len, old.data, MARFS_SUBSPACES_NAME);
-            if (rmdir(child_subspaces) != 0) {
-                if (errno != ENOTEMPTY && errno != ENOENT) {
-                    fprintf(stderr, "rmdir('%s') failed: %s\n", child_subspaces, strerror(errno));
-                    ret = -1;
-                }
+
+            if (rmdir(child_subspaces) != 0 && errno != ENOTEMPTY && errno != ENOENT) {
+                fprintf(stderr, "rmdir('%s') failed: %s\n", child_subspaces, strerror(errno));
+                ret = -1;
             }
+
             free(child_subspaces);
         }
 
-        // move this namespace up a directory (into its grandparent)
+        // move this namespace out of MDAL_subspaces
         {
-            size_t new_len = grandparent.len + 1 + basename.len + 1;  // gp + "/" + base + NUL
+            const size_t new_len = grandparent.len + 1 + basename.len + 1;
             new_path = malloc(new_len);
             if (!new_path) {
                 fprintf(stderr, "malloc failed for new_path\n");
@@ -442,15 +538,19 @@ static int cleanup_marfs_index(void) {
             }
 
             if (rename(old.data, new_path) != 0) {
-                fprintf(stderr, "rename('%s' -> '%s') failed: %s\n", old.data, new_path, strerror(errno));
+                if (errno != ENOENT) {
+                    fprintf(stderr, "rename('%s' -> '%s') failed: %s\n", old.data, new_path, strerror(errno));
+                    ret = -1;
+                }
+
                 free(new_path);
-                ret = -1;
                 continue;
             }
+
             free(new_path);
         }
 
-        // attempt to remove the old "parent" of the namespace
+        // remove the now-empty MDAL_subspaces directory
         {
             if (parent.len > 0) {
                 parent_path = malloc(parent.len + 1);
@@ -463,11 +563,9 @@ static int cleanup_marfs_index(void) {
                 memcpy(parent_path, parent.data, parent.len);
                 parent_path[parent.len] = '\0';
 
-                if (rmdir(parent_path) != 0) {
-                    if (errno != ENOTEMPTY) {
-                        fprintf(stderr, "rmdir('%s') failed: %s\n", parent_path, strerror(errno));
-                        ret = -1;
-                    }
+                if (rmdir(parent_path) != 0 && errno != ENOTEMPTY && errno != ENOENT) {
+                    fprintf(stderr, "rmdir('%s') failed: %s\n", parent_path, strerror(errno));
+                    ret = -1;
                 }
             }
 
@@ -475,69 +573,77 @@ static int cleanup_marfs_index(void) {
         }
     }
 
-    // rename the root namespace to the marfs mountpoint from the marfs config
-    const str_t rn_base = get_basename(g_state.root_namespace);
-    const str_t mm_base = get_basename(g_state.marfs_mountpoint);
+    if (g_state.source_is_sec_root) {
+        const str_t source_base = get_basename(g_state.source);
+        const str_t mountpoint_base = get_basename(g_state.marfs_mountpoint);
 
-    char* rn_path = join_path(g_state.index_parent, rn_base);
-    char* mm_path = join_path(g_state.index_parent, mm_base);
+        char* source_path = join_path(g_state.index_parent, source_base);
+        char* mountpoint_path = join_path(g_state.index_parent, mountpoint_base);
 
-    if (!mm_path || !rn_path) {
-        fprintf(stderr, "join_path failed\n");
-        free(mm_path);
-        free(rn_path);
-        return -1;
+        if (!source_path || !mountpoint_path) {
+            fprintf(stderr, "join_path failed\n");
+            free(source_path);
+            free(mountpoint_path);
+            return -1;
+        }
+
+        if (rename(source_path, mountpoint_path) != 0) {
+            fprintf(stderr, "rename('%s' -> '%s') failed: %s\n", source_path, mountpoint_path, strerror(errno));
+            free(source_path);
+            free(mountpoint_path);
+            return -1;
+        }
+
+        free(source_path);
+        free(mountpoint_path);
     }
-
-    if (rename(rn_path, mm_path) != 0) {
-        fprintf(stderr, "rename('%s' -> '%s') failed: %s\n", rn_path, mm_path, strerror(errno));
-        free(mm_path);
-        free(rn_path);
-        return -1;
-    }
-
-    free(mm_path);
-    free(rn_path);
 
     return ret;
 }
 
-// revert_marfs_index will undo everything that's in cleanup_marfs_index. This allows for indexing to be run over an
-// existing index tree without error
+// revert_marfs_index restores the physical MDAL_subspaces layout in an existing
+// index before GUFI updates it.
 static int revert_marfs_index(void) {
     int ret = 0;
 
-    // rename the marfs mountpoint from the marfs config to the root namespace
-    const str_t mm_base = get_basename(g_state.marfs_mountpoint);
-    const str_t rn_base = get_basename(g_state.root_namespace);
+    if (g_state.source_is_sec_root) {
+        const str_t mountpoint_base = get_basename(g_state.marfs_mountpoint);
+        const str_t source_base = get_basename(g_state.source);
 
-    char* mm_path = join_path(g_state.index_parent, mm_base);
-    char* rn_path = join_path(g_state.index_parent, rn_base);
+        char* mountpoint_path = join_path(g_state.index_parent, mountpoint_base);
+        char* source_path = join_path(g_state.index_parent, source_base);
 
-    if (!mm_path || !rn_path) {
-        fprintf(stderr, "join_path failed\n");
-        free(mm_path);
-        free(rn_path);
-        return -1;
-    }
-
-    if (rename(mm_path, rn_path) != 0) {
-        // if we failed to rename the root ns, then don't worry about the rest of the namespaces
-        if (errno != ENOENT) {
-            fprintf(stderr, "rename('%s' -> '%s') failed: %s\n", mm_path, rn_path, strerror(errno));
-            ret = -1;
+        if (!mountpoint_path || !source_path) {
+            fprintf(stderr, "join_path failed\n");
+            free(mountpoint_path);
+            free(source_path);
+            return -1;
         }
-        free(mm_path);
-        free(rn_path);
-        return ret;
+
+        if (rename(mountpoint_path, source_path) != 0) {
+            // if we failed to rename the root ns, then don't worry about the rest of the namespaces
+            if (errno != ENOENT) {
+                fprintf(stderr, "rename('%s' -> '%s') failed: %s\n", mountpoint_path, source_path, strerror(errno));
+                ret = -1;
+            }
+            free(mountpoint_path);
+            free(source_path);
+            return ret;
+        }
+
+        /*
+         * ENOENT is expected on the first run. Continue restoring namespace
+         * paths in case the source-named index root already exists from an
+         * interrupted earlier run.
+         */
+        free(mountpoint_path);
+        free(source_path);
     }
 
-    free(mm_path);
-    free(rn_path);
-
-    // loop through our index namespaces and add a subspaces into them. then move them down into each subspace
+    // parent namespaces must be restored before nested namespaces
     for (size_t i = 0; i < g_state.namespaces_count; i++) {
         const str_t old = g_state.namespaces[i].index_namespace;
+        if (!old.data || old.len == 0) continue;
 
         const str_t basename = get_basename(old);
         const str_t parent = get_parent(old);
@@ -546,8 +652,8 @@ static int revert_marfs_index(void) {
         char* indexed_path = NULL;
         char* parent_path = NULL;
 
-        size_t new_len = grandparent.len + 1 + basename.len + 1;  // gp + "/" + base + NUL
-        indexed_path = malloc(new_len);
+        const size_t indexed_path_len = grandparent.len + 1 + basename.len + 1;
+        indexed_path = malloc(indexed_path_len);
         if (!indexed_path) {
             fprintf(stderr, "malloc failed for indexed_path\n");
             ret = -1;
@@ -555,18 +661,16 @@ static int revert_marfs_index(void) {
         }
 
         if (grandparent.len == 1 && grandparent.data[0] == '/') {
-            snprintf(indexed_path, new_len, "/%.*s", (int)basename.len, basename.data);
+            snprintf(indexed_path, indexed_path_len, "/%.*s", (int)basename.len, basename.data);
         } else {
-            snprintf(indexed_path, new_len, "%.*s/%.*s", (int)grandparent.len, grandparent.data, (int)basename.len,
-                     basename.data);
+            snprintf(indexed_path, indexed_path_len, "%.*s/%.*s", (int)grandparent.len, grandparent.data,
+                     (int)basename.len, basename.data);
         }
 
-        // make an empty MDAL_subspaces in this namespace's parent
+        // create the namespace's MDAL_subspaces parent
         {
-            // parent is a slice, so make a real C string before mkdir()
             if (parent.len > 1) {
-                size_t parent_path_size = parent.len + 1;
-                parent_path = malloc(parent_path_size);
+                parent_path = malloc(parent.len + 1);
                 if (!parent_path) {
                     fprintf(stderr, "malloc failed for parent_path\n");
                     free(indexed_path);
@@ -574,36 +678,36 @@ static int revert_marfs_index(void) {
                     continue;
                 }
 
-                snprintf(parent_path, parent_path_size, "%.*s", (int)parent.len, parent.data);
+                snprintf(parent_path, parent.len + 1, "%.*s", (int)parent.len, parent.data);
 
-                if (mkdir(parent_path, MARFS_DIR_MODE) != 0) {
-                    if (errno != ENOTEMPTY && errno != EEXIST) {
-                        free(parent_path);
-                        free(indexed_path);
-                        continue;
-                    }
+                if (mkdir(parent_path, MARFS_DIR_MODE) != 0 && errno != EEXIST) {
+                    fprintf(stderr, "mkdir('%s') failed: %s\n", parent_path, strerror(errno));
+                    free(parent_path);
+                    free(indexed_path);
+                    ret = -1;
+                    continue;
                 }
 
                 free(parent_path);
             }
         }
 
-        // move this namespace into the MDAL_subspaces we just made
-        {
-            if (rename(indexed_path, old.data) != 0) {
+        if (rename(indexed_path, old.data) != 0) {
+            // The namespace may not be present in an existing partial index.
+            if (errno != ENOENT) {
                 fprintf(stderr, "rename('%s' -> '%s') failed: %s\n", indexed_path, old.data, strerror(errno));
-                free(indexed_path);
-                continue;
+                ret = -1;
             }
-
-            free(indexed_path);
         }
+
+        free(indexed_path);
     }
 
     return ret;
 }
 
-// marfs_indexing_global_init reads the marfs config and adds the namespaces to a global state.
+// marfs_indexing_global_init reads the MarFS config and builds paths relative to
+// the configured sec-root, independently of where GUFI starts indexing.
 static int marfs_indexing_global_init(struct input* in) {
     pthread_mutex_t marfs_erasurelock = PTHREAD_MUTEX_INITIALIZER;
 
@@ -616,9 +720,22 @@ static int marfs_indexing_global_init(struct input* in) {
         return ret;
     }
 
-    // add index parent and root namespace to global state
-    INSTALL_STR(&g_state.index_parent, in->pos.argv[in->pos.argc - 1]);
-    INSTALL_STR(&g_state.root_namespace, in->pos.argv[0]);
+    if (install_path(&g_state.index_parent, in->pos.argv[in->pos.argc - 1]) != 0 ||
+        install_path(&g_state.source, in->pos.argv[0]) != 0) {
+        fprintf(stderr, "Error: could not store GUFI source or index path\n");
+        goto cleanup;
+    }
+
+    char* sec_root = getenv(MARFS_SEC_ROOT_ENV);
+    if (!sec_root || sec_root[0] == '\0') {
+        fprintf(stderr, "Error: %s is not set\n", MARFS_SEC_ROOT_ENV);
+        goto cleanup;
+    }
+
+    if (install_path(&g_state.sec_root, sec_root) != 0) {
+        fprintf(stderr, "Error: could not store %s\n", MARFS_SEC_ROOT_ENV);
+        goto cleanup;
+    }
 
     char* marfs_config_path = getenv(MARFS_CONFIG_ENV);
     if (!marfs_config_path || marfs_config_path[0] == '\0') {
@@ -634,11 +751,9 @@ static int marfs_indexing_global_init(struct input* in) {
         goto cleanup;
     }
 
-    // add marfs config mountpoint to global state
     INSTALL_STR(&g_state.marfs_mountpoint, g_state.marfs_cfg->mountpoint);
 
     g_state.namespaces_count = count_ns_paths(g_state.marfs_cfg->rootns);
-
     if (g_state.namespaces_count == 0) {
         fprintf(stderr, "Error: no namespaces found in MarFS config\n");
         goto cleanup;
@@ -650,15 +765,9 @@ static int marfs_indexing_global_init(struct input* in) {
         goto cleanup;
     }
 
-    {
-        const str_t rn_base = get_basename(g_state.root_namespace);
-        const str_t empty = REFSTR("", 0);
-
-        if (collect_ns_paths(g_state.marfs_cfg->rootns, empty, g_state.namespaces, &config_index,
-                             g_state.root_namespace, g_state.index_parent, rn_base) != 0) {
-            fprintf(stderr, "Error: collect_ns_paths failed\n");
-            goto cleanup;
-        }
+    if (collect_ns_paths(g_state.marfs_cfg->rootns, g_state.sec_root, g_state.namespaces, &config_index) != 0) {
+        fprintf(stderr, "Error: collect_ns_paths failed\n");
+        goto cleanup;
     }
 
     if (config_index != g_state.namespaces_count) {
@@ -669,56 +778,32 @@ static int marfs_indexing_global_init(struct input* in) {
 
     sort_namespace_pairs(g_state.namespaces, g_state.namespaces_count);
 
-    if (!validate_sec_root()) {
-        fprintf(stderr,
-                "Error: provided dir (%s) is not the root of the parent marfs namespace or marfs_config is incorrect\n",
-                g_state.root_namespace.data);
+    if (validate_source() != 0) goto cleanup;
+
+    g_state.source_is_sec_root = path_eq(g_state.source, g_state.sec_root);
+
+    if (build_index_namespace_paths() != 0) {
+        fprintf(stderr, "Error: build_index_namespace_paths failed\n");
         goto cleanup;
     }
 
-    if (revert_marfs_index() != 0) {
-        fprintf(stderr, "Error: revert_marfs_index failed\n");
-        goto cleanup;
-    }
+    // if (revert_marfs_index() != 0) {
+    //     fprintf(stderr, "Error: revert_marfs_index failed\n");
+    //     goto cleanup;
+    // }
 
     sqlite3_initialize();
 
     ret = 0;
 
 cleanup:
-    if (ret != 0) {
-        marfs_plugin_cleanup();
-    }
+    if (ret != 0) marfs_plugin_cleanup();
 
     return ret;
 }
 
-// simple check to determine if a provided file path is a namespace in the marfs config
-static int is_namespace(str_t path) {
-    if (!path.data) {
-        return 0;
-    }
-
-    for (size_t i = 0; i < g_state.namespaces_count; i++) {
-        str_t ns = g_state.namespaces[i].namespace;
-        if (!ns.data) {
-            continue;
-        }
-
-        if (ns.len != path.len) {
-            continue;
-        }
-
-        if (strncmp(ns.data, path.data, ns.len) == 0) {
-            return 1;
-        }
-    }
-
-    return 0;
-}
-
-// marfs_pre_processing_dir checks if we're about to process a marfs specific directory (MDAL_reference, MDAL_subspaces)
-// or a namespace that is no longer active in the marfs config
+// marfs_dir_action identifies MarFS implementation entries by their physical
+// owner path instead of assuming sec-root is GUFI traversal level 0.
 static plugin_dir_action marfs_dir_action(void* ptr) {
     PCS_t* pcs = ptr;
 
@@ -726,43 +811,21 @@ static plugin_dir_action marfs_dir_action(void* ptr) {
     const str_t basename = get_basename(path);
     const str_t parent = get_parent(path);
 
-    if (starts_with_mdal(basename)) {
-        // this directory starts with MDAL_
-
-        // determine if this is a marfs directory or a user dir.
-        // cases for being a marfs dir:
-        // 1. directly under sec-root
-        // 2. directly under a namespace
-        if (ROOT_NAMESPACE_LEVEL == pcs->work->level - 1 || is_namespace(parent)) {
-            if (str_t_eq_cstr(basename, MARFS_SUBSPACES_NAME, MARFS_SUBSPACES_NAME_LEN)) {
-                // this is a subspaces dir. do not process, but still descend
-                return PLUGIN_NO_PROCESS_DIR;
-            } else {
-                // this is any other marfs dir. do not process, do not descend
-                return PLUGIN_NO_PROCESS_NO_DESCEND_DIR;
-            }
-        } else {
-            return PLUGIN_PROCESS_DIR;
+    if (starts_with_mdal(basename) && is_mdal_owner(parent)) {
+        if (str_t_eq_cstr(basename, MARFS_SUBSPACES_NAME, MARFS_SUBSPACES_NAME_LEN)) {
+            // hide MDAL_subspaces itself, but descend into configured child namespaces
+            return PLUGIN_NO_PROCESS_DIR;
         }
+
+        // hide all other MDAL implementation directories
+        return PLUGIN_NO_PROCESS_NO_DESCEND_DIR;
     }
 
-    if (starts_with_mdal(get_basename(parent))) {
-        // parent directory starts with MDAL_
-        // check to see if it's even possible for this dir to be a marfs namespace
-        // cases for this being a marfs namespace:
-        // 1. grandparent is sec-root
-        // 2. grandparent is a namespace
-        const str_t grandparent = get_parent(parent);
-        if (ROOT_NAMESPACE_LEVEL == pcs->work->level - 2 || is_namespace(grandparent)) {
-            // it's possible for this to be a marfs namespace. check the marfs config to be sure that it is currently
-            // active
-            if (is_namespace(path)) {
-                return PLUGIN_PROCESS_DIR;
-            } else {
-                // this dir is not listed in the marfs config so do not process it or descend
-                return PLUGIN_NO_PROCESS_NO_DESCEND_DIR;
-            }
-        }
+    if (is_mdal_subspaces_dir(parent)) {
+        // Only namespaces present in the active config should be traversed.
+        if (is_namespace(path)) return PLUGIN_PROCESS_DIR;
+
+        return PLUGIN_NO_PROCESS_NO_DESCEND_DIR;
     }
 
     return PLUGIN_PROCESS_DIR;
@@ -829,8 +892,8 @@ static void* marfs_ctx_init(void* ptr) {
     return ctx;
 }
 
-// marfs_pre_process_file removes any marfs specific files from the gufi db, decrements every file nlink by 1, and
-// removes any marfs specific xattrs
+// marfs_pre_process_file removes MarFS xattrs, adjusts nlink, and hides MDAL files
+// directly owned by sec-root or a configured namespace.
 static plugin_file_action marfs_pre_process_file(void* ptr, void* user_data) {
     PCS_t* pcs = ptr;
     struct entry_data* ed = pcs->ed;
@@ -839,68 +902,51 @@ static plugin_file_action marfs_pre_process_file(void* ptr, void* user_data) {
     const str_t path = REFSTR(pcs->work->name, pcs->work->name_len);
     const str_t basename = get_basename(path);
 
-    // remove marfs xattr from entry
     const size_t removed = xattr_remove(&ed->xattrs, MARFS_XATTR_NAME, MARFS_XATTR_NAME_LEN);
 
-    // decrement nlink if the marfs xattr was removed
     if (removed > 0 && pcs->work->statuso.st_nlink > (nlink_t)0) {
         pcs->work->statuso.st_nlink--;
     }
 
-    // remove mdal specific files
-    if (basename.len >= MARFS_PREFIX_LEN && starts_with_mdal(basename)) {
-        // this files starts with MDAL_
-
-        const str_t parent = get_parent(path);
-
-        // determine if this is actual a marfs file or a user file
-        // cases for being a marfs file:
-        // 1. directly under sec-root
-        // 2. directly under a namespace
-        if (ROOT_NAMESPACE_LEVEL == pcs->work->level - 1 || is_namespace(parent)) {
-            // this is a marfs file. do not add it to the database
-            return PLUGIN_NO_PROCESS_FILE;
-        }
+    if (starts_with_mdal(basename) && is_mdal_owner(get_parent(path))) {
+        return PLUGIN_NO_PROCESS_FILE;
     }
 
     return PLUGIN_PROCESS_FILE;
 }
 
-// marfs_process_dir renames the root namespace in the gufi db summary table to match the mountpoint in the marfs
-// config. The actual dir gets renamed in cleanup_marfs_index. It also fixes pinode values for directories whose
-// parent is an MDAL_subspaces directory that will be removed from the final index.
+// Fix pinode only for configured namespaces whose MDAL_subspaces parent will be
+// removed from this particular index.
 static void marfs_pre_process_dir(void* ptr, void* user_data) {
     PCS_t* pcs = ptr;
     (void)user_data;
 
     const str_t path = REFSTR(pcs->work->name, pcs->work->name_len);
+
+    if (!namespace_is_rewritten(path)) return;
+
     const str_t parent = get_parent(path);
-    const str_t parent_basename = get_basename(parent);
+    if (!is_mdal_subspaces_dir(parent)) return;
 
-    // Fix pinode for directories whose parent is MDAL_subspaces (which will be removed)
-    // The pinode currently points to the MDAL_subspaces inode, but should point to the grandparent
-    if (parent_basename.data && str_t_eq_cstr(parent_basename, MARFS_SUBSPACES_NAME, MARFS_SUBSPACES_NAME_LEN)) {
-        const str_t grandparent = get_parent(parent);
+    const str_t grandparent = get_parent(parent);
+    if (!grandparent.data || grandparent.len == 0) return;
 
-        if (grandparent.data && grandparent.len > 0) {
-            size_t gp_path_size = grandparent.len + 1;
-            char* gp_path = malloc(gp_path_size);
-            if (gp_path) {
-                snprintf(gp_path, gp_path_size, "%.*s", (int)grandparent.len, grandparent.data);
-
-                struct stat st;
-                if (stat(gp_path, &st) == 0) {
-                    pcs->work->pinode = (long long int)st.st_ino;
-                } else {
-                    fprintf(stderr, "plugin: stat('%s') failed: %s\n", gp_path, strerror(errno));
-                }
-
-                free(gp_path);
-            } else {
-                fprintf(stderr, "malloc failed for gp_path\n");
-            }
-        }
+    char* grandparent_path = malloc(grandparent.len + 1);
+    if (!grandparent_path) {
+        fprintf(stderr, "malloc failed for grandparent_path\n");
+        return;
     }
+
+    snprintf(grandparent_path, grandparent.len + 1, "%.*s", (int)grandparent.len, grandparent.data);
+
+    struct stat st;
+    if (stat(grandparent_path, &st) == 0) {
+        pcs->work->pinode = (long long int)st.st_ino;
+    } else {
+        fprintf(stderr, "plugin: stat('%s') failed: %s\n", grandparent_path, strerror(errno));
+    }
+
+    free(grandparent_path);
 }
 
 // marfs_process_dir renames the root namespace in the gufi db summary table to match the mountpoint in the marfs
@@ -913,9 +959,8 @@ static void marfs_post_process_dir(void* ptr, void* user_data) {
     const str_t path = REFSTR(pcs->work->name, pcs->work->name_len);
     const str_t basename = get_basename(path);
 
-    // determine if this is the root namespace dir
-    if (ROOT_NAMESPACE_LEVEL == pcs->work->level &&
-        str_t_eq_cstr(g_state.root_namespace, pcs->work->name, pcs->work->name_len)) {
+    // Only a sec-root index is renamed to the MarFS mountpoint.
+    if (g_state.source_is_sec_root && path_eq(path, g_state.source)) {
         // Rename root namespace to mountpoint in database
         const str_t mountpoint = get_basename(g_state.marfs_mountpoint);
 

--- a/contrib/plugins/marfs_plugin.c
+++ b/contrib/plugins/marfs_plugin.c
@@ -171,6 +171,15 @@ static void sort_namespace_pairs(namespace_pair* namespace_list, size_t namespac
     qsort(namespace_list, namespace_count, sizeof *namespace_list, cmp_str_t_ptr);
 }
 
+// return a path with trailing slashes removed, except for "/"
+static str_t trim_trailing_slashes(str_t path) {
+    while (path.len > 1 && path.data[path.len - 1] == '/') {
+        path.len--;
+    }
+
+    return path;
+}
+
 // returns the basename of a path
 static str_t get_basename(str_t path) {
     path = trim_trailing_slashes(path);
@@ -223,15 +232,6 @@ static int str_t_eq_cstr(str_t s, const char* cstr, size_t cstr_len) {
     return strncmp(s.data, cstr, cstr_len) == 0;
 }
 
-// return a path with trailing slashes removed, except for "/"
-static str_t trim_trailing_slashes(str_t path) {
-    while (path.len > 1 && path.data[path.len - 1] == '/') {
-        path.len--;
-    }
-
-    return path;
-}
-
 static void trim_trailing_slashes_in_place(str_t* path) {
     while (path->len > 1 && path->data[path->len - 1] == '/') {
         path->len--;
@@ -243,7 +243,9 @@ static int path_eq(str_t lhs, str_t rhs) {
     lhs = trim_trailing_slashes(lhs);
     rhs = trim_trailing_slashes(rhs);
 
-    return str_cmp(&lhs, &rhs) == 0;
+    if (lhs.len != rhs.len) return 0;
+
+    return strncmp(lhs.data, rhs.data, rhs.len) == 0;
 }
 
 // check whether path is root itself or is below root on a path-component boundary
@@ -264,7 +266,7 @@ static str_t get_relative_path(str_t path, str_t root) {
     path = trim_trailing_slashes(path);
     root = trim_trailing_slashes(root);
 
-    if (!path_is_at_or_below(path, root) || str_cmp(&path, &root)) {
+    if (!path_is_at_or_below(path, root) || path_eq(path, root)) {
         return (str_t)REFSTR(NULL, 0);
     }
 
@@ -500,6 +502,7 @@ static int cleanup_marfs_index(void) {
     // loop through our index namespaces and move them up a directory and delete the unecessary MDAL_subspaces
     for (size_t i = g_state.namespaces_count; i-- > 0;) {
         const str_t old = g_state.namespaces[i].index_namespace;
+        if (!str_exists(&old)) continue;
 
         const str_t basename = get_basename(old);
         const str_t parent = get_parent(old);
@@ -669,6 +672,7 @@ static int revert_marfs_index(void) {
     // loop through our index namespaces and add a subspaces into them. then move them down into each subspace
     for (size_t i = 0; i < g_state.namespaces_count; i++) {
         const str_t old = g_state.namespaces[i].index_namespace;
+        if (!str_exists(&old)) continue;
 
         const str_t basename = get_basename(old);
         const str_t parent = get_parent(old);

--- a/contrib/plugins/marfs_plugin.c
+++ b/contrib/plugins/marfs_plugin.c
@@ -71,27 +71,39 @@ OF SUCH DAMAGE.
  *
  * High level behavior:
  *
- * 1. Reads the MarFS config specified by MARFS_CONFIG_PATH and the physical
- *    MDAL sec-root specified by MARFS_SEC_ROOT. The GUFI source may be the
- *    sec-root, a configured namespace, or a normal directory below one.
+ * 1. Reads the MarFS config specified by MARFS_CONFIG_PATH and discovers all
+ *    configured namespaces under the MDAL sec-root specified by
+ *    MARFS_SEC_ROOT. The selected GUFI source may be the sec-root, a
+ *    configured namespace, or a normal directory below one.
  *
- * 2. Builds the full physical path of every configured namespace from the
- *    configured sec-root. It separately builds temporary index paths only for
- *    configured namespaces below the selected GUFI source.
+ * 2. Builds a sorted list of namespace pairs:
+ *      - namespace:        the real namespace path under sec-root
+ *      - index_namespace:  the corresponding path GUFI will see in the
+ *                          temporary index tree
  *
- * 3. Before indexing begins, restores MDAL_subspaces directories in an
- *    existing index so GUFI can update the physical traversal layout.
+ * 3. Before indexing begins, rewrites the on-disk index layout to match the
+ *    MarFS namespace structure expected by this plugin. In particular, it
+ *    restores MDAL_subspaces directories and renames the indexed root from
+ *    the MarFS mountpoint back to the configured root namespace so repeated
+ *    indexing runs work correctly.
  *
- * 4. During traversal, identifies MarFS metadata by checking whether its
- *    parent is the configured sec-root or a configured namespace. This avoids
- *    depending on GUFI traversal levels.
+ * 4. During traversal, filters out MarFS internal directories and files
+ *    (such as MDAL_* entries) so GUFI does not index MarFS metadata as user
+ *    content. It also skips namespaces that exist on disk but are no longer
+ *    present in the current MarFS config.
  *
- * 5. While processing files, removes MarFS xattrs, decrements link counts to
- *    account for MarFS metadata links, and hides MarFS implementation files.
+ * 5. While processing files, removes MarFS specific database entries,
+ *    decrements link counts to account for MarFS metadata links, and strips
+ *    MarFS xattrs from the stored xattr list.
  *
- * 6. After indexing completes, moves configured child namespaces out of
- *    MDAL_subspaces in the generated index. The index root is renamed to the
- *    MarFS mountpoint only when the selected source is the sec-root itself.
+ * 6. While processing directories, renames the indexed root namespace in the
+ *    GUFI summary table so the final index presents the MarFS mountpoint name
+ *    instead of the raw sec-root namespace name when indexing from sec-root.
+ *
+ * 7. After indexing completes, restores the index tree into a cleaner final
+ *    form by moving namespace directories up out of MDAL_subspaces, removing
+ *    empty MDAL_subspaces directories, and renaming the indexed root back to
+ *    the MarFS mountpoint basename.
  *
  * build instruction:
  *
@@ -135,6 +147,7 @@ static const char MARFS_SUBSPACES_NAME[] = "MDAL_subspaces";
 static const size_t MARFS_SUBSPACES_NAME_LEN = sizeof(MARFS_SUBSPACES_NAME) - 1;
 static const char MARFS_XATTR_NAME[] = "user.MDAL_MARFS-FILE";
 static const size_t MARFS_XATTR_NAME_LEN = sizeof(MARFS_XATTR_NAME) - 1;
+static const size_t ROOT_NAMESPACE_LEVEL = 0;
 // marfs dir mode used for temporary additions of marfs specific directories during re-indexing
 static const mode_t MARFS_DIR_MODE = S_IRWXU | S_IXOTH;
 
@@ -262,10 +275,8 @@ struct marfs_plugin {
 
     str_t index_parent;  // actual index is placed at <index parent>/$(basename <src>)
     str_t marfs_mountpoint;
+    str_t root_namespace;
     str_t source;
-    str_t sec_root;
-
-    int source_is_sec_root;
 
     marfs_config* marfs_cfg;
 };
@@ -283,12 +294,11 @@ static void marfs_plugin_cleanup(void) {
 
     str_free_existing(&g_state.index_parent);
     str_free_existing(&g_state.marfs_mountpoint);
+    str_free_existing(&g_state.root_namespace);
     str_free_existing(&g_state.source);
-    str_free_existing(&g_state.sec_root);
 
     g_state.namespaces = NULL;
     g_state.namespaces_count = 0;
-    g_state.source_is_sec_root = 0;
 
     // cleanup marfs config
     config_term(g_state.marfs_cfg);
@@ -314,68 +324,66 @@ static size_t count_ns_paths(marfs_ns* ns) {
     return total;
 }
 
-// retrieve the physical namespace paths from the marfs config
-static int collect_ns_paths(marfs_ns* ns, str_t parent_namespace, namespace_pair* paths, size_t* index) {
+// retrieve the namespace paths from the marfs config and build namespace pairs
+static int collect_ns_paths(marfs_ns* ns, str_t parent_path, namespace_pair* paths, size_t* index,
+                            str_t root_namespace) {
+    if (!ns || !paths || !index || !root_namespace.data) return -1;
+
     for (size_t i = 0; i < ns->subnodecount; i++) {
         HASH_NODE* hn = &ns->subnodes[i];
         marfs_ns* child = (marfs_ns*)hn->content;
 
         if (!hn->name || !child) continue;
 
-        namespace_pair* pair = &paths[*index];
+        str_t path = {0};
         const size_t name_len = strlen(hn->name);
-        const size_t namespace_len = parent_namespace.len + 1 + MARFS_SUBSPACES_NAME_LEN + 1 + name_len;
 
-        if (!str_alloc_existing(&pair->namespace, namespace_len)) return -1;
+        if (parent_path.len == 0) {
+            const size_t path_len = name_len;
 
-        snprintf(pair->namespace.data, namespace_len + 1, "%.*s/%s/%s", (int)parent_namespace.len,
-                 parent_namespace.data, MARFS_SUBSPACES_NAME, hn->name);
+            if (!str_alloc_existing(&path, path_len)) return -1;
+
+            snprintf(path.data, path_len + 1, "%s", hn->name);
+        } else {
+            // add an MDAL_subspaces dir into the path
+            const size_t path_len = parent_path.len + 1 + MARFS_SUBSPACES_NAME_LEN + 1 + name_len;
+
+            if (!str_alloc_existing(&path, path_len)) return -1;
+
+            snprintf(path.data, path_len + 1, "%.*s/%s/%s", (int)parent_path.len, parent_path.data,
+                     MARFS_SUBSPACES_NAME, hn->name);
+        }
+
+        // build namespace path
+        {
+            namespace_pair* pair = &paths[*index];
+            const size_t namespace_len = root_namespace.len + 1 + MARFS_SUBSPACES_NAME_LEN + 1 + path.len;
+
+            if (!str_alloc_existing(&pair->namespace, namespace_len)) {
+                str_free_existing(&path);
+                return -1;
+            }
+
+            snprintf(pair->namespace.data, namespace_len + 1, "%.*s/%s/%.*s", (int)root_namespace.len,
+                     root_namespace.data, MARFS_SUBSPACES_NAME, (int)path.len, path.data);
+        }
 
         (*index)++;
 
-        if (collect_ns_paths(child, pair->namespace, paths, index) != 0) return -1;
-    }
-
-    return 0;
-}
-
-// simple check to determine if a provided file path is a namespace in the marfs config
-static int is_namespace(str_t path) {
-    if (!path.data) return 0;
-
-    for (size_t i = 0; i < g_state.namespaces_count; i++) {
-        if (str_t_eq(g_state.namespaces[i].namespace, path)) return 1;
-    }
-
-    return 0;
-}
-
-// sec-root and configured namespaces are the directories that own MDAL metadata
-static int is_mdal_owner(str_t path) { 
-    return str_t_eq(path, g_state.sec_root) || is_namespace(path); 
-}
-
-static int is_mdal_subspaces_dir(str_t path) {
-    if (!path.data) return 0;
-
-    const str_t basename = get_basename(path);
-    if (!str_t_eq_cstr(basename, MARFS_SUBSPACES_NAME, MARFS_SUBSPACES_NAME_LEN)) return 0;
-
-    return is_mdal_owner(get_parent(path));
-}
-
-static int namespace_is_rewritten(str_t path) {
-    for (size_t i = 0; i < g_state.namespaces_count; i++) {
-        namespace_pair* pair = &g_state.namespaces[i];
-        if (str_t_eq(pair->namespace, path)) {
-            return pair->index_namespace.data && pair->index_namespace.len > 0;
+        if (collect_ns_paths(child, path, paths, index, root_namespace) != 0) {
+            (*index)--;
+            str_free_existing(&paths[*index].namespace);
+            str_free_existing(&path);
+            return -1;
         }
+
+        str_free_existing(&path);
     }
 
     return 0;
 }
 
-// build only the index paths for configured namespaces that are below the selected source
+// build index paths only for configured namespaces below the selected source
 static int build_index_namespace_paths(void) {
     const str_t source_base = get_basename(g_state.source);
     if (!source_base.data || source_base.len == 0) return -1;
@@ -400,57 +408,66 @@ static int build_index_namespace_paths(void) {
     return 0;
 }
 
-// validate the configured sec-root and ensure the selected source is a usable path inside it
+// validate that we are actually pointed at the root namespace of a marfs-mdal (sec-root).
+// There should be an MDAL_subspaces directly under the root namespace
+// then there should be our first namespaces right under the MDAL_subspaces
+// NOTE: this requires that the namespaces be sorted beforehand
+static int validate_sec_root(void) {
+    struct stat st;
+    int ret = 0;
+    char* path = NULL;
+    int len;
+
+    if (!g_state.root_namespace.data || g_state.root_namespace.len == 0) goto cleanup;
+    if (!g_state.namespaces || g_state.namespaces_count == 0) goto cleanup;
+
+    // check if MDAL_subspaces exists under the target dir
+    len = snprintf(NULL, 0, "%s/%s", g_state.root_namespace.data, MARFS_SUBSPACES_NAME);
+    if (len < 0) goto cleanup;
+
+    path = malloc((size_t)len + 1);
+    if (!path) goto cleanup;
+
+    snprintf(path, (size_t)len + 1, "%s/%s", g_state.root_namespace.data, MARFS_SUBSPACES_NAME);
+
+    if (stat(path, &st) != 0 || !S_ISDIR(st.st_mode)) goto cleanup;
+
+    // check if one of the top namespaces is in the first MDAL_subspaces
+    if (stat(g_state.namespaces[0].namespace.data, &st) != 0 || !S_ISDIR(st.st_mode)) goto cleanup;
+
+    ret = 1;
+
+cleanup:
+    free(path);
+    return ret;
+}
+
+// validate that the selected source is a usable path within sec-root
 static int validate_source(void) {
     struct stat st;
 
-    if (g_state.sec_root.data[0] != '/' || g_state.source.data[0] != '/') {
+    if (g_state.root_namespace.data[0] != '/' || g_state.source.data[0] != '/') {
         fprintf(stderr, "Error: source and %s must both be absolute paths\n", MARFS_SEC_ROOT_ENV);
-        return -1;
-    }
-
-    if (stat(g_state.sec_root.data, &st) != 0 || !S_ISDIR(st.st_mode)) {
-        fprintf(stderr, "Error: %s (%s) is not a directory\n", MARFS_SEC_ROOT_ENV, g_state.sec_root.data);
-        return -1;
-    }
-
-    {
-        const str_t subspaces_name = REFSTR(MARFS_SUBSPACES_NAME, MARFS_SUBSPACES_NAME_LEN);
-        char* subspaces = join_path(g_state.sec_root, subspaces_name);
-
-        if (!subspaces) {
-            fprintf(stderr, "Error: could not build sec-root MDAL_subspaces path\n");
-            return -1;
-        }
-
-        if (stat(subspaces, &st) != 0 || !S_ISDIR(st.st_mode)) {
-            fprintf(stderr, "Error: %s (%s) does not contain %s\n", MARFS_SEC_ROOT_ENV, g_state.sec_root.data,
-                    MARFS_SUBSPACES_NAME);
-            free(subspaces);
-            return -1;
-        }
-
-        free(subspaces);
+        return 0;
     }
 
     if (stat(g_state.source.data, &st) != 0 || !S_ISDIR(st.st_mode)) {
         fprintf(stderr, "Error: source (%s) is not a directory\n", g_state.source.data);
-        return -1;
+        return 0;
     }
 
-    if (!path_is_at_or_below(g_state.source, g_state.sec_root)) {
+    if (!path_is_at_or_below(g_state.source, g_state.root_namespace)) {
         fprintf(stderr, "Error: source (%s) is not within %s (%s)\n", g_state.source.data, MARFS_SEC_ROOT_ENV,
-                g_state.sec_root.data);
-        return -1;
+                g_state.root_namespace.data);
+        return 0;
     }
 
     /*
      * Find the deepest configured namespace containing the source. Relative
      * to that owner, a leading MDAL_* component means the user selected an
-     * internal MarFS implementation directory. Selecting the namespace itself
-     * is valid because it becomes the root of the generated index.
+     * internal MarFS implementation directory.
      */
-    str_t owner = g_state.sec_root;
+    str_t owner = g_state.root_namespace;
 
     for (size_t i = 0; i < g_state.namespaces_count; i++) {
         const str_t ns = g_state.namespaces[i].namespace;
@@ -459,25 +476,22 @@ static int validate_source(void) {
 
     if (!str_t_eq(g_state.source, owner)) {
         const str_t relative = get_relative_path(g_state.source, owner);
-        const str_t first = get_first_component(relative);
-
-        if (starts_with_mdal(first)) {
-            fprintf(stderr, "Error: source (%s) is inside MarFS internal directory %.*s\n", g_state.source.data,
-                    (int)first.len, first.data);
-            return -1;
+        if (starts_with_mdal(get_first_component(relative))) {
+            fprintf(stderr, "Error: source (%s) is inside a MarFS internal directory\n", g_state.source.data);
+            return 0;
         }
     }
 
-    return 0;
+    return 1;
 }
 
-// cleanup_marfs_index moves configured namespaces below the selected source out of
-// MDAL_subspaces directories. When indexing sec-root, it also renames the index root
-// to the basename of the MarFS mountpoint.
+// cleanup_marfs_index will go through each namespace defined in the marfs config, move it up a directory, and delete
+// the empty MDAL_subspaces that remains. It also removes any empty MDAL_subspaces that exist within the namespace as
+// well as renaming the sec-root index to the basename of the specified mountpoint in the marfs config
 static int cleanup_marfs_index(void) {
     int ret = 0;
 
-    // deepest namespaces must be moved before their parents
+    // loop through our index namespaces and move them up a directory and delete the unecessary MDAL_subspaces
     for (size_t i = g_state.namespaces_count; i-- > 0;) {
         const str_t old = g_state.namespaces[i].index_namespace;
         if (!old.data || old.len == 0) continue;
@@ -490,9 +504,10 @@ static int cleanup_marfs_index(void) {
         char* parent_path = NULL;
         char* child_subspaces = NULL;
 
-        // remove an empty MDAL_subspaces contained by this namespace
+        // check to see if there is an empty MDAL_subspaces within this namespace
         {
-            const size_t child_subspaces_len = old.len + 1 + MARFS_SUBSPACES_NAME_LEN + 1;
+            size_t child_subspaces_len =
+                old.len + 1 + MARFS_SUBSPACES_NAME_LEN + 1;  // old + "/" + MDAL_subspaces + NUL
             child_subspaces = malloc(child_subspaces_len);
             if (!child_subspaces) {
                 fprintf(stderr, "malloc failed for child_subspaces\n");
@@ -501,18 +516,18 @@ static int cleanup_marfs_index(void) {
             }
 
             snprintf(child_subspaces, child_subspaces_len, "%.*s/%s", (int)old.len, old.data, MARFS_SUBSPACES_NAME);
-
-            if (rmdir(child_subspaces) != 0 && errno != ENOTEMPTY && errno != ENOENT) {
-                fprintf(stderr, "rmdir('%s') failed: %s\n", child_subspaces, strerror(errno));
-                ret = -1;
+            if (rmdir(child_subspaces) != 0) {
+                if (errno != ENOTEMPTY && errno != ENOENT) {
+                    fprintf(stderr, "rmdir('%s') failed: %s\n", child_subspaces, strerror(errno));
+                    ret = -1;
+                }
             }
-
             free(child_subspaces);
         }
 
-        // move this namespace out of MDAL_subspaces
+        // move this namespace up a directory (into its grandparent)
         {
-            const size_t new_len = grandparent.len + 1 + basename.len + 1;
+            size_t new_len = grandparent.len + 1 + basename.len + 1;  // gp + "/" + base + NUL
             new_path = malloc(new_len);
             if (!new_path) {
                 fprintf(stderr, "malloc failed for new_path\n");
@@ -528,19 +543,15 @@ static int cleanup_marfs_index(void) {
             }
 
             if (rename(old.data, new_path) != 0) {
-                if (errno != ENOENT) {
-                    fprintf(stderr, "rename('%s' -> '%s') failed: %s\n", old.data, new_path, strerror(errno));
-                    ret = -1;
-                }
-
+                fprintf(stderr, "rename('%s' -> '%s') failed: %s\n", old.data, new_path, strerror(errno));
                 free(new_path);
+                ret = -1;
                 continue;
             }
-
             free(new_path);
         }
 
-        // remove the now-empty MDAL_subspaces directory
+        // attempt to remove the old "parent" of the namespace
         {
             if (parent.len > 0) {
                 parent_path = malloc(parent.len + 1);
@@ -553,9 +564,11 @@ static int cleanup_marfs_index(void) {
                 memcpy(parent_path, parent.data, parent.len);
                 parent_path[parent.len] = '\0';
 
-                if (rmdir(parent_path) != 0 && errno != ENOTEMPTY && errno != ENOENT) {
-                    fprintf(stderr, "rmdir('%s') failed: %s\n", parent_path, strerror(errno));
-                    ret = -1;
+                if (rmdir(parent_path) != 0) {
+                    if (errno != ENOTEMPTY) {
+                        fprintf(stderr, "rmdir('%s') failed: %s\n", parent_path, strerror(errno));
+                        ret = -1;
+                    }
                 }
             }
 
@@ -563,74 +576,92 @@ static int cleanup_marfs_index(void) {
         }
     }
 
-    if (g_state.source_is_sec_root) {
-        const str_t source_base = get_basename(g_state.source);
-        const str_t mountpoint_base = get_basename(g_state.marfs_mountpoint);
+    // rename the root namespace to the marfs mountpoint from the marfs config
+    if (str_t_eq(g_state.source, g_state.root_namespace)) {
+        const str_t rn_base = get_basename(g_state.root_namespace);
+        const str_t mm_base = get_basename(g_state.marfs_mountpoint);
 
-        char* source_path = join_path(g_state.index_parent, source_base);
-        char* mountpoint_path = join_path(g_state.index_parent, mountpoint_base);
+        char* rn_path = join_path(g_state.index_parent, rn_base);
+        char* mm_path = join_path(g_state.index_parent, mm_base);
 
-        if (!source_path || !mountpoint_path) {
+        if (!mm_path || !rn_path) {
             fprintf(stderr, "join_path failed\n");
-            free(source_path);
-            free(mountpoint_path);
+            free(mm_path);
+            free(rn_path);
             return -1;
         }
 
-        if (rename(source_path, mountpoint_path) != 0) {
-            fprintf(stderr, "rename('%s' -> '%s') failed: %s\n", source_path, mountpoint_path, strerror(errno));
-            free(source_path);
-            free(mountpoint_path);
+        if (rename(rn_path, mm_path) != 0) {
+            fprintf(stderr, "rename('%s' -> '%s') failed: %s\n", rn_path, mm_path, strerror(errno));
+            free(mm_path);
+            free(rn_path);
             return -1;
         }
 
-        free(source_path);
-        free(mountpoint_path);
+        free(mm_path);
+        free(rn_path);
     }
 
     return ret;
 }
 
-// revert_marfs_index restores the physical MDAL_subspaces layout in an existing
-// index before GUFI updates it.
+// revert_marfs_index will undo everything that's in cleanup_marfs_index. This allows for indexing to be run over an
+// existing index tree without error
 static int revert_marfs_index(void) {
     int ret = 0;
 
-    if (g_state.source_is_sec_root) {
-        const str_t mountpoint_base = get_basename(g_state.marfs_mountpoint);
-        const str_t source_base = get_basename(g_state.source);
+    // rename the marfs mountpoint from the marfs config to the root namespace
+    if (str_t_eq(g_state.source, g_state.root_namespace)) {
+        const str_t mm_base = get_basename(g_state.marfs_mountpoint);
+        const str_t rn_base = get_basename(g_state.root_namespace);
 
-        char* mountpoint_path = join_path(g_state.index_parent, mountpoint_base);
-        char* source_path = join_path(g_state.index_parent, source_base);
+        char* mm_path = join_path(g_state.index_parent, mm_base);
+        char* rn_path = join_path(g_state.index_parent, rn_base);
 
-        if (!mountpoint_path || !source_path) {
+        if (!mm_path || !rn_path) {
             fprintf(stderr, "join_path failed\n");
-            free(mountpoint_path);
-            free(source_path);
+            free(mm_path);
+            free(rn_path);
             return -1;
         }
 
-        if (rename(mountpoint_path, source_path) != 0) {
+        if (rename(mm_path, rn_path) != 0) {
             // if we failed to rename the root ns, then don't worry about the rest of the namespaces
             if (errno != ENOENT) {
-                fprintf(stderr, "rename('%s' -> '%s') failed: %s\n", mountpoint_path, source_path, strerror(errno));
+                fprintf(stderr, "rename('%s' -> '%s') failed: %s\n", mm_path, rn_path, strerror(errno));
                 ret = -1;
             }
-            free(mountpoint_path);
+            free(mm_path);
+            free(rn_path);
+            return ret;
+        }
+
+        free(mm_path);
+        free(rn_path);
+    } else {
+        // there is nothing to restore on the first indexing run
+        const str_t source_base = get_basename(g_state.source);
+        char* source_path = join_path(g_state.index_parent, source_base);
+        struct stat st;
+
+        if (!source_path) {
+            fprintf(stderr, "join_path failed\n");
+            return -1;
+        }
+
+        if (stat(source_path, &st) != 0) {
+            if (errno != ENOENT) {
+                fprintf(stderr, "stat('%s') failed: %s\n", source_path, strerror(errno));
+                ret = -1;
+            }
             free(source_path);
             return ret;
         }
 
-        /*
-         * ENOENT is expected on the first run. Continue restoring namespace
-         * paths in case the source-named index root already exists from an
-         * interrupted earlier run.
-         */
-        free(mountpoint_path);
         free(source_path);
     }
 
-    // parent namespaces must be restored before nested namespaces
+    // loop through our index namespaces and add a subspaces into them. then move them down into each subspace
     for (size_t i = 0; i < g_state.namespaces_count; i++) {
         const str_t old = g_state.namespaces[i].index_namespace;
         if (!old.data || old.len == 0) continue;
@@ -642,8 +673,8 @@ static int revert_marfs_index(void) {
         char* indexed_path = NULL;
         char* parent_path = NULL;
 
-        const size_t indexed_path_len = grandparent.len + 1 + basename.len + 1;
-        indexed_path = malloc(indexed_path_len);
+        size_t new_len = grandparent.len + 1 + basename.len + 1;  // gp + "/" + base + NUL
+        indexed_path = malloc(new_len);
         if (!indexed_path) {
             fprintf(stderr, "malloc failed for indexed_path\n");
             ret = -1;
@@ -651,16 +682,18 @@ static int revert_marfs_index(void) {
         }
 
         if (grandparent.len == 1 && grandparent.data[0] == '/') {
-            snprintf(indexed_path, indexed_path_len, "/%.*s", (int)basename.len, basename.data);
+            snprintf(indexed_path, new_len, "/%.*s", (int)basename.len, basename.data);
         } else {
-            snprintf(indexed_path, indexed_path_len, "%.*s/%.*s", (int)grandparent.len, grandparent.data,
-                     (int)basename.len, basename.data);
+            snprintf(indexed_path, new_len, "%.*s/%.*s", (int)grandparent.len, grandparent.data, (int)basename.len,
+                     basename.data);
         }
 
-        // create the namespace's MDAL_subspaces parent
+        // make an empty MDAL_subspaces in this namespace's parent
         {
+            // parent is a slice, so make a real C string before mkdir()
             if (parent.len > 1) {
-                parent_path = malloc(parent.len + 1);
+                size_t parent_path_size = parent.len + 1;
+                parent_path = malloc(parent_path_size);
                 if (!parent_path) {
                     fprintf(stderr, "malloc failed for parent_path\n");
                     free(indexed_path);
@@ -668,36 +701,36 @@ static int revert_marfs_index(void) {
                     continue;
                 }
 
-                snprintf(parent_path, parent.len + 1, "%.*s", (int)parent.len, parent.data);
+                snprintf(parent_path, parent_path_size, "%.*s", (int)parent.len, parent.data);
 
-                if (mkdir(parent_path, MARFS_DIR_MODE) != 0 && errno != EEXIST) {
-                    fprintf(stderr, "mkdir('%s') failed: %s\n", parent_path, strerror(errno));
-                    free(parent_path);
-                    free(indexed_path);
-                    ret = -1;
-                    continue;
+                if (mkdir(parent_path, MARFS_DIR_MODE) != 0) {
+                    if (errno != ENOTEMPTY && errno != EEXIST) {
+                        free(parent_path);
+                        free(indexed_path);
+                        continue;
+                    }
                 }
 
                 free(parent_path);
             }
         }
 
-        if (rename(indexed_path, old.data) != 0) {
-            // The namespace may not be present in an existing partial index.
-            if (errno != ENOENT) {
+        // move this namespace into the MDAL_subspaces we just made
+        {
+            if (rename(indexed_path, old.data) != 0) {
                 fprintf(stderr, "rename('%s' -> '%s') failed: %s\n", indexed_path, old.data, strerror(errno));
-                ret = -1;
+                free(indexed_path);
+                continue;
             }
-        }
 
-        free(indexed_path);
+            free(indexed_path);
+        }
     }
 
     return ret;
 }
 
-// marfs_indexing_global_init reads the MarFS config and builds paths relative to
-// the configured sec-root, independently of where GUFI starts indexing.
+// marfs_indexing_global_init reads the marfs config and adds the namespaces to a global state.
 static int marfs_indexing_global_init(struct input* in) {
     pthread_mutex_t marfs_erasurelock = PTHREAD_MUTEX_INITIALIZER;
 
@@ -710,11 +743,9 @@ static int marfs_indexing_global_init(struct input* in) {
         return ret;
     }
 
-    if (INSTALL_STR(&g_state.index_parent, in->pos.argv[in->pos.argc - 1]) != 0 ||
-        INSTALL_STR(&g_state.source, in->pos.argv[0]) != 0) {
-        fprintf(stderr, "Error: could not store GUFI source or index path\n");
-        goto cleanup;
-    }
+    // add index parent, selected source, and root namespace to global state
+    INSTALL_STR(&g_state.index_parent, in->pos.argv[in->pos.argc - 1]);
+    INSTALL_STR(&g_state.source, in->pos.argv[0]);
 
     char* sec_root = getenv(MARFS_SEC_ROOT_ENV);
     if (!sec_root || sec_root[0] == '\0') {
@@ -722,10 +753,7 @@ static int marfs_indexing_global_init(struct input* in) {
         goto cleanup;
     }
 
-    if (INSTALL_STR(&g_state.sec_root, sec_root) != 0) {
-        fprintf(stderr, "Error: could not store %s\n", MARFS_SEC_ROOT_ENV);
-        goto cleanup;
-    }
+    INSTALL_STR(&g_state.root_namespace, sec_root);
 
     char* marfs_config_path = getenv(MARFS_CONFIG_ENV);
     if (!marfs_config_path || marfs_config_path[0] == '\0') {
@@ -741,9 +769,11 @@ static int marfs_indexing_global_init(struct input* in) {
         goto cleanup;
     }
 
+    // add marfs config mountpoint to global state
     INSTALL_STR(&g_state.marfs_mountpoint, g_state.marfs_cfg->mountpoint);
 
     g_state.namespaces_count = count_ns_paths(g_state.marfs_cfg->rootns);
+
     if (g_state.namespaces_count == 0) {
         fprintf(stderr, "Error: no namespaces found in MarFS config\n");
         goto cleanup;
@@ -755,9 +785,14 @@ static int marfs_indexing_global_init(struct input* in) {
         goto cleanup;
     }
 
-    if (collect_ns_paths(g_state.marfs_cfg->rootns, g_state.sec_root, g_state.namespaces, &config_index) != 0) {
-        fprintf(stderr, "Error: collect_ns_paths failed\n");
-        goto cleanup;
+    {
+        const str_t empty = REFSTR("", 0);
+
+        if (collect_ns_paths(g_state.marfs_cfg->rootns, empty, g_state.namespaces, &config_index,
+                             g_state.root_namespace) != 0) {
+            fprintf(stderr, "Error: collect_ns_paths failed\n");
+            goto cleanup;
+        }
     }
 
     if (config_index != g_state.namespaces_count) {
@@ -768,32 +803,81 @@ static int marfs_indexing_global_init(struct input* in) {
 
     sort_namespace_pairs(g_state.namespaces, g_state.namespaces_count);
 
-    if (validate_source() != 0) goto cleanup;
+    if (!validate_sec_root()) {
+        fprintf(stderr, "Error: %s (%s) is not a MarFS sec-root or marfs_config is incorrect\n", MARFS_SEC_ROOT_ENV,
+                g_state.root_namespace.data);
+        goto cleanup;
+    }
 
-    g_state.source_is_sec_root = str_t_eq(g_state.source, g_state.sec_root);
+    if (!validate_source()) {
+        goto cleanup;
+    }
 
     if (build_index_namespace_paths() != 0) {
         fprintf(stderr, "Error: build_index_namespace_paths failed\n");
         goto cleanup;
     }
 
-    // if (revert_marfs_index() != 0) {
-    //     fprintf(stderr, "Error: revert_marfs_index failed\n");
-    //     goto cleanup;
-    // }
+    if (revert_marfs_index() != 0) {
+        fprintf(stderr, "Error: revert_marfs_index failed\n");
+        goto cleanup;
+    }
 
     sqlite3_initialize();
 
     ret = 0;
 
 cleanup:
-    if (ret != 0) marfs_plugin_cleanup();
+    if (ret != 0) {
+        marfs_plugin_cleanup();
+    }
 
     return ret;
 }
 
-// marfs_dir_action identifies MarFS implementation entries by their physical
-// owner path instead of assuming sec-root is GUFI traversal level 0.
+// simple check to determine if a provided file path is a namespace in the marfs config
+static int is_namespace(str_t path) {
+    if (!path.data) {
+        return 0;
+    }
+
+    for (size_t i = 0; i < g_state.namespaces_count; i++) {
+        str_t ns = g_state.namespaces[i].namespace;
+        if (!ns.data) {
+            continue;
+        }
+
+        if (ns.len != path.len) {
+            continue;
+        }
+
+        if (strncmp(ns.data, path.data, ns.len) == 0) {
+            return 1;
+        }
+    }
+
+    return 0;
+}
+
+// sec-root and configured namespaces are the directories that own MDAL metadata
+static int is_mdal_owner(str_t path) {
+    return str_t_eq(path, g_state.root_namespace) || is_namespace(path);
+}
+
+// check whether a namespace will be moved out of MDAL_subspaces in this index
+static int namespace_is_rewritten(str_t path) {
+    for (size_t i = 0; i < g_state.namespaces_count; i++) {
+        namespace_pair* pair = &g_state.namespaces[i];
+        if (str_t_eq(pair->namespace, path)) {
+            return pair->index_namespace.data && pair->index_namespace.len > 0;
+        }
+    }
+
+    return 0;
+}
+
+// marfs_pre_processing_dir checks if we're about to process a marfs specific directory (MDAL_reference, MDAL_subspaces)
+// or a namespace that is no longer active in the marfs config
 static plugin_dir_action marfs_dir_action(void* ptr) {
     PCS_t* pcs = ptr;
 
@@ -801,21 +885,43 @@ static plugin_dir_action marfs_dir_action(void* ptr) {
     const str_t basename = get_basename(path);
     const str_t parent = get_parent(path);
 
-    if (starts_with_mdal(basename) && is_mdal_owner(parent)) {
-        if (str_t_eq_cstr(basename, MARFS_SUBSPACES_NAME, MARFS_SUBSPACES_NAME_LEN)) {
-            // hide MDAL_subspaces itself, but descend into configured child namespaces
-            return PLUGIN_NO_PROCESS_DIR;
-        }
+    if (starts_with_mdal(basename)) {
+        // this directory starts with MDAL_
 
-        // hide all other MDAL implementation directories
-        return PLUGIN_NO_PROCESS_NO_DESCEND_DIR;
+        // determine if this is a marfs directory or a user dir.
+        // cases for being a marfs dir:
+        // 1. directly under sec-root
+        // 2. directly under a namespace
+        if (is_mdal_owner(parent)) {
+            if (str_t_eq_cstr(basename, MARFS_SUBSPACES_NAME, MARFS_SUBSPACES_NAME_LEN)) {
+                // this is a subspaces dir. do not process, but still descend
+                return PLUGIN_NO_PROCESS_DIR;
+            } else {
+                // this is any other marfs dir. do not process, do not descend
+                return PLUGIN_NO_PROCESS_NO_DESCEND_DIR;
+            }
+        } else {
+            return PLUGIN_PROCESS_DIR;
+        }
     }
 
-    if (is_mdal_subspaces_dir(parent)) {
-        // Only namespaces present in the active config should be traversed.
-        if (is_namespace(path)) return PLUGIN_PROCESS_DIR;
-
-        return PLUGIN_NO_PROCESS_NO_DESCEND_DIR;
+    if (starts_with_mdal(get_basename(parent))) {
+        // parent directory starts with MDAL_
+        // check to see if it's even possible for this dir to be a marfs namespace
+        // cases for this being a marfs namespace:
+        // 1. grandparent is sec-root
+        // 2. grandparent is a namespace
+        const str_t grandparent = get_parent(parent);
+        if (is_mdal_owner(grandparent)) {
+            // it's possible for this to be a marfs namespace. check the marfs config to be sure that it is currently
+            // active
+            if (is_namespace(path)) {
+                return PLUGIN_PROCESS_DIR;
+            } else {
+                // this dir is not listed in the marfs config so do not process it or descend
+                return PLUGIN_NO_PROCESS_NO_DESCEND_DIR;
+            }
+        }
     }
 
     return PLUGIN_PROCESS_DIR;
@@ -882,8 +988,8 @@ static void* marfs_ctx_init(void* ptr) {
     return ctx;
 }
 
-// marfs_pre_process_file removes MarFS xattrs, adjusts nlink, and hides MDAL files
-// directly owned by sec-root or a configured namespace.
+// marfs_pre_process_file removes any marfs specific files from the gufi db, decrements every file nlink by 1, and
+// removes any marfs specific xattrs
 static plugin_file_action marfs_pre_process_file(void* ptr, void* user_data) {
     PCS_t* pcs = ptr;
     struct entry_data* ed = pcs->ed;
@@ -892,51 +998,69 @@ static plugin_file_action marfs_pre_process_file(void* ptr, void* user_data) {
     const str_t path = REFSTR(pcs->work->name, pcs->work->name_len);
     const str_t basename = get_basename(path);
 
+    // remove marfs xattr from entry
     const size_t removed = xattr_remove(&ed->xattrs, MARFS_XATTR_NAME, MARFS_XATTR_NAME_LEN);
 
+    // decrement nlink if the marfs xattr was removed
     if (removed > 0 && pcs->work->statuso.st_nlink > (nlink_t)0) {
         pcs->work->statuso.st_nlink--;
     }
 
-    if (starts_with_mdal(basename) && is_mdal_owner(get_parent(path))) {
-        return PLUGIN_NO_PROCESS_FILE;
+    // remove mdal specific files
+    if (basename.len >= MARFS_PREFIX_LEN && starts_with_mdal(basename)) {
+        // this files starts with MDAL_
+
+        const str_t parent = get_parent(path);
+
+        // determine if this is actual a marfs file or a user file
+        // cases for being a marfs file:
+        // 1. directly under sec-root
+        // 2. directly under a namespace
+        if (is_mdal_owner(parent)) {
+            // this is a marfs file. do not add it to the database
+            return PLUGIN_NO_PROCESS_FILE;
+        }
     }
 
     return PLUGIN_PROCESS_FILE;
 }
 
-// Fix pinode only for configured namespaces whose MDAL_subspaces parent will be
-// removed from this particular index.
+// marfs_process_dir renames the root namespace in the gufi db summary table to match the mountpoint in the marfs
+// config. The actual dir gets renamed in cleanup_marfs_index. It also fixes pinode values for directories whose
+// parent is an MDAL_subspaces directory that will be removed from the final index.
 static void marfs_pre_process_dir(void* ptr, void* user_data) {
     PCS_t* pcs = ptr;
     (void)user_data;
 
     const str_t path = REFSTR(pcs->work->name, pcs->work->name_len);
-
-    if (!namespace_is_rewritten(path)) return;
-
     const str_t parent = get_parent(path);
-    if (!is_mdal_subspaces_dir(parent)) return;
+    const str_t parent_basename = get_basename(parent);
 
-    const str_t grandparent = get_parent(parent);
-    if (!grandparent.data || grandparent.len == 0) return;
+    // Fix pinode for directories whose parent is MDAL_subspaces (which will be removed)
+    // The pinode currently points to the MDAL_subspaces inode, but should point to the grandparent
+    if (parent_basename.data && str_t_eq_cstr(parent_basename, MARFS_SUBSPACES_NAME, MARFS_SUBSPACES_NAME_LEN) &&
+        namespace_is_rewritten(path)) {
+        const str_t grandparent = get_parent(parent);
 
-    char* grandparent_path = malloc(grandparent.len + 1);
-    if (!grandparent_path) {
-        fprintf(stderr, "malloc failed for grandparent_path\n");
-        return;
+        if (grandparent.data && grandparent.len > 0) {
+            size_t gp_path_size = grandparent.len + 1;
+            char* gp_path = malloc(gp_path_size);
+            if (gp_path) {
+                snprintf(gp_path, gp_path_size, "%.*s", (int)grandparent.len, grandparent.data);
+
+                struct stat st;
+                if (stat(gp_path, &st) == 0) {
+                    pcs->work->pinode = (long long int)st.st_ino;
+                } else {
+                    fprintf(stderr, "plugin: stat('%s') failed: %s\n", gp_path, strerror(errno));
+                }
+
+                free(gp_path);
+            } else {
+                fprintf(stderr, "malloc failed for gp_path\n");
+            }
+        }
     }
-
-    snprintf(grandparent_path, grandparent.len + 1, "%.*s", (int)grandparent.len, grandparent.data);
-
-    struct stat st;
-    if (stat(grandparent_path, &st) == 0) {
-        pcs->work->pinode = (long long int)st.st_ino;
-    } else {
-        fprintf(stderr, "plugin: stat('%s') failed: %s\n", grandparent_path, strerror(errno));
-    }
-
-    free(grandparent_path);
 }
 
 // marfs_process_dir renames the root namespace in the gufi db summary table to match the mountpoint in the marfs
@@ -949,8 +1073,9 @@ static void marfs_post_process_dir(void* ptr, void* user_data) {
     const str_t path = REFSTR(pcs->work->name, pcs->work->name_len);
     const str_t basename = get_basename(path);
 
-    // Only a sec-root index is renamed to the MarFS mountpoint.
-    if (g_state.source_is_sec_root && str_t_eq(path, g_state.source)) {
+    // determine if this is the root namespace dir
+    if (str_t_eq(g_state.source, g_state.root_namespace) && ROOT_NAMESPACE_LEVEL == pcs->work->level &&
+        str_t_eq_cstr(g_state.source, pcs->work->name, pcs->work->name_len)) {
         // Rename root namespace to mountpoint in database
         const str_t mountpoint = get_basename(g_state.marfs_mountpoint);
 

--- a/contrib/plugins/marfs_plugin.c
+++ b/contrib/plugins/marfs_plugin.c
@@ -231,15 +231,37 @@ static int str_t_eq_cstr(str_t s, const char* cstr, size_t cstr_len) {
     return strncmp(s.data, cstr, cstr_len) == 0;
 }
 
+// return a path with trailing slashes removed, except for "/"
+static str_t trim_trailing_slashes(str_t path) {
+    while (path.len > 1 && path.data[path.len - 1] == '/') {
+        path.len--;
+    }
+
+    return path;
+}
+
+static void trim_trailing_slashes_in_place(str_t* path) {
+    while (path->len > 1 && path->data[path->len - 1] == '/') {
+        path->len--;
+        path->data[path->len] = '\0';
+    }
+}
+
 static int str_t_eq(str_t lhs, str_t rhs) {
-    if (!lhs.data || !rhs.data || lhs.len != rhs.len) return 0;
+    lhs = trim_trailing_slashes(lhs);
+    rhs = trim_trailing_slashes(rhs);
+
+    if (lhs.len != rhs.len) return 0;
 
     return strncmp(lhs.data, rhs.data, lhs.len) == 0;
 }
 
 // check whether path is root itself or is below root on a path-component boundary
 static int path_is_at_or_below(str_t path, str_t root) {
-    if (!path.data || !root.data || path.len < root.len) return 0;
+    path = trim_trailing_slashes(path);
+    root = trim_trailing_slashes(root);
+
+    if (path.len < root.len) return 0;
     if (strncmp(path.data, root.data, root.len) != 0) return 0;
     if (path.len == root.len) return 1;
 
@@ -249,6 +271,9 @@ static int path_is_at_or_below(str_t path, str_t root) {
 }
 
 static str_t get_relative_path(str_t path, str_t root) {
+    path = trim_trailing_slashes(path);
+    root = trim_trailing_slashes(root);
+
     if (!path_is_at_or_below(path, root) || str_t_eq(path, root)) {
         return (str_t)REFSTR(NULL, 0);
     }
@@ -747,6 +772,9 @@ static int marfs_indexing_global_init(struct input* in) {
     INSTALL_STR(&g_state.index_parent, in->pos.argv[in->pos.argc - 1]);
     INSTALL_STR(&g_state.source, in->pos.argv[0]);
 
+    trim_trailing_slashes_in_place(&g_state.index_parent);
+    trim_trailing_slashes_in_place(&g_state.source);
+
     char* sec_root = getenv(MARFS_SEC_ROOT_ENV);
     if (!sec_root || sec_root[0] == '\0') {
         fprintf(stderr, "Error: %s is not set\n", MARFS_SEC_ROOT_ENV);
@@ -754,6 +782,7 @@ static int marfs_indexing_global_init(struct input* in) {
     }
 
     INSTALL_STR(&g_state.root_namespace, sec_root);
+    trim_trailing_slashes_in_place(&g_state.root_namespace);
 
     char* marfs_config_path = getenv(MARFS_CONFIG_ENV);
     if (!marfs_config_path || marfs_config_path[0] == '\0') {
@@ -837,21 +866,13 @@ cleanup:
 
 // simple check to determine if a provided file path is a namespace in the marfs config
 static int is_namespace(str_t path) {
-    if (!path.data) {
-        return 0;
-    }
-
     for (size_t i = 0; i < g_state.namespaces_count; i++) {
         str_t ns = g_state.namespaces[i].namespace;
         if (!ns.data) {
             continue;
         }
 
-        if (ns.len != path.len) {
-            continue;
-        }
-
-        if (strncmp(ns.data, path.data, ns.len) == 0) {
+        if (str_t_eq(ns, path)) {
             return 1;
         }
     }

--- a/src/gufi_dir2index.c
+++ b/src/gufi_dir2index.c
@@ -142,18 +142,20 @@ static int processdir(QPTPool_ctx_t *ctx, void *data) {
     topath.len -= 1 + DBNAME_LEN;
     topath.data[topath.len] = '\0';
 
-    /* set permissions on index directory */
-    if (chmod(topath.data, work->statuso.st_mode) != 0) {
-        const int err = errno;
-        fprintf(stderr, "Warning: Unable to set permission for \"%s\": %s (%d)\n",
-                topath.data, strerror(err), err);
-    }
+    if (process_dir != PLUGIN_NO_PROCESS_NO_DESCEND_DIR){
+        /* set permissions on index directory */
+        if (chmod(topath.data, work->statuso.st_mode) != 0) {
+            const int err = errno;
+            fprintf(stderr, "Warning: Unable to set permission for \"%s\": %s (%d)\n",
+                    topath.data, strerror(err), err);
+        }
 
-    /* set owners on index directory */
-    if (chown(topath.data, work->statuso.st_uid, work->statuso.st_gid) != 0) {
-        const int err = errno;
-        fprintf(stderr, "Warning: Unable to set owners for \"%s\": %s (%d)\n",
-                topath.data, strerror(err), err);
+        /* set owners on index directory */
+        if (chown(topath.data, work->statuso.st_uid, work->statuso.st_gid) != 0) {
+            const int err = errno;
+            fprintf(stderr, "Warning: Unable to set owners for \"%s\": %s (%d)\n",
+                    topath.data, strerror(err), err);
+        }
     }
 
   free_topath:

--- a/test/regression/marfs_plugin.expected
+++ b/test/regression/marfs_plugin.expected
@@ -71,7 +71,7 @@ search/marfs/namespace1/userfile1.txt|user.myattr
 
 
 # verify nlink decrement
-# All file nlink counts should be decremented by 1 (MarFS metadata link removed)
+# Files with MarFS metadata links should have nlink decremented by 1
 $ gufi_query -d "|" -S "SELECT rpath(sname, sroll), nlink FROM vrsummary;" -E "SELECT rpath(sname, sroll, name), nlink FROM vrpentries WHERE type == 'f' ORDER BY name;" "search"
 search/marfs/namespace1/namespace2/nestedfile1.txt|0
 search/marfs/namespace1/namespace2/nestedfile2.txt|1
@@ -89,9 +89,9 @@ $ sqlite3 "search/marfs/db.db" "SELECT name FROM summary;"
 marfs
 
 
-# test: re-index over existing index
-# Plugin should handle existing index structure correctly
-$ gufi_dir2index -x --plugin "GUFI_MARFS_PLUGIN:marfs_indexing_plugin" "prefix/var/marfs/mdal-root/sec-root" "search"
+# test: re-index over existing index with trailing slashes
+# Plugin should handle existing index structure and trailing slashes correctly
+$ gufi_dir2index -x --plugin "GUFI_MARFS_PLUGIN:marfs_indexing_plugin" "prefix/var/marfs/mdal-root/sec-root/" "search/"
 "search" Already exists!
 Creating GUFI tree search with 1 threads
 Total Dirs:          4
@@ -107,16 +107,68 @@ search/marfs/namespace1/namespace2
 search/marfs/namespace1/userdir
 
 
+# test: index starting from a configured namespace
+$ gufi_dir2index -x --plugin "GUFI_MARFS_PLUGIN:marfs_indexing_plugin" "prefix/var/marfs/mdal-root/sec-root/MDAL_subspaces/namespace1" "search_namespace"
+Creating GUFI tree search_namespace with 1 threads
+Total Dirs:          3
+Total Non-Dirs:      7
+
+
+# verify configured namespace index structure
+$ find "search_namespace" -type d
+search_namespace
+search_namespace/namespace1
+search_namespace/namespace1/namespace2
+search_namespace/namespace1/userdir
+
+
+# verify configured namespace index contents
+$ gufi_query -d "|"         -S "SELECT rpath(sname, sroll) FROM vrsummary;"         -E "SELECT rpath(sname, sroll, name) FROM vrpentries;"         "search_namespace"
+search_namespace/namespace1
+search_namespace/namespace1/namespace2
+search_namespace/namespace1/namespace2/nestedfile1.txt
+search_namespace/namespace1/namespace2/nestedfile2.txt
+search_namespace/namespace1/userdir
+search_namespace/namespace1/userdir/userfile3.txt
+search_namespace/namespace1/userfile1.txt
+search_namespace/namespace1/userfile2.txt
+
+
+# test: index starting from a directory below a namespace
+$ gufi_dir2index -x --plugin "GUFI_MARFS_PLUGIN:marfs_indexing_plugin" "prefix/var/marfs/mdal-root/sec-root/MDAL_subspaces/namespace1/userdir" "search_subdir"
+Creating GUFI tree search_subdir with 1 threads
+Total Dirs:          1
+Total Non-Dirs:      1
+
+
+# verify subdirectory index structure
+$ find "search_subdir" -type d
+search_subdir
+search_subdir/userdir
+
+
+# verify subdirectory index contents
+$ gufi_query -d "|"         -S "SELECT rpath(sname, sroll) FROM vrsummary;"         -E "SELECT rpath(sname, sroll, name) FROM vrpentries;"         "search_subdir"
+search_subdir/userdir
+search_subdir/userdir/userfile3.txt
+
+
 # test: error handling - missing config
 # Should fail with appropriate error message
 $ gufi_dir2index -x --plugin "GUFI_MARFS_PLUGIN:marfs_indexing_plugin" "prefix/var/marfs/mdal-root/sec-root" "search_fail" 2>&1 | head -n 1
 Error: MARFS_CONFIG_PATH is not set
 
 
+# test: error handling - missing sec-root
+# Should fail with appropriate error message
+$ gufi_dir2index -x --plugin "GUFI_MARFS_PLUGIN:marfs_indexing_plugin" "prefix/var/marfs/mdal-root/sec-root" "search_fail2" 2>&1 | head -n 1
+Error: MARFS_SEC_ROOT is not set
+
+
 # test: error handling - invalid path
-# Should fail when path is not a MarFS sec-root
-$ gufi_dir2index -x --plugin "GUFI_MARFS_PLUGIN:marfs_indexing_plugin" "/tmp" "search_fail2" 2>&1 | grep -i 'error' | head -n 1
-Error: provided dir (/tmp) is not the root of the parent marfs namespace or marfs_config is incorrect
+# Should fail when path is outside the configured MarFS sec-root
+$ gufi_dir2index -x --plugin "GUFI_MARFS_PLUGIN:marfs_indexing_plugin" "/tmp" "search_fail3" 2>&1 | grep -i 'error' | head -n 1
+Error: source (/tmp) is not within MARFS_SEC_ROOT (prefix/var/marfs/mdal-root/sec-root)
 
 
 # test: verify inode/pinode relationships

--- a/test/regression/marfs_plugin.sh.in
+++ b/test/regression/marfs_plugin.sh.in
@@ -73,8 +73,14 @@ MARFS_DAL_ROOT="${MARFS_BASE}/dal-root"
 MARFS_MDAL_ROOT="${MARFS_BASE}/mdal-root"
 MARFS_SEC_ROOT="${MARFS_MDAL_ROOT}/sec-root"
 
+SEARCH_NAMESPACE="${SEARCH}_namespace"
+SEARCH_SUBDIR="${SEARCH}_subdir"
+
 cleanup() {
-    rm -rf "${MARFS_BASE}" "${MARFS_CONFIG}"
+    rm -rf "${MARFS_BASE}" \
+           "${MARFS_CONFIG}" \
+           "${SEARCH_NAMESPACE}" \
+           "${SEARCH_SUBDIR}"
 }
 
 cleanup_exit() {
@@ -118,13 +124,20 @@ cleanup
 
     run_sort "find \"${MARFS_SEC_ROOT}\" -type f -o -type d"
 
+    # The plugin requires absolute source and sec-root paths. Keep the relative
+    # paths above so the existing regression output does not unnecessarily change.
+    MARFS_DAL_ROOT_ABS="$(cd "${MARFS_DAL_ROOT}" && pwd)"
+    MARFS_SEC_ROOT_ABS="$(cd "${MARFS_SEC_ROOT}" && pwd)"
+    MARFS_NAMESPACE1_ABS="${MARFS_SEC_ROOT_ABS}/MDAL_subspaces/namespace1"
+    MARFS_USERDIR_ABS="${MARFS_NAMESPACE1_ABS}/userdir"
+
     echo
     echo "# create MarFS config XML"
     cp "@CMAKE_CURRENT_BINARY_DIR@/marfs_plugin_config.xml" "${MARFS_CONFIG}"
 
     # Replace placeholders with actual paths
-    @SED@ -i "s|DAL_ROOT_PLACEHOLDER|${MARFS_DAL_ROOT}|g" "${MARFS_CONFIG}"
-    @SED@ -i "s|NS_ROOT_PLACEHOLDER|${MARFS_SEC_ROOT}|g" "${MARFS_CONFIG}"
+    @SED@ -i "s|DAL_ROOT_PLACEHOLDER|${MARFS_DAL_ROOT_ABS}|g" "${MARFS_CONFIG}"
+    @SED@ -i "s|NS_ROOT_PLACEHOLDER|${MARFS_SEC_ROOT_ABS}|g" "${MARFS_CONFIG}"
 
     echo "Created MarFS config at ${MARFS_CONFIG}"
 
@@ -135,7 +148,9 @@ cleanup
     echo "#   - Filter out MDAL_MARFS-FILE xattrs"
     echo "#   - Preserve MDAL_subspaces structure during indexing"
     echo "#   - Rename root namespace to mountpoint in final index"
-    MARFS_CONFIG_PATH="${MARFS_CONFIG}" run_no_sort "${GUFI_DIR2INDEX} -x --plugin \"GUFI_MARFS_PLUGIN:${MARFS_INDEXING_PLUGIN}\" \"${MARFS_SEC_ROOT}\" \"${SEARCH}\"" 2>&1 | remove_time
+    MARFS_CONFIG_PATH="${MARFS_CONFIG}" \
+    MARFS_SEC_ROOT="${MARFS_SEC_ROOT_ABS}" \
+        run_no_sort "${GUFI_DIR2INDEX} -x --plugin \"GUFI_MARFS_PLUGIN:${MARFS_INDEXING_PLUGIN}\" \"${MARFS_SEC_ROOT_ABS}\" \"${SEARCH}\"" 2>&1 | remove_time
 
     echo
     echo "# verify index structure"
@@ -160,7 +175,7 @@ cleanup
 
     echo
     echo "# verify nlink decrement"
-    echo "# All file nlink counts should be decremented by 1 (MarFS metadata link removed)"
+    echo "# Files with MarFS metadata links should have nlink decremented by 1"
     run_sort "${GUFI_QUERY} -d \"${DELIM}\" -S \"SELECT rpath(sname, sroll), nlink FROM vrsummary;\" -E \"SELECT rpath(sname, sroll, name), nlink FROM vrpentries WHERE type == 'f' ORDER BY name;\" \"${SEARCH}\""
 
     echo
@@ -168,24 +183,68 @@ cleanup
     run_sort "${SQLITE3} \"${SEARCH}/marfs/db.db\" \"SELECT name FROM summary;\""
 
     echo
-    echo "# test: re-index over existing index"
-    echo "# Plugin should handle existing index structure correctly"
-    MARFS_CONFIG_PATH="${MARFS_CONFIG}" run_no_sort "${GUFI_DIR2INDEX} -x --plugin \"GUFI_MARFS_PLUGIN:${MARFS_INDEXING_PLUGIN}\" \"${MARFS_SEC_ROOT}\" \"${SEARCH}\"" 2>&1 | remove_time
+    echo "# test: re-index over existing index with trailing slashes"
+    echo "# Plugin should handle existing index structure and trailing slashes correctly"
+    MARFS_CONFIG_PATH="${MARFS_CONFIG}" \
+    MARFS_SEC_ROOT="${MARFS_SEC_ROOT_ABS}" \
+        run_no_sort "${GUFI_DIR2INDEX} -x --plugin \"GUFI_MARFS_PLUGIN:${MARFS_INDEXING_PLUGIN}\" \"${MARFS_SEC_ROOT_ABS}/\" \"${SEARCH}/\"" 2>&1 | remove_time
 
     echo
     echo "# verify structure after re-indexing"
     run_sort "find \"${SEARCH}\" -type d"
 
     echo
+    echo "# test: index starting from a configured namespace"
+    MARFS_CONFIG_PATH="${MARFS_CONFIG}" \
+    MARFS_SEC_ROOT="${MARFS_SEC_ROOT_ABS}" \
+        run_no_sort "${GUFI_DIR2INDEX} -x --plugin \"GUFI_MARFS_PLUGIN:${MARFS_INDEXING_PLUGIN}\" \"${MARFS_NAMESPACE1_ABS}\" \"${SEARCH_NAMESPACE}\"" 2>&1 | remove_time
+
+    echo
+    echo "# verify configured namespace index structure"
+    run_sort "find \"${SEARCH_NAMESPACE}\" -type d"
+
+    echo
+    echo "# verify configured namespace index contents"
+    run_sort "${GUFI_QUERY} -d \"${DELIM}\" \
+        -S \"SELECT rpath(sname, sroll) FROM vrsummary;\" \
+        -E \"SELECT rpath(sname, sroll, name) FROM vrpentries;\" \
+        \"${SEARCH_NAMESPACE}\""
+
+    echo
+    echo "# test: index starting from a directory below a namespace"
+    MARFS_CONFIG_PATH="${MARFS_CONFIG}" \
+    MARFS_SEC_ROOT="${MARFS_SEC_ROOT_ABS}" \
+        run_no_sort "${GUFI_DIR2INDEX} -x --plugin \"GUFI_MARFS_PLUGIN:${MARFS_INDEXING_PLUGIN}\" \"${MARFS_USERDIR_ABS}\" \"${SEARCH_SUBDIR}\"" 2>&1 | remove_time
+
+    echo
+    echo "# verify subdirectory index structure"
+    run_sort "find \"${SEARCH_SUBDIR}\" -type d"
+
+    echo
+    echo "# verify subdirectory index contents"
+    run_sort "${GUFI_QUERY} -d \"${DELIM}\" \
+        -S \"SELECT rpath(sname, sroll) FROM vrsummary;\" \
+        -E \"SELECT rpath(sname, sroll, name) FROM vrpentries;\" \
+        \"${SEARCH_SUBDIR}\""
+
+    echo
     echo "# test: error handling - missing config"
     echo "# Should fail with appropriate error message"
-    unset MARFS_CONFIG_PATH
-    run_no_sort "${GUFI_DIR2INDEX} -x --plugin \"GUFI_MARFS_PLUGIN:${MARFS_INDEXING_PLUGIN}\" \"${MARFS_SEC_ROOT}\" \"${SEARCH}_fail\" 2>&1 | head -n 1" || true
+    MARFS_SEC_ROOT="${MARFS_SEC_ROOT_ABS}" \
+        run_no_sort "${GUFI_DIR2INDEX} -x --plugin \"GUFI_MARFS_PLUGIN:${MARFS_INDEXING_PLUGIN}\" \"${MARFS_SEC_ROOT_ABS}\" \"${SEARCH}_fail\" 2>&1 | head -n 1" || true
+
+    echo
+    echo "# test: error handling - missing sec-root"
+    echo "# Should fail with appropriate error message"
+    MARFS_CONFIG_PATH="${MARFS_CONFIG}" \
+        run_no_sort "${GUFI_DIR2INDEX} -x --plugin \"GUFI_MARFS_PLUGIN:${MARFS_INDEXING_PLUGIN}\" \"${MARFS_SEC_ROOT_ABS}\" \"${SEARCH}_fail2\" 2>&1 | head -n 1" || true
 
     echo
     echo "# test: error handling - invalid path"
-    echo "# Should fail when path is not a MarFS sec-root"
-    MARFS_CONFIG_PATH="${MARFS_CONFIG}" run_no_sort "${GUFI_DIR2INDEX} -x --plugin \"GUFI_MARFS_PLUGIN:${MARFS_INDEXING_PLUGIN}\" \"/tmp\" \"${SEARCH}_fail2\" 2>&1 | @GREP@ -i 'error' | head -n 1" || true
+    echo "# Should fail when path is outside the configured MarFS sec-root"
+    MARFS_CONFIG_PATH="${MARFS_CONFIG}" \
+    MARFS_SEC_ROOT="${MARFS_SEC_ROOT_ABS}" \
+        run_no_sort "${GUFI_DIR2INDEX} -x --plugin \"GUFI_MARFS_PLUGIN:${MARFS_INDEXING_PLUGIN}\" \"/tmp\" \"${SEARCH}_fail3\" 2>&1 | @GREP@ -i 'error' | head -n 1" || true
 
     echo
     echo "# test: verify inode/pinode relationships"


### PR DESCRIPTION
Updates the MarFS indexing plugin so GUFI can index from anywhere within a MarFS sec-root instead of requiring the selected source to be the sec-root itself.

The plugin now uses `MARFS_SEC_ROOT` to identify the MarFS metadata root independently from the GUFI source path. The selected source may be the sec-root, a configured namespace, or a normal directory below a namespace.

## Changes

* Add `MARFS_SEC_ROOT` configuration to separate the MarFS sec-root from the selected GUFI source.
* Support indexing from:

  * the full MarFS sec-root
  * a configured MarFS namespace
  * a normal directory beneath a namespace
* Validate that the selected source:

  * exists and is a directory
  * is contained within `MARFS_SEC_ROOT`
  * is not inside an internal `MDAL_*` directory.
* Update MDAL ownership checks to use actual sec-root/namespace paths instead of traversal levels, allowing filtering to work correctly when indexing from below sec-root.
* Only rename the index root to the MarFS mountpoint when indexing directly from the sec-root. Namespace and subdirectory indexes retain their selected source name.
* Make re-index cleanup/restoration operate only on namespaces that are actually present beneath the selected source.
* Add trailing-slash handling for source and destination paths.
* Use GUFI's existing `basename_len` when processing files/directories instead of rescanning paths in hot callbacks.
* Remove the per-directory MarFS SQLite context and unused prepared `DELETE` statement. The root summary rename is now prepared and executed only for the single directory that requires it, avoiding per-directory allocations and statement preparation. - Reuse GUFI path/string helpers where appropriate and keep path operations as non-owning `str_t` views where possible.